### PR TITLE
Enable definition of user tasks using JSON file

### DIFF
--- a/src/WorkflowCore/Models/DefinitionStorage/v1/StepSourceV1.cs
+++ b/src/WorkflowCore/Models/DefinitionStorage/v1/StepSourceV1.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Text;
 
+using Newtonsoft.Json.Linq;
+
 namespace WorkflowCore.Models.DefinitionStorage.v1
 {
     public class StepSourceV1
@@ -30,6 +32,6 @@ namespace WorkflowCore.Models.DefinitionStorage.v1
 
         public Dictionary<string, string> Outputs { get; set; } = new Dictionary<string, string>();
 
-        
+        public JObject Properties { get; set; }
     }
 }

--- a/src/WorkflowCore/Services/DefinitionStorage/DefinitionLoader.cs
+++ b/src/WorkflowCore/Services/DefinitionStorage/DefinitionLoader.cs
@@ -24,7 +24,7 @@ namespace WorkflowCore.Services.DefinitionStorage
             _registry = registry;
             _serviceProvider = serviceProvider;
         }
-                        
+
         public WorkflowDefinition LoadDefinition(string json)
         {
             var source = JsonConvert.DeserializeObject<DefinitionSourceV1>(json);
@@ -144,7 +144,7 @@ namespace WorkflowCore.Services.DefinitionStorage
                     targetStep.Outcomes.Add(new StepOutcome() { Tag = $"{nextStep.NextStepId}" });
 
                 result.Add(targetStep);
-                
+
                 i++;
             }
 
@@ -230,7 +230,7 @@ namespace WorkflowCore.Services.DefinitionStorage
             return Type.GetType(name, true, true);
         }
 
-        private Type FindGenericWorkflowStepTypeArgument(Type workflowType)
+        private static Type FindGenericWorkflowStepTypeArgument(Type workflowType)
         {
             var previousType = workflowType;
             while (previousType != typeof(WorkflowStep))

--- a/test/WorkflowCore.IntegrationTests/Scenarios/UserScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/UserScenario.cs
@@ -78,7 +78,7 @@ namespace WorkflowCore.IntegrationTests.Scenarios
         {
             var data = new ApprovalData();
             var workflowId = await Host.StartWorkflow<ApprovalData>("HumanWorkflowJson", data);
-            await Scenario(workflowId, data);
+            await Scenario(workflowId, data).ConfigureAwait(false);
         }
 
         private async Task Scenario(string workflowId, ApprovalData data)

--- a/test/WorkflowCore.IntegrationTests/Scenarios/UserScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/UserScenario.cs
@@ -8,30 +8,55 @@ using FluentAssertions;
 using FluentAssertions.Collections;
 using WorkflowCore.Users.Models;
 using System.Linq;
+using System.Threading.Tasks;
+
 using WorkflowCore.Testing;
 
 namespace WorkflowCore.IntegrationTests.Scenarios
 {
-    public class UserScenario : WorkflowTest<UserScenario.HumanWorkflow, Object>
+    public class UserScenario : WorkflowTest<UserScenario.HumanWorkflow, UserScenario.ApprovalData>
     {
-        internal static int ApproveStepTicker = 0;
-        internal static int DisapproveStepTicker = 0;
+        public class ApprovalData
+        {
+            public int ApproveStepTicker { get; set; }
+            public int DisapproveStepTicker { get; set; }
+        }
 
-        public class HumanWorkflow : IWorkflow
+        public class HumanWorkflow : IWorkflow<ApprovalData>
         {
             public string Id => "HumanWorkflow";
             public int Version => 1;
-            public void Build(IWorkflowBuilder<object> builder)
+            public void Build(IWorkflowBuilder<ApprovalData> builder)
             {
                 builder
                     .StartWith(context => ExecutionResult.Next())
                     .UserTask("Do you approve", data => @"user1")
                         .WithOption("yes", "I approve").Do(then => then
-                            .StartWith(context => ApproveStepTicker++)
+                            .StartWith<ApprovalStep>()
                         )
                         .WithOption("no", "I do not approve").Do(then => then
-                            .StartWith(context => DisapproveStepTicker++)
+                            .StartWith<DisapprovalStep>()
                     );
+            }
+        }
+
+        public class ApprovalStep : IStepBody
+        {
+            public Task<ExecutionResult> RunAsync(IStepExecutionContext context)
+            {
+                var data = (ApprovalData) context.Workflow.Data;
+                data.ApproveStepTicker++;
+                return Task.FromResult(ExecutionResult.Next());
+            }
+        }
+
+        public class DisapprovalStep : IStepBody
+        {
+            public Task<ExecutionResult> RunAsync(IStepExecutionContext context)
+            {
+                var data = (ApprovalData) context.Workflow.Data;
+                data.DisapproveStepTicker++;
+                return Task.FromResult(ExecutionResult.Next());
             }
         }
 
@@ -41,15 +66,31 @@ namespace WorkflowCore.IntegrationTests.Scenarios
         }
 
         [Fact]
-        public void Scenario()
+        public void ScenarioFluent()
         {
-            var workflowId = StartWorkflow(null);
+            var data = new ApprovalData();
+            var workflowId = StartWorkflow(data);
+            Scenario(workflowId, data).Wait();
+        }
+
+        [Fact]
+        public async Task ScenarioJson()
+        {
+            var data = new ApprovalData();
+            var workflowId = await Host.StartWorkflow<ApprovalData>("HumanWorkflowJson", data);
+            await Scenario(workflowId, data);
+        }
+
+        private async Task Scenario(string workflowId, ApprovalData data)
+        {
             var counter = 0;
 
-            while ((!Host.GetOpenUserActions(workflowId).Any()) && (counter < 180))
+            var instance = await PersistenceProvider.GetWorkflowInstance(workflowId);
+            while ((!instance.GetOpenUserActions().Any()) && (counter < 5))
             {
                 System.Threading.Thread.Sleep(200);
                 counter++;
+                instance = await PersistenceProvider.GetWorkflowInstance(workflowId);
             }
 
             var openItems1 = Host.GetOpenUserActions(workflowId).ToList();
@@ -60,8 +101,8 @@ namespace WorkflowCore.IntegrationTests.Scenarios
 
             var openItems2 = Host.GetOpenUserActions(workflowId);        
 
-            ApproveStepTicker.Should().Be(1);
-            DisapproveStepTicker.Should().Be(0);
+            data.ApproveStepTicker.Should().Be(1);
+            data.DisapproveStepTicker.Should().Be(0);
             openItems1.Count().Should().Be(1);
             openItems1.First().Options.Count().Should().Be(2);
             openItems1.First().Options.Any(x => Convert.ToString(x.Value) == "yes").Should().Be(true);
@@ -69,6 +110,63 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             openItems2.Count().Should().Be(0);
             UnhandledStepErrors.Count.Should().Be(0);
             GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
+        }
+
+        protected override void Setup()
+        {
+            base.Setup();
+
+            var workflowAsJson = @"{
+    ""Id"": ""HumanWorkflowJson"",
+    ""Version"": 1,
+    ""DataType"": ""WorkflowCore.IntegrationTests.Scenarios.UserScenario+ApprovalData, WorkflowCore.IntegrationTests"",
+    ""Steps"": [
+        {
+            ""Id"": ""UserTask"",
+            ""StepType"": ""WorkflowCore.Users.Primitives.UserTaskStep, WorkflowCore.Users"",
+            ""Properties"": {
+                ""Options"": {
+                    ""I approve"": ""yes"",
+                    ""I do not approve"": ""no""
+                }
+            },
+            ""Inputs"": {
+                ""AssignedPrincipal"": ""\""user1\"""",
+                ""Prompt"": ""\""Do you approve\""""
+            },
+            ""Do"": [[
+                {
+                    ""Id"": ""Choice: yes"",
+                    ""StepType"": ""WorkflowCore.Primitives.When, WorkflowCore"",
+                    ""Inputs"": {
+                        ""ExpectedOutcome"": ""\""yes\""""
+                    },
+                    ""Do"": [[
+                        {
+                            ""Id"": ""Approve"",
+                            ""StepType"": ""WorkflowCore.IntegrationTests.Scenarios.UserScenario+ApprovalStep, WorkflowCore.IntegrationTests"",
+                        }
+                    ]]
+                },
+                {
+                    ""Id"": ""Choice: No"",
+                    ""StepType"": ""WorkflowCore.Primitives.When, WorkflowCore"",
+                    ""Inputs"": {
+                        ""ExpectedOutcome"": ""\""no\""""
+                    },
+                    ""Do"": [[
+                        {
+                            ""Id"": ""Disapprove"",
+                            ""StepType"": ""WorkflowCore.IntegrationTests.Scenarios.UserScenario+DisapprovalStep, WorkflowCore.IntegrationTests"",
+                        }
+                    ]]
+                }
+            ]]
+        }
+    ]
+}";
+
+            DefinitionLoader.LoadDefinition(workflowAsJson);
         }
     }
 }

--- a/test/WorkflowCore.Testing/WorkflowTest.cs
+++ b/test/WorkflowCore.Testing/WorkflowTest.cs
@@ -15,6 +15,7 @@ namespace WorkflowCore.Testing
         where TWorkflow : IWorkflow<TData>, new()
         where TData : class, new()
     {
+        protected IDefinitionLoader DefinitionLoader;
         protected IWorkflowHost Host;
         protected IPersistenceProvider PersistenceProvider;
         protected List<StepError> UnhandledStepErrors = new List<StepError>();
@@ -33,6 +34,7 @@ namespace WorkflowCore.Testing
             //loggerFactory.AddConsole(LogLevel.Debug);
 
             PersistenceProvider = serviceProvider.GetService<IPersistenceProvider>();
+            DefinitionLoader = serviceProvider.GetRequiredService<IDefinitionLoader>();
             Host = serviceProvider.GetService<IWorkflowHost>();
             Host.RegisterWorkflow<TWorkflow, TData>();
             Host.OnStepError += Host_OnStepError;

--- a/test/WorkflowCore.UnitTests/Services/DefinitionStorage/DefinitionLoaderTests.cs
+++ b/test/WorkflowCore.UnitTests/Services/DefinitionStorage/DefinitionLoaderTests.cs
@@ -23,7 +23,7 @@ namespace WorkflowCore.UnitTests.Services.DefinitionStorage
         public DefinitionLoaderTests()
         {
             _registry = A.Fake<IWorkflowRegistry>();
-            _subject = new DefinitionLoader(_registry);
+            _subject = new DefinitionLoader(_registry, null);
         }
 
         [Fact(DisplayName = "Should register workflow")]


### PR DESCRIPTION
Fixes issue #101.

CancelCondition and Saga aren't supported for this use case. The DefinitionLoader requires a new IServiceProvider parameter to enable instantiation of the workflow step using DI.