### PR TITLE
Assign workflow instance name/identifier

### DIFF
--- a/src/WorkflowCore/Interface/IWorkflowController.cs
+++ b/src/WorkflowCore/Interface/IWorkflowController.cs
@@ -7,10 +7,10 @@ namespace WorkflowCore.Interface
 {
     public interface IWorkflowController
     {
-        Task<string> StartWorkflow(string workflowId, object data = null);
-        Task<string> StartWorkflow(string workflowId, int? version, object data = null);
-        Task<string> StartWorkflow<TData>(string workflowId, TData data = null) where TData : class;
-        Task<string> StartWorkflow<TData>(string workflowId, int? version, TData data = null) where TData : class;
+        Task<string> StartWorkflow(string workflowId, object data = null, string reference=null);
+        Task<string> StartWorkflow(string workflowId, int? version, object data = null, string reference=null);
+        Task<string> StartWorkflow<TData>(string workflowId, TData data = null, string reference=null) where TData : class;
+        Task<string> StartWorkflow<TData>(string workflowId, int? version, TData data = null, string reference=null) where TData : class;
 
         Task PublishEvent(string eventName, string eventKey, object eventData, DateTime? effectiveDate = null);
         void RegisterWorkflow<TWorkflow>() where TWorkflow : IWorkflow, new();

--- a/src/WorkflowCore/Services/WorkflowController.cs
+++ b/src/WorkflowCore/Services/WorkflowController.cs
@@ -29,23 +29,23 @@ namespace WorkflowCore.Services
             _logger = loggerFactory.CreateLogger<WorkflowController>();
         }
 
-        public Task<string> StartWorkflow(string workflowId, object data = null)
+        public Task<string> StartWorkflow(string workflowId, object data = null, string reference=null)
         {
-            return StartWorkflow(workflowId, null, data);
+            return StartWorkflow(workflowId, null, data, reference);
         }
 
-        public Task<string> StartWorkflow(string workflowId, int? version, object data = null)
+        public Task<string> StartWorkflow(string workflowId, int? version, object data = null, string reference=null)
         {
-            return StartWorkflow<object>(workflowId, version, data);
+            return StartWorkflow<object>(workflowId, version, data, reference);
         }
 
-        public Task<string> StartWorkflow<TData>(string workflowId, TData data = null) 
+        public Task<string> StartWorkflow<TData>(string workflowId, TData data = null, string reference=null) 
             where TData : class
         {
-            return StartWorkflow<TData>(workflowId, null, data);
+            return StartWorkflow<TData>(workflowId, null, data, reference);
         }
 
-        public async Task<string> StartWorkflow<TData>(string workflowId, int? version, TData data = null)
+        public async Task<string> StartWorkflow<TData>(string workflowId, int? version, TData data = null, string reference=null)
             where TData : class
         {
             
@@ -63,7 +63,8 @@ namespace WorkflowCore.Services
                 Description = def.Description,
                 NextExecution = 0,
                 CreateTime = DateTime.Now.ToUniversalTime(),
-                Status = WorkflowStatus.Runnable
+                Status = WorkflowStatus.Runnable,
+                Reference = reference
             };
 
             if ((def.DataType != null) && (data == null))

--- a/src/WorkflowCore/Services/WorkflowHost.cs
+++ b/src/WorkflowCore/Services/WorkflowHost.cs
@@ -43,27 +43,27 @@ namespace WorkflowCore.Services
             persistenceStore.EnsureStoreExists();
         }
 
-        public Task<string> StartWorkflow(string workflowId, object data = null)
+        public Task<string> StartWorkflow(string workflowId, object data = null, string reference=null)
         {
-            return _workflowController.StartWorkflow(workflowId, data);
+            return _workflowController.StartWorkflow(workflowId, data, reference);
         }
 
-        public Task<string> StartWorkflow(string workflowId, int? version, object data = null)
+        public Task<string> StartWorkflow(string workflowId, int? version, object data = null, string reference=null)
         {
-            return _workflowController.StartWorkflow<object>(workflowId, version, data);
+            return _workflowController.StartWorkflow<object>(workflowId, version, data, reference);
         }
 
-        public Task<string> StartWorkflow<TData>(string workflowId, TData data = null)
+        public Task<string> StartWorkflow<TData>(string workflowId, TData data = null, string reference=null)
             where TData : class
         {
-            return _workflowController.StartWorkflow<TData>(workflowId, null, data);
+            return _workflowController.StartWorkflow<TData>(workflowId, null, data, reference);
         }
 
 
-        public Task<string> StartWorkflow<TData>(string workflowId, int? version, TData data = null)
+        public Task<string> StartWorkflow<TData>(string workflowId, int? version, TData data = null, string reference=null)
             where TData : class
         {
-            return _workflowController.StartWorkflow(workflowId, version, data);
+            return _workflowController.StartWorkflow(workflowId, version, data, reference);
         }
 
         public Task PublishEvent(string eventName, string eventKey, object eventData, DateTime? effectiveDate = null)

--- a/src/WorkflowCore/WorkflowCore.csproj
+++ b/src/WorkflowCore/WorkflowCore.csproj
@@ -15,9 +15,9 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Description>Workflow Core is a light weight workflow engine targeting .NET Standard.</Description>
-    <Version>1.6.4</Version>
-    <AssemblyVersion>1.6.4.0</AssemblyVersion>
-    <FileVersion>1.6.4.0</FileVersion>
+    <Version>1.6.5</Version>
+    <AssemblyVersion>1.6.5.0</AssemblyVersion>
+    <FileVersion>1.6.5.0</FileVersion>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageIconUrl>https://github.com/danielgerlag/workflow-core/raw/master/src/logo.png</PackageIconUrl>
   </PropertyGroup>

--- a/src/extensions/WorkflowCore.WebAPI/Controllers/WorkflowsController.cs
+++ b/src/extensions/WorkflowCore.WebAPI/Controllers/WorkflowsController.cs
@@ -45,7 +45,7 @@ namespace WorkflowCore.WebAPI.Controllers
 
         [HttpPost("{id}")]
         [HttpPost("{id}/{version}")]        
-        public async Task<IActionResult> Post(string id, int? version, [FromBody]JObject data)
+        public async Task<IActionResult> Post(string id, int? version, string reference, [FromBody]JObject data)
         {
             string workflowId = null;            
             var def = _registry.GetDefinition(id, version);
@@ -55,11 +55,11 @@ namespace WorkflowCore.WebAPI.Controllers
             {
                 var dataStr = JsonConvert.SerializeObject(data);
                 var dataObj = JsonConvert.DeserializeObject(dataStr, def.DataType);
-                workflowId = await _workflowHost.StartWorkflow(id, version, dataObj);
+                workflowId = await _workflowHost.StartWorkflow(id, version, dataObj, reference);
             }
             else
             {
-                workflowId = await _workflowHost.StartWorkflow(id, version, null);
+                workflowId = await _workflowHost.StartWorkflow(id, version, null, reference);
             }
             
             return Ok(workflowId);

--- a/src/samples/WorkflowCore.Sample01/Program.cs
+++ b/src/samples/WorkflowCore.Sample01/Program.cs
@@ -22,7 +22,7 @@ namespace WorkflowCore.Sample01
             host.RegisterWorkflow<HelloWorldWorkflow>();        
             host.Start();            
 
-            host.StartWorkflow("HelloWorld", 1, null, null);
+            host.StartWorkflow("HelloWorld");
             
             Console.ReadLine();
             host.Stop();

--- a/src/samples/WorkflowCore.Sample01/Program.cs
+++ b/src/samples/WorkflowCore.Sample01/Program.cs
@@ -22,7 +22,7 @@ namespace WorkflowCore.Sample01
             host.RegisterWorkflow<HelloWorldWorkflow>();        
             host.Start();            
 
-            host.StartWorkflow("HelloWorld", 1, null);
+            host.StartWorkflow("HelloWorld", 1, null, null);
             
             Console.ReadLine();
             host.Stop();

--- a/src/samples/WorkflowCore.Sample02/Program.cs
+++ b/src/samples/WorkflowCore.Sample02/Program.cs
@@ -21,7 +21,7 @@ namespace WorkflowCore.Sample02
             host.RegisterWorkflow<SimpleDecisionWorkflow>();
             host.Start();
 
-            host.StartWorkflow("Simple Decision Workflow", 1, null, null);
+            host.StartWorkflow("Simple Decision Workflow");
 
             Console.ReadLine();
             host.Stop();

--- a/src/samples/WorkflowCore.Sample02/Program.cs
+++ b/src/samples/WorkflowCore.Sample02/Program.cs
@@ -21,7 +21,7 @@ namespace WorkflowCore.Sample02
             host.RegisterWorkflow<SimpleDecisionWorkflow>();
             host.Start();
 
-            host.StartWorkflow("Simple Decision Workflow", 1, null);
+            host.StartWorkflow("Simple Decision Workflow", 1, null, null);
 
             Console.ReadLine();
             host.Stop();

--- a/src/samples/WorkflowCore.Sample05/Program.cs
+++ b/src/samples/WorkflowCore.Sample05/Program.cs
@@ -22,7 +22,7 @@ namespace WorkflowCore.Sample05
             host.RegisterWorkflow<DeferSampleWorkflow>();
             host.Start();
 
-            host.StartWorkflow("DeferSampleWorkflow", 1, null);
+            host.StartWorkflow("DeferSampleWorkflow", 1, null, null);
                         
             Console.ReadLine();
             host.Stop();

--- a/src/samples/WorkflowCore.Sample06/Program.cs
+++ b/src/samples/WorkflowCore.Sample06/Program.cs
@@ -22,7 +22,7 @@ namespace WorkflowCore.Sample06
             host.RegisterWorkflow<MultipleOutcomeWorkflow>();
             host.Start();
 
-            host.StartWorkflow("MultipleOutcomeWorkflow", 1, null);
+            host.StartWorkflow("MultipleOutcomeWorkflow", 1, null, null);
 
             Console.ReadLine();
             host.Stop();

--- a/src/samples/WorkflowCore.Sample15/Program.cs
+++ b/src/samples/WorkflowCore.Sample15/Program.cs
@@ -18,7 +18,7 @@ namespace WorkflowCore.Sample15
             host.RegisterWorkflow<HelloWorldWorkflow>();
             host.Start();
 
-            host.StartWorkflow("HelloWorld", 1, null);
+            host.StartWorkflow("HelloWorld", 1, null, null);
 
             Console.ReadLine();
             host.Stop();

--- a/test/WorkflowCore.UnitTests/BasePersistenceFixture.cs
+++ b/test/WorkflowCore.UnitTests/BasePersistenceFixture.cs
@@ -49,7 +49,8 @@ namespace WorkflowCore.UnitTests
                 Status = WorkflowStatus.Runnable,
                 NextExecution = 0,
                 Version = 1,
-                WorkflowDefinitionId = "My Workflow"
+                WorkflowDefinitionId = "My Workflow",
+                Reference =  "My Reference"
             };
             workflow.ExecutionPointers.Add(new ExecutionPointer()
             {
@@ -76,7 +77,8 @@ namespace WorkflowCore.UnitTests
                 NextExecution = 0,
                 Version = 1,
                 WorkflowDefinitionId = "My Workflow",
-                CreateTime = new DateTime(2000, 1, 1).ToUniversalTime()
+                CreateTime = new DateTime(2000, 1, 1).ToUniversalTime(),
+                Reference = "My Reference"
             };
             oldWorkflow.ExecutionPointers.Add(new ExecutionPointer()
             {
@@ -87,6 +89,7 @@ namespace WorkflowCore.UnitTests
             var workflowId = Subject.CreateNewWorkflow(oldWorkflow).Result;
             var newWorkflow = Utils.DeepCopy(oldWorkflow);
             newWorkflow.Data = oldWorkflow.Data;
+            newWorkflow.Reference = oldWorkflow.Reference;
             newWorkflow.NextExecution = 7;
             newWorkflow.ExecutionPointers.Add(new ExecutionPointer() { Id = Guid.NewGuid().ToString(), Active = true, StepId = 1 });
 


### PR DESCRIPTION
This PR is to address #153 which exposes the WorkflowInstance's 'Reference' property.

Notes:
* A number of unit tests are failing from my end prior to change, I didn't bother with those.  I'm using Rider 2018.1 on Mac.
* Regarding placement of "Reference" argument in  StartWorkflow().  The current placement feels awkward, but it sets up for slightly better compatibility. Preferably, the sequence will be (id, version, reference, data)
* I'm considering updating model builder to index 'Reference'.  But then, probably better to let the end users decide on that.