### PR TITLE
Remove reflection for creating Data

### DIFF
--- a/src/WorkflowCore/Interface/IWorkflowController.cs
+++ b/src/WorkflowCore/Interface/IWorkflowController.cs
@@ -9,8 +9,8 @@ namespace WorkflowCore.Interface
     {
         Task<string> StartWorkflow(string workflowId, object data = null);
         Task<string> StartWorkflow(string workflowId, int? version, object data = null);
-        Task<string> StartWorkflow<TData>(string workflowId, TData data = null) where TData : class;
-        Task<string> StartWorkflow<TData>(string workflowId, int? version, TData data = null) where TData : class;
+        Task<string> StartWorkflow<TData>(string workflowId, TData data = null) where TData : class, new();
+        Task<string> StartWorkflow<TData>(string workflowId, int? version, TData data = null) where TData : class, new();
 
         Task PublishEvent(string eventName, string eventKey, object eventData, DateTime? effectiveDate = null);
         void RegisterWorkflow<TWorkflow>() where TWorkflow : IWorkflow, new();

--- a/src/WorkflowCore/Services/WorkflowController.cs
+++ b/src/WorkflowCore/Services/WorkflowController.cs
@@ -18,7 +18,7 @@ namespace WorkflowCore.Services
         private readonly IQueueProvider _queueProvider;
         private readonly IExecutionPointerFactory _pointerFactory;
         private readonly ILogger _logger;
-        
+
         public WorkflowController(IPersistenceProvider persistenceStore, IDistributedLockProvider lockProvider, IWorkflowRegistry registry, IQueueProvider queueProvider, IExecutionPointerFactory pointerFactory, ILoggerFactory loggerFactory)
         {
             _persistenceStore = persistenceStore;
@@ -39,16 +39,16 @@ namespace WorkflowCore.Services
             return StartWorkflow<object>(workflowId, version, data);
         }
 
-        public Task<string> StartWorkflow<TData>(string workflowId, TData data = null) 
-            where TData : class
+        public Task<string> StartWorkflow<TData>(string workflowId, TData data = null)
+            where TData : class, new()
         {
             return StartWorkflow<TData>(workflowId, null, data);
         }
 
         public async Task<string> StartWorkflow<TData>(string workflowId, int? version, TData data = null)
-            where TData : class
+            where TData : class, new()
         {
-            
+
             var def = _registry.GetDefinition(workflowId, version);
             if (def == null)
             {
@@ -68,7 +68,7 @@ namespace WorkflowCore.Services
 
             if ((def.DataType != null) && (data == null))
             {
-                wf.Data = TypeExtensions.GetConstructor(def.DataType, new Type[] { }).Invoke(null);
+                wf.Data = new TData();
             }
 
             wf.ExecutionPointers.Add(_pointerFactory.BuildGenesisPointer(def));
@@ -101,7 +101,7 @@ namespace WorkflowCore.Services
         {
             if (!await _lockProvider.AcquireLock(workflowId, new CancellationToken()))
                 return false;
-            
+
             try
             {
                 var wf = await _persistenceStore.GetWorkflowInstance(workflowId);
@@ -168,7 +168,7 @@ namespace WorkflowCore.Services
                 await _lockProvider.ReleaseLock(workflowId);
             }
         }
-        
+
         public void RegisterWorkflow<TWorkflow>()
             where TWorkflow : IWorkflow, new()
         {

--- a/src/WorkflowCore/Services/WorkflowHost.cs
+++ b/src/WorkflowCore/Services/WorkflowHost.cs
@@ -12,8 +12,8 @@ using WorkflowCore.Exceptions;
 namespace WorkflowCore.Services
 {
     public class WorkflowHost : IWorkflowHost, IDisposable
-    {                
-        protected bool _shutdown = true;        
+    {
+        protected bool _shutdown = true;
         protected readonly IServiceProvider _serviceProvider;
 
         private readonly IEnumerable<IBackgroundTask> _backgroundTasks;
@@ -54,14 +54,14 @@ namespace WorkflowCore.Services
         }
 
         public Task<string> StartWorkflow<TData>(string workflowId, TData data = null)
-            where TData : class
+            where TData : class, new()
         {
             return _workflowController.StartWorkflow<TData>(workflowId, null, data);
         }
 
 
         public Task<string> StartWorkflow<TData>(string workflowId, int? version, TData data = null)
-            where TData : class
+            where TData : class, new()
         {
             return _workflowController.StartWorkflow(workflowId, version, data);
         }
@@ -72,7 +72,7 @@ namespace WorkflowCore.Services
         }
 
         public void Start()
-        {            
+        {
             _shutdown = false;
             PersistenceStore.EnsureStoreExists();
             QueueProvider.Start().Wait();
@@ -86,26 +86,26 @@ namespace WorkflowCore.Services
 
         public void Stop()
         {
-            _shutdown = true;            
-            
+            _shutdown = true;
+
             Logger.LogInformation("Stopping background tasks");
             foreach (var th in _backgroundTasks)
                 th.Stop();
-            
+
             Logger.LogInformation("Worker tasks stopped");
-            
+
             QueueProvider.Stop();
             LockProvider.Stop();
         }
-        
-        public void RegisterWorkflow<TWorkflow>() 
+
+        public void RegisterWorkflow<TWorkflow>()
             where TWorkflow : IWorkflow, new()
         {
             TWorkflow wf = new TWorkflow();
             Registry.RegisterWorkflow(wf);
         }
 
-        public void RegisterWorkflow<TWorkflow, TData>() 
+        public void RegisterWorkflow<TWorkflow, TData>()
             where TWorkflow : IWorkflow<TData>, new()
             where TData : new()
         {


### PR DESCRIPTION
Since Data for Workflow must have a parameterless constructor, this constraint can be added to `StartWorkflow<TData>`,  so we don't use reflection for creating `Data`