### PR TITLE
Added support for indexers instead of properties for the DataType.

### DIFF
--- a/src/WorkflowCore/Services/DefinitionStorage/DefinitionLoader.cs
+++ b/src/WorkflowCore/Services/DefinitionStorage/DefinitionLoader.cs
@@ -173,12 +173,15 @@ namespace WorkflowCore.Services.DefinitionStorage
                 var dataParameter = Expression.Parameter(dataType, "data");
                 var contextParameter = Expression.Parameter(typeof(IStepExecutionContext), "context");
                 var sourceExpr = DynamicExpressionParser.ParseLambda(new [] { dataParameter, contextParameter }, typeof(object), input.Value);
-                var targetExpr = Expression.Property(Expression.Parameter(stepType), input.Key);
 
-                step.Inputs.Add(new DataMapping()
+                var stepParameter = Expression.Parameter(stepType, "step");
+                var targetProperty = Expression.Property(stepParameter, input.Key);
+                var targetExpr = Expression.Lambda(targetProperty, stepParameter);
+
+                step.Inputs.Add(new DataMapping
                 {
                     Source = sourceExpr,
-                    Target = Expression.Lambda(targetExpr)
+                    Target = targetExpr
                 });
             }
         }
@@ -189,12 +192,28 @@ namespace WorkflowCore.Services.DefinitionStorage
             {
                 var stepParameter = Expression.Parameter(stepType, "step");
                 var sourceExpr = DynamicExpressionParser.ParseLambda(new[] { stepParameter }, typeof(object), output.Value);
-                var targetExpr = Expression.Property(Expression.Parameter(dataType), output.Key);
 
-                step.Outputs.Add(new DataMapping()
+                var dataParameter = Expression.Parameter(dataType, "data");
+                Expression targetProperty;
+                
+                // Check if our datatype has a matching property
+                var propertyInfo = dataType.GetProperty(output.Key);
+                if (propertyInfo != null)
+                {
+                    targetProperty = Expression.Property(dataParameter, propertyInfo);
+                }
+                else
+                {
+                    // If we did not find a matching property try to find a Indexer with string parameter
+                    propertyInfo = dataType.GetProperty("Item");
+                    targetProperty = Expression.Property(dataParameter, propertyInfo, Expression.Constant(output.Key));
+                }
+                var targetExpr = Expression.Lambda(targetProperty, dataParameter);
+
+                step.Outputs.Add(new DataMapping
                 {
                     Source = sourceExpr,
-                    Target = Expression.Lambda(targetExpr)
+                    Target = targetExpr
                 });
             }
         }

--- a/src/WorkflowCore/Services/FluentBuilders/ExpressionHelpers.cs
+++ b/src/WorkflowCore/Services/FluentBuilders/ExpressionHelpers.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace WorkflowCore.Services.FluentBuilders
+{
+    internal static class ExpressionHelpers
+    {
+        public static Expression<Action<TObject, TParam>> CreateSetter<TObject, TParam>(
+            Expression<Func<TObject, TParam>> getterExpression)
+        {
+            var valueParameter = Expression.Parameter(typeof(TParam), "value");
+            Expression assignment;
+            if (getterExpression.Body is MethodCallExpression callExpression && callExpression.Method.Name == "get_Item")
+            {
+                //Get Matching setter method for the indexer
+                var parameterTypes = callExpression.Method.GetParameters()
+                    .Select(p => p.ParameterType)
+                    .ToArray();
+                var itemProperty = callExpression.Method.DeclaringType.GetProperty("Item", typeof(TParam), parameterTypes);
+
+                assignment = Expression.Call(callExpression.Object, itemProperty.SetMethod, callExpression.Arguments.Concat(new[] { valueParameter }));
+            }
+            else
+            {
+                assignment = Expression.Assign(getterExpression.Body, valueParameter);
+            }
+            return Expression.Lambda<Action<TObject, TParam>>(assignment, valueParameter);
+        }
+
+        public static LambdaExpression CreateSetter(LambdaExpression getterExpression)
+        {
+            var thisParameter = getterExpression.Parameters.Single();
+            var valueParameter = Expression.Parameter(getterExpression.ReturnType, "value");
+            Expression assignment;
+            if (getterExpression.Body is MethodCallExpression callExpression && callExpression.Method.Name == "get_Item")
+            {
+                //Get Matching setter method for the indexer
+                var parameterTypes = callExpression.Method.GetParameters()
+                    .Select(p => p.ParameterType)
+                    .ToArray();
+                var itemProperty = callExpression.Method.DeclaringType.GetProperty("Item", valueParameter.Type, parameterTypes);
+
+                assignment = Expression.Call(callExpression.Object, itemProperty.SetMethod, callExpression.Arguments.Concat(new[] { valueParameter }));
+            }
+            else
+            {
+                assignment = Expression.Assign(getterExpression.Body, valueParameter);
+            }
+            return Expression.Lambda(assignment, thisParameter, valueParameter);
+        }
+    }
+}

--- a/src/WorkflowCore/Services/FluentBuilders/ExpressionHelpers.cs
+++ b/src/WorkflowCore/Services/FluentBuilders/ExpressionHelpers.cs
@@ -31,7 +31,6 @@ namespace WorkflowCore.Services.FluentBuilders
 
         public static LambdaExpression CreateSetter(LambdaExpression getterExpression)
         {
-            var thisParameter = getterExpression.Parameters.Single();
             var valueParameter = Expression.Parameter(getterExpression.ReturnType, "value");
             Expression assignment;
             if (getterExpression.Body is MethodCallExpression callExpression && callExpression.Method.Name == "get_Item")
@@ -48,7 +47,9 @@ namespace WorkflowCore.Services.FluentBuilders
             {
                 assignment = Expression.Assign(getterExpression.Body, valueParameter);
             }
-            return Expression.Lambda(assignment, thisParameter, valueParameter);
+
+            var parameters = getterExpression.Parameters.Concat(new[] {valueParameter}).ToArray();
+            return Expression.Lambda(assignment, parameters);
         }
     }
 }

--- a/src/WorkflowCore/Services/WorkflowExecutor.cs
+++ b/src/WorkflowCore/Services/WorkflowExecutor.cs
@@ -111,7 +111,7 @@ namespace WorkflowCore.Services
 
                         if (result.Proceed)
                         {
-                            ProcessOutputs(workflow, step, body);
+                            ProcessOutputs(workflow, step, body, context);
                         }
 
                         _executionResultProcessor.ProcessExecutionResult(workflow, def, pointer, step, result, wfResult);
@@ -176,15 +176,23 @@ namespace WorkflowCore.Services
             }
         }
 
-        private void ProcessOutputs(WorkflowInstance workflow, WorkflowStep step, IStepBody body)
+        private void ProcessOutputs(WorkflowInstance workflow, WorkflowStep step, IStepBody body, IStepExecutionContext context)
         {
             foreach (var output in step.Outputs)
             {
                 var resolvedValue = output.Source.Compile().DynamicInvoke(body);
                 var data = workflow.Data;
                 var setter = ExpressionHelpers.CreateSetter(output.Target);
-                var convertedValue = Convert.ChangeType(resolvedValue, setter.Parameters[1].Type);
-                setter.Compile().DynamicInvoke(data, convertedValue);
+                var convertedValue = Convert.ChangeType(resolvedValue, setter.Parameters.Last().Type);
+
+                if (setter.Parameters.Count == 2)
+                {
+                    setter.Compile().DynamicInvoke(data, convertedValue);
+                }
+                else
+                {
+                    setter.Compile().DynamicInvoke(data, context, convertedValue);
+                }
             }
         }
 

--- a/src/WorkflowCore/Services/WorkflowExecutor.cs
+++ b/src/WorkflowCore/Services/WorkflowExecutor.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
+using WorkflowCore.Services.FluentBuilders;
 
 namespace WorkflowCore.Services
 {
@@ -179,12 +180,11 @@ namespace WorkflowCore.Services
         {
             foreach (var output in step.Outputs)
             {
-                var member = (output.Target.Body as MemberExpression);
                 var resolvedValue = output.Source.Compile().DynamicInvoke(body);
                 var data = workflow.Data;
-                var property = data.GetType().GetProperty(member.Member.Name);
-                var convertedValue = Convert.ChangeType(resolvedValue, property.PropertyType);
-                property.SetValue(data, convertedValue);
+                var setter = ExpressionHelpers.CreateSetter(output.Target);
+                var convertedValue = Convert.ChangeType(resolvedValue, setter.Parameters[1].Type);
+                setter.Compile().DynamicInvoke(data, convertedValue);
             }
         }
 

--- a/src/samples/WorkflowCore.Sample03/PassingDataWorkflow2.cs
+++ b/src/samples/WorkflowCore.Sample03/PassingDataWorkflow2.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using WorkflowCore.Sample03.Steps;
+
+namespace WorkflowCore.Sample03
+{
+    public class PassingDataWorkflow2 : IWorkflow<Dictionary<string, int>>
+    {
+        public void Build(IWorkflowBuilder<Dictionary<string, int>> builder)
+        {
+            builder
+                .StartWith(context =>
+                {
+                    Console.WriteLine("Starting workflow...");
+                    return ExecutionResult.Next();
+                })
+                .Then<AddNumbers>()
+                .Input(step => step.Input1, data => data["Value1"])
+                .Input(step => step.Input2, data => data["Value2"])
+                .Output(data => data["Value3"], step => step.Output)
+                .Then<CustomMessage>()
+                .Name("Print custom message")
+                .Input(step => step.Message, data => "The answer is " + data["Value3"].ToString())
+                .Then(context =>
+                {
+                    Console.WriteLine("Workflow complete");
+                    return ExecutionResult.Next();
+                });
+        }
+
+        public string Id => "PassingDataWorkflow2";
+
+        public int Version => 1;
+
+    }
+}

--- a/src/samples/WorkflowCore.Sample03/PassingDataWorkflow2.cs
+++ b/src/samples/WorkflowCore.Sample03/PassingDataWorkflow2.cs
@@ -17,17 +17,17 @@ namespace WorkflowCore.Sample03
                     return ExecutionResult.Next();
                 })
                 .Then<AddNumbers>()
-                .Input(step => step.Input1, data => data["Value1"])
-                .Input(step => step.Input2, data => data["Value2"])
-                .Output(data => data["Value3"], step => step.Output)
+                    .Input(step => step.Input1, data => data["Value1"])
+                    .Input(step => step.Input2, data => data["Value2"])
+                    .Output(data => data["Value3"], step => step.Output)
                 .Then<CustomMessage>()
-                .Name("Print custom message")
-                .Input(step => step.Message, data => "The answer is " + data["Value3"].ToString())
+                    .Name("Print custom message")
+                    .Input(step => step.Message, data => "The answer is " + data["Value3"].ToString())
                 .Then(context =>
-                {
-                    Console.WriteLine("Workflow complete");
-                    return ExecutionResult.Next();
-                });
+                    {
+                        Console.WriteLine("Workflow complete");
+                        return ExecutionResult.Next();
+                    });
         }
 
         public string Id => "PassingDataWorkflow2";

--- a/src/samples/WorkflowCore.Sample03/Program.cs
+++ b/src/samples/WorkflowCore.Sample03/Program.cs
@@ -29,6 +29,17 @@ namespace WorkflowCore.Sample03
 
             host.StartWorkflow("PassingDataWorkflow", 1, initialData);
 
+            host.RegisterWorkflow<PassingDataWorkflow2, Dictionary<string, int>>();
+            //host.Start();
+
+            var initialData2 = new Dictionary<string, int>
+            {
+                ["Value1"] = 2,
+                ["Value2"] = 3
+            };
+
+            host.StartWorkflow("PassingDataWorkflow2", 1, initialData2);
+
             Console.ReadLine();
             host.Stop();
         }

--- a/test/WorkflowCore.IntegrationTests/Scenarios/DynamicDataIOScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/DynamicDataIOScenario.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using WorkflowCore.Testing;
+using Xunit;
+
+namespace WorkflowCore.IntegrationTests.Scenarios
+{
+    public class DynamicDataIOScenario : WorkflowTest<DynamicDataIOScenario.DataIOWorkflow, DynamicDataIOScenario.MyDataClass>
+    {
+        public class AddNumbers : StepBody
+        {
+            public int Input1 { get; set; }
+            public int Input2 { get; set; }
+            public int Output { get; set; }
+
+            public override ExecutionResult Run(IStepExecutionContext context)
+            {
+                Output = (Input1 + Input2);
+                return ExecutionResult.Next();
+            }
+        }
+
+        public class MyDataClass
+        {
+            public int Value1 { get; set; }
+            public int Value2 { get; set; }
+
+            public Dictionary<string, int> _storage = new Dictionary<string, int>();
+
+            public int this[string propertyName]
+            {
+                get => _storage[propertyName];
+                set => _storage[propertyName] = value;
+            }
+        }
+
+        public class DataIOWorkflow : IWorkflow<MyDataClass>
+        {
+            public string Id => "DataIOWorkflow";
+            public int Version => 1;
+            public void Build(IWorkflowBuilder<MyDataClass> builder)
+            {
+                builder
+                    .StartWith<AddNumbers>()
+                    .Input(step => step.Input1, data => data.Value1)
+                    .Input(step => step.Input2, data => data.Value2)
+                    .Output(data => data["Value3"], step => step.Output);
+            }
+        }
+
+        public DynamicDataIOScenario()
+        {
+            Setup();
+        }
+
+        [Fact]
+        public void Scenario()
+        {
+            var workflowId = StartWorkflow(new MyDataClass() { Value1 = 2, Value2 = 3 });
+            WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(30));
+
+            GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
+            UnhandledStepErrors.Count.Should().Be(0);
+            GetData(workflowId)["Value3"].Should().Be(5);
+        }
+    }
+}

--- a/test/WorkflowCore.IntegrationTests/Scenarios/DynamicDataIOScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/DynamicDataIOScenario.cs
@@ -27,8 +27,7 @@ namespace WorkflowCore.IntegrationTests.Scenarios
         {
             public int Value1 { get; set; }
             public int Value2 { get; set; }
-
-            public Dictionary<string, int> Storage = new Dictionary<string, int>();
+            public Dictionary<string, int> Storage { get; set; } = new Dictionary<string, int>();
 
             public int this[string propertyName]
             {

--- a/test/WorkflowCore.IntegrationTests/Scenarios/DynamicDataIOScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/DynamicDataIOScenario.cs
@@ -28,12 +28,12 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             public int Value1 { get; set; }
             public int Value2 { get; set; }
 
-            public Dictionary<string, int> _storage = new Dictionary<string, int>();
+            public Dictionary<string, int> Storage = new Dictionary<string, int>();
 
             public int this[string propertyName]
             {
-                get => _storage[propertyName];
-                set => _storage[propertyName] = value;
+                get => Storage[propertyName];
+                set => Storage[propertyName] = value;
             }
         }
 

--- a/test/WorkflowCore.TestAssets/DataTypes/DynamicData.cs
+++ b/test/WorkflowCore.TestAssets/DataTypes/DynamicData.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace WorkflowCore.TestAssets.DataTypes
+{
+    public class DynamicData
+    {
+        public Dictionary<string, object> Storage { get; set; } = new Dictionary<string, object>();
+
+        public object this[string propertyName]
+        {
+            get => Storage.TryGetValue(propertyName, out var value) ? value : null;
+            set => Storage[propertyName] = value;
+        }
+    }
+}

--- a/test/WorkflowCore.TestAssets/Utils.cs
+++ b/test/WorkflowCore.TestAssets/Utils.cs
@@ -23,6 +23,11 @@ namespace WorkflowCore.TestAssets
             //return Properties.Resources.ResourceManager.GetString("stored_definition");
             return File.ReadAllText("stored-definition.json");
         }
+
+        public static string GetTestDefinitionDynamicJson()
+        {
+            return File.ReadAllText("stored-dynamic-definition.json");
+        }
     }
 }
 

--- a/test/WorkflowCore.TestAssets/WorkflowCore.TestAssets.csproj
+++ b/test/WorkflowCore.TestAssets/WorkflowCore.TestAssets.csproj
@@ -13,9 +13,13 @@
 
   <ItemGroup>
     <None Remove="stored-definition.json" />
+    <None Remove="stored-dynamic-definition.json" />
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="stored-dynamic-definition.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
     <EmbeddedResource Include="stored-definition.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </EmbeddedResource>

--- a/test/WorkflowCore.TestAssets/stored-dynamic-definition.json
+++ b/test/WorkflowCore.TestAssets/stored-dynamic-definition.json
@@ -1,0 +1,70 @@
+﻿{
+  "Id": "Test",
+  "Version": 1,
+  "Description": "",
+  "DataType": "WorkflowCore.TestAssets.DataTypes.DynamicData, WorkflowCore.TestAssets",
+  "Steps": [
+    {
+      "Id": "Step1",
+      "StepType": "WorkflowCore.TestAssets.Steps.Counter, WorkflowCore.TestAssets",
+      "Inputs": { "Value": "data[\"Counter1\"]" },
+      "Outputs": { "Counter1": "step.Value" },
+      "NextStepId": "Step2"
+    },
+    {
+      "Id": "Step2",
+      "StepType": "WorkflowCore.TestAssets.Steps.Counter, WorkflowCore.TestAssets",
+      "Inputs": { "Value": "data[\"Counter2\"]" },
+      "Outputs": { "Counter2": "step.Value" },
+      "NextStepId": "Step3"
+    },
+    {
+      "Id": "Step3",
+      "StepType": "WorkflowCore.Primitives.If, WorkflowCore",
+      "NextStepId": "Step4",
+      "Inputs": { "Condition": "object.Equals(data[\"Flag1\"], true)" },
+      "Do": [
+        [
+          {
+            "Id": "Step3.1.1",
+            "StepType": "WorkflowCore.TestAssets.Steps.Counter, WorkflowCore.TestAssets",
+            "Inputs": { "Value": "data[\"Counter3\"]" },
+            "Outputs": { "Counter3": "step.Value" },
+            "NextStepId": "Step3.1.2"
+          },
+          {
+            "Id": "Step3.1.2",
+            "StepType": "WorkflowCore.TestAssets.Steps.Counter, WorkflowCore.TestAssets",
+            "Inputs": { "Value": "data[\"Counter4\"]" },
+            "Outputs": { "Counter4": "step.Value" }
+          }
+        ],
+        [
+          {
+            "Id": "Step3.2.1",
+            "StepType": "WorkflowCore.Primitives.WaitFor, WorkflowCore",
+            "NextStepId": "Step3.2.2",
+            "CancelCondition": "object.Equals(data[\"Flag2\"], true)",
+            "Inputs": {
+              "EventName": "\"Event1\"",
+              "EventKey": "\"Key1\"",
+              "EffectiveDate": "DateTime.Now"
+            }
+          },
+          {
+            "Id": "Step3.2.2",
+            "StepType": "WorkflowCore.TestAssets.Steps.Counter, WorkflowCore.TestAssets",
+            "Inputs": { "Value": "data[\"Counter5\"]" },
+            "Outputs": { "Counter5": "step.Value" }
+          }
+        ]
+      ]
+    },
+    {
+      "Id": "Step4",
+      "StepType": "WorkflowCore.TestAssets.Steps.Counter, WorkflowCore.TestAssets",
+      "Inputs": { "Value": "data[\"Counter6\"]" },
+      "Outputs": { "Counter6": "step.Value" }
+    }
+  ]
+}

--- a/test/WorkflowCore.Tests.MongoDB/Scenarios/MongoDynamicDataScenario.cs
+++ b/test/WorkflowCore.Tests.MongoDB/Scenarios/MongoDynamicDataScenario.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using Xunit;
+
+namespace WorkflowCore.Tests.MongoDB.Scenarios
+{
+    [Collection("Mongo collection")]
+    public class MongoDynamicDataScenario : DynamicDataIOScenario
+    {
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseMongoDB(MongoDockerSetup.ConnectionString, "integration-tests"));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.PostgreSQL/Scenarios/PostgresDynamicDataScenario.cs
+++ b/test/WorkflowCore.Tests.PostgreSQL/Scenarios/PostgresDynamicDataScenario.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using Xunit;
+
+namespace WorkflowCore.Tests.PostgreSQL.Scenarios
+{
+    [Collection("Postgres collection")]
+    public class PostgresDynamicDataScenario : DynamicDataIOScenario
+    {
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UsePostgreSQL(PostgresDockerSetup.ScenarioConnectionString, true, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.SqlServer/Scenarios/SqlServerDynamicDataScenario.cs
+++ b/test/WorkflowCore.Tests.SqlServer/Scenarios/SqlServerDynamicDataScenario.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using Xunit;
+
+namespace WorkflowCore.Tests.SqlServer.Scenarios
+{
+    [Collection("SqlServer collection")]
+    public class SqlServerDynamicDataScenario : DynamicDataIOScenario
+    {
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseSqlServer(SqlDockerSetup.ScenarioConnectionString, true, true));
+        }
+    }
+}

--- a/test/WorkflowCore.UnitTests/Services/DefinitionStorage/DefinitionLoaderTests.cs
+++ b/test/WorkflowCore.UnitTests/Services/DefinitionStorage/DefinitionLoaderTests.cs
@@ -27,7 +27,7 @@ namespace WorkflowCore.UnitTests.Services.DefinitionStorage
         }
 
         [Fact(DisplayName = "Should register workflow")]
-        public void RegisterDefintion()
+        public void RegisterDefinition()
         {
             _subject.LoadDefinition("{\"Id\": \"HelloWorld\", \"Version\": 1, \"Steps\": []}");
 
@@ -37,7 +37,7 @@ namespace WorkflowCore.UnitTests.Services.DefinitionStorage
         }
 
         [Fact(DisplayName = "Should parse definition")]
-        public void ParseDefintion()
+        public void ParseDefinition()
         {
             _subject.LoadDefinition(TestAssets.Utils.GetTestDefinitionJson());
 

--- a/test/WorkflowCore.UnitTests/Services/DefinitionStorage/DefinitionLoaderTests.cs
+++ b/test/WorkflowCore.UnitTests/Services/DefinitionStorage/DefinitionLoaderTests.cs
@@ -43,7 +43,19 @@ namespace WorkflowCore.UnitTests.Services.DefinitionStorage
 
             A.CallTo(() => _registry.RegisterWorkflow(A<WorkflowDefinition>.That.Matches(x => x.Id == "Test"))).MustHaveHappened();
             A.CallTo(() => _registry.RegisterWorkflow(A<WorkflowDefinition>.That.Matches(x => x.Version == 1))).MustHaveHappened();
-            A.CallTo(() => _registry.RegisterWorkflow(A<WorkflowDefinition>.That.Matches(x => x.DataType == typeof(TestAssets.DataTypes.CounterBoard)))).MustHaveHappened();
+            A.CallTo(() => _registry.RegisterWorkflow(A<WorkflowDefinition>.That.Matches(x => x.DataType == typeof(CounterBoard)))).MustHaveHappened();
+            A.CallTo(() => _registry.RegisterWorkflow(A<WorkflowDefinition>.That.Matches(MatchTestDefinition, ""))).MustHaveHappened();
+        }
+
+
+        [Fact(DisplayName = "Should parse definition")]
+        public void ParseDefinitionDynamic()
+        {
+            _subject.LoadDefinition(TestAssets.Utils.GetTestDefinitionDynamicJson());
+
+            A.CallTo(() => _registry.RegisterWorkflow(A<WorkflowDefinition>.That.Matches(x => x.Id == "Test"))).MustHaveHappened();
+            A.CallTo(() => _registry.RegisterWorkflow(A<WorkflowDefinition>.That.Matches(x => x.Version == 1))).MustHaveHappened();
+            A.CallTo(() => _registry.RegisterWorkflow(A<WorkflowDefinition>.That.Matches(x => x.DataType == typeof(DynamicData)))).MustHaveHappened();
             A.CallTo(() => _registry.RegisterWorkflow(A<WorkflowDefinition>.That.Matches(MatchTestDefinition, ""))).MustHaveHappened();
         }
 

--- a/test/WorkflowCore.UnitTests/Services/WorkflowExecutorFixture.cs
+++ b/test/WorkflowCore.UnitTests/Services/WorkflowExecutorFixture.cs
@@ -223,6 +223,54 @@ namespace WorkflowCore.UnitTests.Services
             data.Value1.Should().Be(7);
         }
 
+        [Fact(DisplayName = "Should map dynamic outputs")]
+        public void should_map_outputs_dynamic()
+        {
+            //arrange
+            Expression<Func<IStepWithProperties, int>> p1 = x => x.Property1;
+            Expression<Func<DynamicDataClass, IStepExecutionContext, int>> v1 = (x, context) => x["Value1"];
+
+            var step1Body = A.Fake<IStepWithProperties>();
+            A.CallTo(() => step1Body.Property1).Returns(7);
+            A.CallTo(() => step1Body.RunAsync(A<IStepExecutionContext>.Ignored)).Returns(ExecutionResult.Next());
+            WorkflowStep step1 = BuildFakeStep(step1Body, new List<DataMapping>(), new List<DataMapping>()
+                {
+                    new DataMapping()
+                    {
+                        Source = p1,
+                        Target = v1
+                    }
+                }
+            );
+
+            Given1StepWorkflow(step1, "Workflow", 1);
+
+            var data = new DynamicDataClass()
+            {
+                ["Value1"] = 5
+            };
+
+            var instance = new WorkflowInstance
+            {
+                WorkflowDefinitionId = "Workflow",
+                Version = 1,
+                Status = WorkflowStatus.Runnable,
+                NextExecution = 0,
+                Id = "001",
+                Data = data,
+                ExecutionPointers = new List<ExecutionPointer>()
+                {
+                    new ExecutionPointer() { Active = true, StepId = 0 }
+                }
+            };
+
+            //act
+            Subject.Execute(instance);
+
+            //assert
+            data["Value1"].Should().Be(7);
+        }
+
         [Fact(DisplayName = "Should handle step exception")]
         public void should_handle_step_exception()
         {
@@ -332,6 +380,17 @@ namespace WorkflowCore.UnitTests.Services
             public int Value1 { get; set; }
             public int Value2 { get; set; }
             public int Value3 { get; set; }
+        }
+
+        public class DynamicDataClass
+        {
+            public Dictionary<string, int> Storage { get; set; } = new Dictionary<string, int>();
+
+            public int this[string propertyName]
+            {
+                get => Storage[propertyName];
+                set => Storage[propertyName] = value;
+            }
         }
     }
 }


### PR DESCRIPTION
I recently discovered your library and liked it quite a lot.
However I had a similar use case to issue #95, basically requiring a dynamic data model.

I decided to give a try to extending support for this without breaking old code or changing public interfaces.

My changes would allow any type with an indexer with a string parameter to be used.
You could even mix normal properties and "dynamic" ones.

This code is of course not perfect, so please let me know if you think this would be useful for workflow-core and if you have ideas for improvements.