### PR TITLE
Order of compensation steps

### DIFF
--- a/ReleaseNotes/1.6.8.md
+++ b/ReleaseNotes/1.6.8.md
@@ -1,0 +1,3 @@
+# Workflow Core 1.6.8
+
+* Fixed the order in which multiple compensating steps execute within a saga transaction. [Issue 191](https://github.com/danielgerlag/workflow-core/issues/191)

--- a/WorkflowCore.sln
+++ b/WorkflowCore.sln
@@ -92,6 +92,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ReleaseNotes", "ReleaseNote
 		ReleaseNotes\1.4.0.md = ReleaseNotes\1.4.0.md
 		ReleaseNotes\1.6.0.md = ReleaseNotes\1.6.0.md
 		ReleaseNotes\1.6.6.md = ReleaseNotes\1.6.6.md
+		ReleaseNotes\1.6.8.md = ReleaseNotes\1.6.8.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Sample14", "src\samples\WorkflowCore.Sample14\WorkflowCore.Sample14.csproj", "{6BC66637-B42A-4334-ADFB-DBEC9F29D293}"

--- a/src/WorkflowCore/Services/ExecutionResultProcessor.cs
+++ b/src/WorkflowCore/Services/ExecutionResultProcessor.cs
@@ -152,7 +152,11 @@ namespace WorkflowCore.Services
 
                 if (revert)
                 {
-                    var prevSiblings = workflow.ExecutionPointers.Where(x => pointer.Scope.SequenceEqual(x.Scope) && x.Id != pointer.Id && x.Status == PointerStatus.Complete).ToList();
+                    var prevSiblings = workflow.ExecutionPointers
+                        .Where(x => pointer.Scope.SequenceEqual(x.Scope) && x.Id != pointer.Id && x.Status == PointerStatus.Complete)
+                        .OrderByDescending(x => x.EndTime)
+                        .ToList();
+
                     foreach (var siblingPointer in prevSiblings)
                     {
                         var siblingStep = def.Steps.First(x => x.Id == siblingPointer.StepId);

--- a/src/WorkflowCore/WorkflowCore.csproj
+++ b/src/WorkflowCore/WorkflowCore.csproj
@@ -15,9 +15,9 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Description>Workflow Core is a light weight workflow engine targeting .NET Standard.</Description>
-    <Version>1.6.7</Version>
-    <AssemblyVersion>1.6.7.0</AssemblyVersion>
-    <FileVersion>1.6.7.0</FileVersion>
+    <Version>1.6.8</Version>
+    <AssemblyVersion>1.6.8.0</AssemblyVersion>
+    <FileVersion>1.6.8.0</FileVersion>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageIconUrl>https://github.com/danielgerlag/workflow-core/raw/master/src/logo.png</PackageIconUrl>
   </PropertyGroup>

--- a/test/WorkflowCore.IntegrationTests/Scenarios/MultistepCompensationScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/MultistepCompensationScenario.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using Xunit;
+using FluentAssertions;
+using System.Linq;
+using WorkflowCore.Testing;
+
+namespace WorkflowCore.IntegrationTests.Scenarios
+{
+    public class MultistepCompensationScenario : WorkflowTest<MultistepCompensationScenario.Workflow, Object>
+    {
+        public class Workflow : IWorkflow
+        {
+            public static int Compensation1Fired = -1;
+            public static int Compensation2Fired = -1;
+            public static int Compensation3Fired = -1;
+            public static int Compensation4Fired = -1;
+            public static int CompensationCounter = 0;
+
+            public string Id => "CompensatingWorkflow";
+            public int Version => 1;
+            public void Build(IWorkflowBuilder<object> builder)
+            {
+                builder
+                    .StartWith(context => ExecutionResult.Next())
+                    .Saga(x => x
+                        .StartWith(context => ExecutionResult.Next())
+                            .CompensateWith(context =>
+                            {
+                                CompensationCounter++;
+                                Compensation1Fired = CompensationCounter;
+                            })
+                        .Then(context => ExecutionResult.Next())
+                            .CompensateWith(context =>
+                            {
+                                CompensationCounter++;
+                                Compensation2Fired = CompensationCounter;
+                            })
+                        .Then(context => ExecutionResult.Next())
+                            .CompensateWith(context =>
+                            {
+                                CompensationCounter++;
+                                Compensation3Fired = CompensationCounter;
+                            })
+                        .Then(context => throw new Exception())
+                            .CompensateWith(context =>
+                            {
+                                CompensationCounter++;
+                                Compensation4Fired = CompensationCounter;
+                            })
+                        );
+            }
+        }
+
+        public MultistepCompensationScenario()
+        {
+            Setup();
+            Workflow.Compensation1Fired = -1;
+            Workflow.Compensation2Fired = -1;
+            Workflow.Compensation3Fired = -1;
+            Workflow.Compensation4Fired = -1;
+            Workflow.CompensationCounter = 0;
+        }
+        
+        [Fact]
+        public void MultiCompensationStepOrder()
+        {
+            var workflowId = StartWorkflow(null);
+            WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(30));
+
+            GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
+            UnhandledStepErrors.Count.Should().Be(1);
+            
+            Workflow.Compensation1Fired.Should().Be(4);
+            Workflow.Compensation2Fired.Should().Be(3);
+            Workflow.Compensation3Fired.Should().Be(2);
+            Workflow.Compensation4Fired.Should().Be(1);
+        }
+    }
+}


### PR DESCRIPTION
This PR resolves #191 by fixing the order in which multiple compensation steps are executed within a saga transaction.