### PR TITLE
Add MySQL Provider

### DIFF
--- a/WorkflowCore.sln
+++ b/WorkflowCore.sln
@@ -113,7 +113,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Sample17", "sr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.QueueProviders.SqlServer", "src\providers\WorkflowCore.QueueProviders.SqlServer\WorkflowCore.QueueProviders.SqlServer.csproj", "{7EDD9353-F5C2-414C-AE51-4B0F1C5E105A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkflowCore.Providers.AWS", "src\providers\WorkflowCore.Providers.AWS\WorkflowCore.Providers.AWS.csproj", "{5E82A137-0954-46A1-8C46-13C00F0E4842}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Providers.AWS", "src\providers\WorkflowCore.Providers.AWS\WorkflowCore.Providers.AWS.csproj", "{5E82A137-0954-46A1-8C46-13C00F0E4842}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Persistence.MySQL", "src\providers\WorkflowCore.Persistence.MySQL\WorkflowCore.Persistence.MySQL.csproj", "{453E260D-DBDC-4DDC-BC9C-CA500CED7897}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Tests.MySQL", "test\WorkflowCore.Tests.MySQL\WorkflowCore.Tests.MySQL.csproj", "{DF7F7ECA-1771-40C9-9CD0-AFEFC44E60DE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -289,6 +293,14 @@ Global
 		{5E82A137-0954-46A1-8C46-13C00F0E4842}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5E82A137-0954-46A1-8C46-13C00F0E4842}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5E82A137-0954-46A1-8C46-13C00F0E4842}.Release|Any CPU.Build.0 = Release|Any CPU
+		{453E260D-DBDC-4DDC-BC9C-CA500CED7897}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{453E260D-DBDC-4DDC-BC9C-CA500CED7897}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{453E260D-DBDC-4DDC-BC9C-CA500CED7897}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{453E260D-DBDC-4DDC-BC9C-CA500CED7897}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF7F7ECA-1771-40C9-9CD0-AFEFC44E60DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF7F7ECA-1771-40C9-9CD0-AFEFC44E60DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF7F7ECA-1771-40C9-9CD0-AFEFC44E60DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF7F7ECA-1771-40C9-9CD0-AFEFC44E60DE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -339,6 +351,8 @@ Global
 		{42F475BC-95F4-42E1-8CCD-7B9C27487E33} = {5080DB09-CBE8-4C45-9957-C3BB7651755E}
 		{7EDD9353-F5C2-414C-AE51-4B0F1C5E105A} = {2EEE6ABD-EE9B-473F-AF2D-6DABB85D7BA2}
 		{5E82A137-0954-46A1-8C46-13C00F0E4842} = {2EEE6ABD-EE9B-473F-AF2D-6DABB85D7BA2}
+		{453E260D-DBDC-4DDC-BC9C-CA500CED7897} = {2EEE6ABD-EE9B-473F-AF2D-6DABB85D7BA2}
+		{DF7F7ECA-1771-40C9-9CD0-AFEFC44E60DE} = {E6CEAD8D-F565-471E-A0DC-676F54EAEDEB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DC0FA8D3-6449-4FDA-BB46-ECF58FAD23B4}

--- a/src/providers/WorkflowCore.Persistence.MySQL/MysqlContext.cs
+++ b/src/providers/WorkflowCore.Persistence.MySQL/MysqlContext.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using WorkflowCore.Persistence.EntityFramework.Models;
+using WorkflowCore.Persistence.EntityFramework.Services;
+
+namespace WorkflowCore.Persistence.MySQL
+{
+    public class MysqlContext : WorkflowDbContext
+    {
+        private readonly string _connectionString;
+        private readonly Action<MySqlDbContextOptionsBuilder> _mysqlOptionsAction;
+
+        public MysqlContext(string connectionString, Action<MySqlDbContextOptionsBuilder> mysqlOptionsAction = null)
+            : base()
+        {
+            _connectionString = connectionString;
+            _mysqlOptionsAction = mysqlOptionsAction;
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            base.OnConfiguring(optionsBuilder);
+            optionsBuilder.UseMySql(_connectionString, _mysqlOptionsAction);
+        }
+
+        protected override void ConfigureSubscriptionStorage(EntityTypeBuilder<PersistedSubscription> builder)
+        {
+            builder.ToTable("Subscription");
+            builder.Property(x => x.PersistenceId).ValueGeneratedOnAdd();
+        }
+
+        protected override void ConfigureWorkflowStorage(EntityTypeBuilder<PersistedWorkflow> builder)
+        {
+            builder.ToTable("Workflow");
+            builder.Property(x => x.PersistenceId).ValueGeneratedOnAdd();
+        }
+
+        protected override void ConfigureExecutionPointerStorage(EntityTypeBuilder<PersistedExecutionPointer> builder)
+        {
+            builder.ToTable("ExecutionPointer");
+            builder.Property(x => x.PersistenceId).ValueGeneratedOnAdd();
+        }
+
+        protected override void ConfigureExecutionErrorStorage(EntityTypeBuilder<PersistedExecutionError> builder)
+        {
+            builder.ToTable("ExecutionError");
+            builder.Property(x => x.PersistenceId).ValueGeneratedOnAdd();
+        }
+
+        protected override void ConfigureExetensionAttributeStorage(EntityTypeBuilder<PersistedExtensionAttribute> builder)
+        {
+            builder.ToTable("ExtensionAttribute");
+            builder.Property(x => x.PersistenceId).ValueGeneratedOnAdd();
+        }
+
+        protected override void ConfigureEventStorage(EntityTypeBuilder<PersistedEvent> builder)
+        {
+            builder.ToTable("Event");
+            builder.Property(x => x.PersistenceId).ValueGeneratedOnAdd();
+        }
+    }
+}

--- a/src/providers/WorkflowCore.Persistence.MySQL/MysqlContext.cs
+++ b/src/providers/WorkflowCore.Persistence.MySQL/MysqlContext.cs
@@ -13,7 +13,6 @@ namespace WorkflowCore.Persistence.MySQL
         private readonly Action<MySqlDbContextOptionsBuilder> _mysqlOptionsAction;
 
         public MysqlContext(string connectionString, Action<MySqlDbContextOptionsBuilder> mysqlOptionsAction = null)
-            : base()
         {
             _connectionString = connectionString;
             _mysqlOptionsAction = mysqlOptionsAction;

--- a/src/providers/WorkflowCore.Persistence.MySQL/MysqlContextFactory.cs
+++ b/src/providers/WorkflowCore.Persistence.MySQL/MysqlContextFactory.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+using System;
+using WorkflowCore.Persistence.EntityFramework.Interfaces;
+using WorkflowCore.Persistence.EntityFramework.Services;
+
+namespace WorkflowCore.Persistence.MySQL
+{
+    public class MysqlContextFactory : IWorkflowDbContextFactory
+    {
+        private readonly string _connectionString;
+        private readonly Action<MySqlDbContextOptionsBuilder> _mysqlOptionsAction;
+
+        public MysqlContextFactory(string connectionString, Action<MySqlDbContextOptionsBuilder> mysqlOptionsAction = null)
+        {
+            _connectionString = connectionString;
+            _mysqlOptionsAction = mysqlOptionsAction;
+        }
+
+        public WorkflowDbContext Build()
+        {
+            return new MysqlContext(_connectionString, _mysqlOptionsAction);
+        }
+    }
+}

--- a/src/providers/WorkflowCore.Persistence.MySQL/README.md
+++ b/src/providers/WorkflowCore.Persistence.MySQL/README.md
@@ -1,0 +1,19 @@
+﻿# MySQL Persistence provider for Workflow Core
+
+Provides support to persist workflows running on [Workflow Core](../../README.md) to a MySQL database.
+
+## Installing
+
+Install the NuGet package "WorkflowCore.Persistence.MySQL"
+
+```
+PM> Install-Package WorkflowCore.Persistence.MySQL -Pre
+```
+
+## Usage
+
+Use the .UseMySQL extension method when building your service provider.
+
+```C#
+services.AddWorkflow(x => x.UseMySQL(@"Server=127.0.0.1;Database=workflow;User=root;Password=password;", true));
+```

--- a/src/providers/WorkflowCore.Persistence.MySQL/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.MySQL/ServiceCollectionExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using WorkflowCore.Models;
+using WorkflowCore.Persistence.EntityFramework.Services;
+using WorkflowCore.Persistence.MySQL;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static WorkflowOptions UseMySQL(this WorkflowOptions options, string connectionString, bool canCreateDB, Action<MySqlDbContextOptionsBuilder> mysqlOptionsAction = null)
+        {
+            options.UsePersistence(sp => new EntityFrameworkPersistenceProvider(new MysqlContextFactory(connectionString, mysqlOptionsAction), canCreateDB, false));
+            return options;
+        }
+    }
+}

--- a/src/providers/WorkflowCore.Persistence.MySQL/WorkflowCore.Persistence.MySQL.csproj
+++ b/src/providers/WorkflowCore.Persistence.MySQL/WorkflowCore.Persistence.MySQL.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\WorkflowCore\WorkflowCore.csproj" />
+    <ProjectReference Include="..\WorkflowCore.Persistence.EntityFramework\WorkflowCore.Persistence.EntityFramework.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/WorkflowCore.Tests.MySQL/DockerSetup.cs
+++ b/test/WorkflowCore.Tests.MySQL/DockerSetup.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using Docker.Testify;
+using Xunit;
+using MySql.Data.MySqlClient;
+using System;
+
+namespace WorkflowCore.Tests.MySQL
+{
+    public class MysqlDockerSetup : DockerSetup
+    {
+        public static string ConnectionString { get; set; }
+        public static string ScenarioConnectionString { get; set; }
+        public static string RootPassword => "rootpwd123";
+
+        public override string ImageTag => "5.7.24";
+        public override string ImageName => "mysql";
+        public override IList<string> EnvironmentVariables => new List<string> {
+            $"MYSQL_ROOT_PASSWORD={RootPassword}"
+        };
+
+        public override int InternalPort => 3306;
+
+        public override void PublishConnectionInfo()
+        {
+            ConnectionString = $"Server=127.0.0.1;Port={ExternalPort};Database=workflow;User=root;Password={RootPassword};";
+            ScenarioConnectionString = $"Server=127.0.0.1;Port={ExternalPort};Database=scenarios;User=root;Password={RootPassword};";
+        }
+
+        public override bool TestReady()
+        {
+            try
+            {
+                var connection = new MySqlConnection($"host=127.0.0.1;port={ExternalPort};user=root;password={RootPassword};database=mysql;");
+                connection.Open();
+                connection.Close();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+
+        }
+    }
+
+    [CollectionDefinition("Mysql collection")]
+    public class MysqlCollection : ICollectionFixture<MysqlDockerSetup>
+    {
+    }
+
+}

--- a/test/WorkflowCore.Tests.MySQL/MysqlPersistenceProviderFixture.cs
+++ b/test/WorkflowCore.Tests.MySQL/MysqlPersistenceProviderFixture.cs
@@ -1,0 +1,23 @@
+﻿using WorkflowCore.Interface;
+using WorkflowCore.Persistence.EntityFramework.Services;
+using WorkflowCore.Persistence.MySQL;
+using WorkflowCore.UnitTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace WorkflowCore.Tests.MySQL
+{
+    [Collection("Mysql collection")]
+    public class MysqlPersistenceProviderFixture : BasePersistenceFixture
+    {
+        private readonly IPersistenceProvider _subject;
+        protected override IPersistenceProvider Subject => _subject;
+
+        public MysqlPersistenceProviderFixture(MysqlDockerSetup dockerSetup, ITestOutputHelper output)
+        {
+            output.WriteLine($"Connecting on {MysqlDockerSetup.ConnectionString}");
+            _subject = new EntityFrameworkPersistenceProvider(new MysqlContextFactory(MysqlDockerSetup.ConnectionString), true, false);
+            _subject.EnsureStoreExists();
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlBasicScenario.cs
+++ b/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlBasicScenario.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using Xunit;
+
+namespace WorkflowCore.Tests.MySQL.Scenarios
+{
+    [Collection("Mysql collection")]
+    public class MysqlBasicScenario : BasicScenario
+    {
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseMySQL(MysqlDockerSetup.ScenarioConnectionString, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlDataScenario.cs
+++ b/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlDataScenario.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using Xunit;
+
+namespace WorkflowCore.Tests.MySQL.Scenarios
+{
+    [Collection("Mysql collection")]
+    public class MysqlDataScenario : DataIOScenario
+    {
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseMySQL(MysqlDockerSetup.ScenarioConnectionString, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlDynamicDataScenario.cs
+++ b/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlDynamicDataScenario.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using WorkflowCore.Tests.MySQL;
+using Xunit;
+
+namespace WorkflowCore.Tests.MySQL.Scenarios
+{
+    [Collection("Mysql collection")]
+    public class MysqlDynamicDataScenario : DynamicDataIOScenario
+    {
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseMySQL(MysqlDockerSetup.ScenarioConnectionString, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlEventScenario.cs
+++ b/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlEventScenario.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using WorkflowCore.Tests.MySQL;
+using Xunit;
+
+namespace WorkflowCore.Tests.MySQL.Scenarios
+{
+    [Collection("Mysql collection")]
+    public class MysqlEventScenario : EventScenario
+    {        
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseMySQL(MysqlDockerSetup.ScenarioConnectionString, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlForeachScenario.cs
+++ b/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlForeachScenario.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using WorkflowCore.Tests.MySQL;
+using Xunit;
+
+namespace WorkflowCore.Tests.MySQL.Scenarios
+{
+    [Collection("Mysql collection")]
+    public class MysqlForeachScenario : ForeachScenario
+    {        
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseMySQL(MysqlDockerSetup.ScenarioConnectionString, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlForkScenario.cs
+++ b/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlForkScenario.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using WorkflowCore.Tests.MySQL;
+using Xunit;
+
+namespace WorkflowCore.Tests.MySQL.Scenarios
+{
+    [Collection("Mysql collection")]
+    public class MysqlForkScenario : ForkScenario
+    {        
+        protected override void Configure(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseMySQL(MysqlDockerSetup.ScenarioConnectionString, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlIfScenario.cs
+++ b/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlIfScenario.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using WorkflowCore.Tests.MySQL;
+using Xunit;
+
+namespace WorkflowCore.Tests.MySQL.Scenarios
+{
+    [Collection("Mysql collection")]
+    public class MysqlIfScenario : IfScenario
+    {        
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseMySQL(MysqlDockerSetup.ScenarioConnectionString, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlRetrySagaScenario.cs
+++ b/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlRetrySagaScenario.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using WorkflowCore.Tests.MySQL;
+using Xunit;
+
+namespace WorkflowCore.Tests.MySQL.Scenarios
+{
+    [Collection("Mysql collection")]
+    public class MysqlRetrySagaScenario : RetrySagaScenario
+    {        
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseMySQL(MysqlDockerSetup.ScenarioConnectionString, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlSagaScenario.cs
+++ b/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlSagaScenario.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using WorkflowCore.Tests.MySQL;
+using Xunit;
+
+namespace WorkflowCore.Tests.MySQL.Scenarios
+{
+    [Collection("Mysql collection")]
+    public class MysqlSagaScenario : SagaScenario
+    {        
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseMySQL(MysqlDockerSetup.ScenarioConnectionString, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlUserScenario.cs
+++ b/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlUserScenario.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using WorkflowCore.Tests.MySQL;
+using Xunit;
+
+namespace WorkflowCore.Tests.MySQL.Scenarios
+{
+    [Collection("Mysql collection")]
+    public class MysqlUserScenario : UserScenario
+    {        
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseMySQL(MysqlDockerSetup.ScenarioConnectionString, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlWhenScenario.cs
+++ b/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlWhenScenario.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using WorkflowCore.Tests.MySQL;
+using Xunit;
+
+namespace WorkflowCore.Tests.MySQL.Scenarios
+{
+    [Collection("Mysql collection")]
+    public class MysqlWhenScenario : WhenScenario
+    {        
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseMySQL(MysqlDockerSetup.ScenarioConnectionString, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlWhileScenario.cs
+++ b/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlWhileScenario.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using WorkflowCore.Tests.MySQL;
+using Xunit;
+
+namespace WorkflowCore.Tests.MySQL.Scenarios
+{
+    [Collection("Mysql collection")]
+    public class MysqlWhileScenario : WhileScenario
+    {        
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseMySQL(MysqlDockerSetup.ScenarioConnectionString, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.MySQL/WorkflowCore.Tests.MySQL.csproj
+++ b/test/WorkflowCore.Tests.MySQL/WorkflowCore.Tests.MySQL.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\providers\WorkflowCore.Persistence.MySQL\WorkflowCore.Persistence.MySQL.csproj" />
+    <ProjectReference Include="..\..\src\WorkflowCore\WorkflowCore.csproj" />
+    <ProjectReference Include="..\Docker.Testify\Docker.Testify.csproj" />
+    <ProjectReference Include="..\WorkflowCore.IntegrationTests\WorkflowCore.IntegrationTests.csproj" />
+    <ProjectReference Include="..\WorkflowCore.TestAssets\WorkflowCore.TestAssets.csproj" />
+    <ProjectReference Include="..\WorkflowCore.Testing\WorkflowCore.Testing.csproj" />
+    <ProjectReference Include="..\WorkflowCore.UnitTests\WorkflowCore.UnitTests.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
(This pull request created again because of last one was in wrong branch.)
Hi,

First of all thanks for developing such a good library. I created the MySQL Persistence Provider, but first i want to point out some things:

  1. This provider based on Pomelo.EntityFrameworkCore.MySql v2.0.1, only 2.0.1 version can fit in this project.
   2. I didn't add migration feature, that's because of a critical migration bug in 2.0.1 version of Pomelo's MySql Provider. PomeloFoundation/Pomelo.EntityFrameworkCore.MySql#393
   3. Oracle's EF Core MySQL Provider (MySql.Data.EntityFrameworkCore 6.10.7 ) couldn't be option here, it doesn't support Guid Columns feature and there is no way to make it support that feature, it's based on NET Standard v2.x but it can't be run on .NET Framework 4.6.x either.

Q: How can we support MySQL Provider with Migration feature ?
A: It's not easy neither nor hard, if we update the dependency Microsoft.EntityFrameworkCore to 2.1.x from 2.0.1 it will be solved.

Have a good day.