### PR TITLE
 Fixed bug with Convert.ChangeType being called on object type.

### DIFF
--- a/src/WorkflowCore/Services/WorkflowExecutor.cs
+++ b/src/WorkflowCore/Services/WorkflowExecutor.cs
@@ -183,7 +183,15 @@ namespace WorkflowCore.Services
                 var resolvedValue = output.Source.Compile().DynamicInvoke(body);
                 var data = workflow.Data;
                 var setter = ExpressionHelpers.CreateSetter(output.Target);
-                var convertedValue = Convert.ChangeType(resolvedValue, setter.Parameters.Last().Type);
+                var targetType = setter.Parameters.Last().Type;
+
+                var convertedValue = resolvedValue;
+                // We need to make sure the resolvedValue is of the correct type.
+                // However if the targetType is object we don't need to do anything and in some cases Convert.ChangeType will throw.
+                if (targetType != typeof(object))
+                {
+                    convertedValue = Convert.ChangeType(resolvedValue, targetType);
+                }
 
                 if (setter.Parameters.Count == 2)
                 {

--- a/test/WorkflowCore.UnitTests/WorkflowCore.UnitTests.csproj
+++ b/test/WorkflowCore.UnitTests/WorkflowCore.UnitTests.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="4.3.0" />
+    <PackageReference Include="FakeItEasy" Version="4.9.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />


### PR DESCRIPTION
This fixes the problem that calling for example:
`Convert.ChangeType(new DataClass(), typeof(object))` throws, even though the conversion should be trivial.
We avoid the problem by just not calling Convert.ChangeType for target Type object.
