### PR TITLE
Workflow life cycle events

### DIFF
--- a/ReleaseNotes/1.6.9.md
+++ b/ReleaseNotes/1.6.9.md
@@ -1,0 +1,5 @@
+# Workflow Core 1.6.9
+
+This release adds functionality to subscribe to workflow life cycle events (WorkflowStarted, WorkflowComplete, WorkflowError, WorkflowSuspended, WorkflowResumed, StepStarted, StepCompleted, etc...)
+This can be achieved by either grabbing the `ILifeCycleEventHub` implementation from the IoC container and subscribing to events there, or attach an event on the workflow host class `IWorkflowHost.OnLifeCycleEvent`.
+This implementation only publishes events to the local node... we will still need to implement a distributed version of the EventHub to solve the problem for multi-node clusters.

--- a/WorkflowCore.sln
+++ b/WorkflowCore.sln
@@ -93,6 +93,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ReleaseNotes", "ReleaseNote
 		ReleaseNotes\1.6.0.md = ReleaseNotes\1.6.0.md
 		ReleaseNotes\1.6.6.md = ReleaseNotes\1.6.6.md
 		ReleaseNotes\1.6.8.md = ReleaseNotes\1.6.8.md
+		ReleaseNotes\1.6.9.md = ReleaseNotes\1.6.9.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Sample14", "src\samples\WorkflowCore.Sample14\WorkflowCore.Sample14.csproj", "{6BC66637-B42A-4334-ADFB-DBEC9F29D293}"
@@ -113,7 +114,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Sample17", "sr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.QueueProviders.SqlServer", "src\providers\WorkflowCore.QueueProviders.SqlServer\WorkflowCore.QueueProviders.SqlServer.csproj", "{7EDD9353-F5C2-414C-AE51-4B0F1C5E105A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkflowCore.Providers.AWS", "src\providers\WorkflowCore.Providers.AWS\WorkflowCore.Providers.AWS.csproj", "{5E82A137-0954-46A1-8C46-13C00F0E4842}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Providers.AWS", "src\providers\WorkflowCore.Providers.AWS\WorkflowCore.Providers.AWS.csproj", "{5E82A137-0954-46A1-8C46-13C00F0E4842}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/WorkflowCore/Interface/IExecutionResultProcessor.cs
+++ b/src/WorkflowCore/Interface/IExecutionResultProcessor.cs
@@ -5,7 +5,7 @@ namespace WorkflowCore.Interface
 {
     public interface IExecutionResultProcessor
     {
-        void HandleStepException(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer pointer, WorkflowStep step);
+        void HandleStepException(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer pointer, WorkflowStep step, Exception exception);
         void ProcessExecutionResult(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer pointer, WorkflowStep step, ExecutionResult result, WorkflowExecutorResult workflowResult);
     }
 }

--- a/src/WorkflowCore/Interface/ILifeCycleEventHub.cs
+++ b/src/WorkflowCore/Interface/ILifeCycleEventHub.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using WorkflowCore.Models.LifeCycleEvents;
+
+namespace WorkflowCore.Interface
+{
+    public interface ILifeCycleEventHub
+    {
+        Task PublishNotification(LifeCycleEvent evt);
+        void Subscribe(Action<LifeCycleEvent> action);
+    }
+}

--- a/src/WorkflowCore/Interface/ILifeCycleEventPublisher.cs
+++ b/src/WorkflowCore/Interface/ILifeCycleEventPublisher.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using WorkflowCore.Models.LifeCycleEvents;
+
+namespace WorkflowCore.Interface
+{
+    public interface ILifeCycleEventPublisher : IBackgroundTask
+    {
+        void PublishNotification(LifeCycleEvent evt);
+    }
+}

--- a/src/WorkflowCore/Interface/IWorkflowErrorHandler.cs
+++ b/src/WorkflowCore/Interface/IWorkflowErrorHandler.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using WorkflowCore.Models;
+
+namespace WorkflowCore.Interface
+{
+    public interface IWorkflowErrorHandler
+    {
+        WorkflowErrorHandling Type { get; }
+        void Handle(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer pointer, WorkflowStep step, Exception exception, Queue<ExecutionPointer> bubbleUpQueue);
+    }
+}

--- a/src/WorkflowCore/Interface/IWorkflowHost.cs
+++ b/src/WorkflowCore/Interface/IWorkflowHost.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading.Tasks;
 using WorkflowCore.Models;
+using WorkflowCore.Models.LifeCycleEvents;
 
 namespace WorkflowCore.Interface
 {
@@ -19,6 +20,7 @@ namespace WorkflowCore.Interface
         
         
         event StepErrorEventHandler OnStepError;
+        event LifeCycleEventHandler OnLifeCycleEvent;
         void ReportStepError(WorkflowInstance workflow, WorkflowStep step, Exception exception);
 
         //public dependencies to allow for extension method access
@@ -32,4 +34,5 @@ namespace WorkflowCore.Interface
     }
 
     public delegate void StepErrorEventHandler(WorkflowInstance workflow, WorkflowStep step, Exception exception);
+    public delegate void LifeCycleEventHandler(LifeCycleEvent evt);
 }

--- a/src/WorkflowCore/Models/LifeCycleEvents/LifeCycleEvent.cs
+++ b/src/WorkflowCore/Models/LifeCycleEvents/LifeCycleEvent.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WorkflowCore.Models.LifeCycleEvents
+{
+    public abstract class LifeCycleEvent
+    {
+        public DateTime EventTimeUtc { get; set; }
+
+        public string WorkflowInsanceId { get; set; }
+
+        public string WorkflowDefinitionId { get; set; }
+
+        public int Version { get; set; }
+
+        public string Reference { get; set; }
+    }
+}

--- a/src/WorkflowCore/Models/LifeCycleEvents/StepCompleted.cs
+++ b/src/WorkflowCore/Models/LifeCycleEvents/StepCompleted.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WorkflowCore.Models.LifeCycleEvents
+{
+    public class StepCompleted : LifeCycleEvent
+    {
+        public string ExecutionPointerId { get; set; }
+
+        public int StepId { get; set; }
+    }
+}

--- a/src/WorkflowCore/Models/LifeCycleEvents/StepStarted.cs
+++ b/src/WorkflowCore/Models/LifeCycleEvents/StepStarted.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WorkflowCore.Models.LifeCycleEvents
+{
+    public class StepStarted : LifeCycleEvent
+    {
+        public string ExecutionPointerId { get; set; }
+
+        public int StepId { get; set; }
+    }
+}

--- a/src/WorkflowCore/Models/LifeCycleEvents/WorkflowCompleted.cs
+++ b/src/WorkflowCore/Models/LifeCycleEvents/WorkflowCompleted.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WorkflowCore.Models.LifeCycleEvents
+{
+    public class WorkflowCompleted : LifeCycleEvent
+    {
+    }
+}

--- a/src/WorkflowCore/Models/LifeCycleEvents/WorkflowError.cs
+++ b/src/WorkflowCore/Models/LifeCycleEvents/WorkflowError.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WorkflowCore.Models.LifeCycleEvents
+{
+    public class WorkflowError : LifeCycleEvent
+    {
+        public string Message { get; set; }
+
+        public string ExecutionPointerId { get; set; }
+
+        public int StepId { get; set; }
+    }
+}

--- a/src/WorkflowCore/Models/LifeCycleEvents/WorkflowResumed.cs
+++ b/src/WorkflowCore/Models/LifeCycleEvents/WorkflowResumed.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WorkflowCore.Models.LifeCycleEvents
+{
+    public class WorkflowResumed : LifeCycleEvent
+    {
+    }
+}

--- a/src/WorkflowCore/Models/LifeCycleEvents/WorkflowStarted.cs
+++ b/src/WorkflowCore/Models/LifeCycleEvents/WorkflowStarted.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WorkflowCore.Models.LifeCycleEvents
+{
+    public class WorkflowStarted : LifeCycleEvent
+    {
+    }
+}

--- a/src/WorkflowCore/Models/LifeCycleEvents/WorkflowSuspended.cs
+++ b/src/WorkflowCore/Models/LifeCycleEvents/WorkflowSuspended.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WorkflowCore.Models.LifeCycleEvents
+{
+    public class WorkflowSuspended : LifeCycleEvent
+    {
+    }
+}

--- a/src/WorkflowCore/Models/LifeCycleEvents/WorkflowTerminated.cs
+++ b/src/WorkflowCore/Models/LifeCycleEvents/WorkflowTerminated.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WorkflowCore.Models.LifeCycleEvents
+{
+    public class WorkflowTerminated : LifeCycleEvent
+    {
+    }
+}

--- a/src/WorkflowCore/Models/WorkflowOptions.cs
+++ b/src/WorkflowCore/Models/WorkflowOptions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
+using Microsoft.Extensions.Logging;
 using WorkflowCore.Interface;
 using WorkflowCore.Services;
 
@@ -10,6 +11,7 @@ namespace WorkflowCore.Models
         internal Func<IServiceProvider, IPersistenceProvider> PersistanceFactory;
         internal Func<IServiceProvider, IQueueProvider> QueueFactory;
         internal Func<IServiceProvider, IDistributedLockProvider> LockFactory;
+        internal Func<IServiceProvider, ILifeCycleEventHub> EventHubFactory;
         internal TimeSpan PollInterval;
         internal TimeSpan IdleTime;
         internal TimeSpan ErrorRetryInterval;
@@ -26,6 +28,7 @@ namespace WorkflowCore.Models
             QueueFactory = new Func<IServiceProvider, IQueueProvider>(sp => new SingleNodeQueueProvider());
             LockFactory = new Func<IServiceProvider, IDistributedLockProvider>(sp => new SingleNodeLockProvider());
             PersistanceFactory = new Func<IServiceProvider, IPersistenceProvider>(sp => new MemoryPersistenceProvider());
+            EventHubFactory = new Func<IServiceProvider, ILifeCycleEventHub>(sp => new SingleNodeEventHub(sp.GetService<ILoggerFactory>()));
         }
 
         public void UsePersistence(Func<IServiceProvider, IPersistenceProvider> factory)
@@ -41,6 +44,11 @@ namespace WorkflowCore.Models
         public void UseQueueProvider(Func<IServiceProvider, IQueueProvider> factory)
         {
             QueueFactory = factory;
+        }
+
+        public void UseEventHub(Func<IServiceProvider, ILifeCycleEventHub> factory)
+        {
+            EventHubFactory = factory;
         }
 
         public void UsePollInterval(TimeSpan interval)

--- a/src/WorkflowCore/ServiceCollectionExtensions.cs
+++ b/src/WorkflowCore/ServiceCollectionExtensions.cs
@@ -30,10 +30,12 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ILifeCycleEventHub>(options.EventHubFactory);
             services.AddSingleton<IWorkflowRegistry, WorkflowRegistry>();
             services.AddSingleton<WorkflowOptions>(options);
+            services.AddSingleton<ILifeCycleEventPublisher, LifeCycleEventPublisher>();
 
             services.AddTransient<IBackgroundTask, WorkflowConsumer>();
             services.AddTransient<IBackgroundTask, EventConsumer>();
             services.AddTransient<IBackgroundTask, RunnablePoller>();
+            services.AddTransient<IBackgroundTask>(sp => sp.GetService<ILifeCycleEventPublisher>());
 
             services.AddTransient<IWorkflowErrorHandler, CompensateHandler>();
             services.AddTransient<IWorkflowErrorHandler, RetryHandler>();

--- a/src/WorkflowCore/ServiceCollectionExtensions.cs
+++ b/src/WorkflowCore/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.ObjectPool;
 using WorkflowCore.Primitives;
 using WorkflowCore.Services.BackgroundTasks;
 using WorkflowCore.Services.DefinitionStorage;
+using WorkflowCore.Services.ErrorHandlers;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -26,12 +27,18 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddTransient<IPersistenceProvider>(options.PersistanceFactory);
             services.AddSingleton<IQueueProvider>(options.QueueFactory);
             services.AddSingleton<IDistributedLockProvider>(options.LockFactory);
+            services.AddSingleton<ILifeCycleEventHub>(options.EventHubFactory);
             services.AddSingleton<IWorkflowRegistry, WorkflowRegistry>();
             services.AddSingleton<WorkflowOptions>(options);
 
             services.AddTransient<IBackgroundTask, WorkflowConsumer>();
             services.AddTransient<IBackgroundTask, EventConsumer>();
             services.AddTransient<IBackgroundTask, RunnablePoller>();
+
+            services.AddTransient<IWorkflowErrorHandler, CompensateHandler>();
+            services.AddTransient<IWorkflowErrorHandler, RetryHandler>();
+            services.AddTransient<IWorkflowErrorHandler, TerminateHandler>();
+            services.AddTransient<IWorkflowErrorHandler, SuspendHandler>();
 
             services.AddSingleton<IWorkflowController, WorkflowController>();
             services.AddSingleton<IWorkflowHost, WorkflowHost>();

--- a/src/WorkflowCore/Services/DefaultProviders/SingleNodeEventHub.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/SingleNodeEventHub.cs
@@ -30,7 +30,7 @@ namespace WorkflowCore.Services
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogWarning(ex, $"Error on event subscriber: {ex.Message}");
+                        _logger.LogWarning(default(EventId), ex, $"Error on event subscriber: {ex.Message}");
                     }
                 }
             });

--- a/src/WorkflowCore/Services/DefaultProviders/SingleNodeEventHub.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/SingleNodeEventHub.cs
@@ -30,7 +30,7 @@ namespace WorkflowCore.Services
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogWarning($"Error on event subscriber: {ex.Message}");
+                        _logger.LogWarning(ex, $"Error on event subscriber: {ex.Message}");
                     }
                 }
             });

--- a/src/WorkflowCore/Services/DefaultProviders/SingleNodeEventHub.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/SingleNodeEventHub.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using WorkflowCore.Interface;
+using WorkflowCore.Models.LifeCycleEvents;
+
+namespace WorkflowCore.Services
+{
+    public class SingleNodeEventHub : ILifeCycleEventHub
+    {
+        private ICollection<Action<LifeCycleEvent>> _subscribers = new HashSet<Action<LifeCycleEvent>>();
+        private readonly ILogger _logger;
+
+        public SingleNodeEventHub(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<SingleNodeEventHub>();
+        }
+
+        public Task PublishNotification(LifeCycleEvent evt)
+        {
+            Task.Run(() =>
+            {
+                foreach (var subscriber in _subscribers)
+                {
+                    try
+                    {
+                        subscriber(evt);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning($"Error on event subscriber: {ex.Message}");
+                    }
+                }
+            });
+            return Task.CompletedTask;
+        }
+
+        public void Subscribe(Action<LifeCycleEvent> action)
+        {
+            _subscribers.Add(action);
+        }
+    }
+}

--- a/src/WorkflowCore/Services/ErrorHandlers/CompensateHandler.cs
+++ b/src/WorkflowCore/Services/ErrorHandlers/CompensateHandler.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using WorkflowCore.Models.LifeCycleEvents;
+
+namespace WorkflowCore.Services.ErrorHandlers
+{
+    public class CompensateHandler : IWorkflowErrorHandler
+    {
+        private readonly ILifeCycleEventHub _eventHub;
+        private readonly IExecutionPointerFactory _pointerFactory;
+        private readonly IDateTimeProvider _datetimeProvider;
+        private readonly WorkflowOptions _options;
+
+        public WorkflowErrorHandling Type => WorkflowErrorHandling.Compensate;
+
+        public CompensateHandler(IExecutionPointerFactory pointerFactory, ILifeCycleEventHub eventHub, IDateTimeProvider datetimeProvider, WorkflowOptions options)
+        {
+            _pointerFactory = pointerFactory;
+            _eventHub = eventHub;
+            _datetimeProvider = datetimeProvider;
+            _options = options;
+        }
+
+        public void Handle(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer exceptionPointer, WorkflowStep exceptionStep, Exception exception, Queue<ExecutionPointer> bubbleUpQueue)
+        {
+            var scope = new Stack<string>(exceptionPointer.Scope);
+            scope.Push(exceptionPointer.Id);
+
+            exceptionPointer.Active = false;
+            exceptionPointer.EndTime = _datetimeProvider.Now.ToUniversalTime();
+            exceptionPointer.Status = PointerStatus.Failed;
+
+            while (scope.Any())
+            {
+                var pointerId = scope.Pop();
+                var scopePointer = workflow.ExecutionPointers.First(x => x.Id == pointerId);
+                var scopeStep = def.Steps.First(x => x.Id == scopePointer.StepId);
+
+                var resume = true;
+                var revert = false;
+
+                if (scope.Any())
+                {
+                    var parentId = scope.Peek();
+                    var parentPointer = workflow.ExecutionPointers.First(x => x.Id == parentId);
+                    var parentStep = def.Steps.First(x => x.Id == parentPointer.StepId);
+                    resume = parentStep.ResumeChildrenAfterCompensation;
+                    revert = parentStep.RevertChildrenAfterCompensation;
+                }
+
+                if ((scopeStep.ErrorBehavior ?? WorkflowErrorHandling.Compensate) != WorkflowErrorHandling.Compensate)
+                {
+                    bubbleUpQueue.Enqueue(scopePointer);
+                    continue;
+                }
+
+                if (scopeStep.CompensationStepId.HasValue)
+                {
+                    scopePointer.Active = false;
+                    scopePointer.EndTime = _datetimeProvider.Now.ToUniversalTime();
+                    scopePointer.Status = PointerStatus.Compensated;
+
+                    var compensationPointer = _pointerFactory.BuildCompensationPointer(def, scopePointer, exceptionPointer, scopeStep.CompensationStepId.Value);
+                    workflow.ExecutionPointers.Add(compensationPointer);
+
+                    if (resume)
+                    {
+                        foreach (var outcomeTarget in scopeStep.Outcomes.Where(x => x.GetValue(workflow.Data) == null))
+                            workflow.ExecutionPointers.Add(_pointerFactory.BuildNextPointer(def, scopePointer, outcomeTarget));
+                    }
+                }
+
+                if (revert)
+                {
+                    var prevSiblings = workflow.ExecutionPointers
+                        .Where(x => scopePointer.Scope.SequenceEqual(x.Scope) && x.Id != scopePointer.Id && x.Status == PointerStatus.Complete)
+                        .OrderByDescending(x => x.EndTime)
+                        .ToList();
+
+                    foreach (var siblingPointer in prevSiblings)
+                    {
+                        var siblingStep = def.Steps.First(x => x.Id == siblingPointer.StepId);
+                        if (siblingStep.CompensationStepId.HasValue)
+                        {
+                            var compensationPointer = _pointerFactory.BuildCompensationPointer(def, siblingPointer, exceptionPointer, siblingStep.CompensationStepId.Value);
+                            workflow.ExecutionPointers.Add(compensationPointer);
+                            siblingPointer.Status = PointerStatus.Compensated;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/WorkflowCore/Services/ErrorHandlers/CompensateHandler.cs
+++ b/src/WorkflowCore/Services/ErrorHandlers/CompensateHandler.cs
@@ -10,17 +10,17 @@ namespace WorkflowCore.Services.ErrorHandlers
 {
     public class CompensateHandler : IWorkflowErrorHandler
     {
-        private readonly ILifeCycleEventHub _eventHub;
+        private readonly ILifeCycleEventPublisher _eventPublisher;
         private readonly IExecutionPointerFactory _pointerFactory;
         private readonly IDateTimeProvider _datetimeProvider;
         private readonly WorkflowOptions _options;
 
         public WorkflowErrorHandling Type => WorkflowErrorHandling.Compensate;
 
-        public CompensateHandler(IExecutionPointerFactory pointerFactory, ILifeCycleEventHub eventHub, IDateTimeProvider datetimeProvider, WorkflowOptions options)
+        public CompensateHandler(IExecutionPointerFactory pointerFactory, ILifeCycleEventPublisher eventPublisher, IDateTimeProvider datetimeProvider, WorkflowOptions options)
         {
             _pointerFactory = pointerFactory;
-            _eventHub = eventHub;
+            _eventPublisher = eventPublisher;
             _datetimeProvider = datetimeProvider;
             _options = options;
         }

--- a/src/WorkflowCore/Services/ErrorHandlers/RetryHandler.cs
+++ b/src/WorkflowCore/Services/ErrorHandlers/RetryHandler.cs
@@ -9,14 +9,12 @@ namespace WorkflowCore.Services.ErrorHandlers
 {
     public class RetryHandler : IWorkflowErrorHandler
     {
-        private readonly ILifeCycleEventHub _eventHub;
         private readonly IDateTimeProvider _datetimeProvider;
         private readonly WorkflowOptions _options;
         public WorkflowErrorHandling Type => WorkflowErrorHandling.Retry;
 
-        public RetryHandler(ILifeCycleEventHub eventHub, IDateTimeProvider datetimeProvider, WorkflowOptions options)
+        public RetryHandler(IDateTimeProvider datetimeProvider, WorkflowOptions options)
         {
-            _eventHub = eventHub;
             _datetimeProvider = datetimeProvider;
             _options = options;
         }

--- a/src/WorkflowCore/Services/ErrorHandlers/RetryHandler.cs
+++ b/src/WorkflowCore/Services/ErrorHandlers/RetryHandler.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using WorkflowCore.Models.LifeCycleEvents;
+
+namespace WorkflowCore.Services.ErrorHandlers
+{
+    public class RetryHandler : IWorkflowErrorHandler
+    {
+        private readonly ILifeCycleEventHub _eventHub;
+        private readonly IDateTimeProvider _datetimeProvider;
+        private readonly WorkflowOptions _options;
+        public WorkflowErrorHandling Type => WorkflowErrorHandling.Retry;
+
+        public RetryHandler(ILifeCycleEventHub eventHub, IDateTimeProvider datetimeProvider, WorkflowOptions options)
+        {
+            _eventHub = eventHub;
+            _datetimeProvider = datetimeProvider;
+            _options = options;
+        }
+
+        public void Handle(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer pointer, WorkflowStep step, Exception exception, Queue<ExecutionPointer> bubbleUpQueue)
+        {
+            pointer.RetryCount++;
+            pointer.SleepUntil = _datetimeProvider.Now.ToUniversalTime().Add(step.RetryInterval ?? def.DefaultErrorRetryInterval ?? _options.ErrorRetryInterval);
+            step.PrimeForRetry(pointer);
+        }
+    }
+}

--- a/src/WorkflowCore/Services/ErrorHandlers/SuspendHandler.cs
+++ b/src/WorkflowCore/Services/ErrorHandlers/SuspendHandler.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using WorkflowCore.Models.LifeCycleEvents;
+
+namespace WorkflowCore.Services.ErrorHandlers
+{
+    public class SuspendHandler : IWorkflowErrorHandler
+    {
+        private readonly ILifeCycleEventHub _eventHub;
+        private readonly IDateTimeProvider _datetimeProvider;
+        public WorkflowErrorHandling Type => WorkflowErrorHandling.Suspend;
+
+        public SuspendHandler(ILifeCycleEventHub eventHub, IDateTimeProvider datetimeProvider)
+        {
+            _eventHub = eventHub;
+            _datetimeProvider = datetimeProvider;
+        }
+
+        public void Handle(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer pointer, WorkflowStep step, Exception exception, Queue<ExecutionPointer> bubbleUpQueue)
+        {
+            workflow.Status = WorkflowStatus.Suspended;
+            _eventHub.PublishNotification(new WorkflowSuspended()
+            {
+                EventTimeUtc = _datetimeProvider.Now,
+                Reference = workflow.Reference,
+                WorkflowInsanceId = workflow.Id,
+                WorkflowDefinitionId = workflow.WorkflowDefinitionId,
+                Version = workflow.Version
+            });
+        }
+    }
+}

--- a/src/WorkflowCore/Services/ErrorHandlers/SuspendHandler.cs
+++ b/src/WorkflowCore/Services/ErrorHandlers/SuspendHandler.cs
@@ -9,20 +9,20 @@ namespace WorkflowCore.Services.ErrorHandlers
 {
     public class SuspendHandler : IWorkflowErrorHandler
     {
-        private readonly ILifeCycleEventHub _eventHub;
+        private readonly ILifeCycleEventPublisher _eventPublisher;
         private readonly IDateTimeProvider _datetimeProvider;
         public WorkflowErrorHandling Type => WorkflowErrorHandling.Suspend;
 
-        public SuspendHandler(ILifeCycleEventHub eventHub, IDateTimeProvider datetimeProvider)
+        public SuspendHandler(ILifeCycleEventPublisher eventPublisher, IDateTimeProvider datetimeProvider)
         {
-            _eventHub = eventHub;
+            _eventPublisher = eventPublisher;
             _datetimeProvider = datetimeProvider;
         }
 
         public void Handle(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer pointer, WorkflowStep step, Exception exception, Queue<ExecutionPointer> bubbleUpQueue)
         {
             workflow.Status = WorkflowStatus.Suspended;
-            _eventHub.PublishNotification(new WorkflowSuspended()
+            _eventPublisher.PublishNotification(new WorkflowSuspended()
             {
                 EventTimeUtc = _datetimeProvider.Now,
                 Reference = workflow.Reference,

--- a/src/WorkflowCore/Services/ErrorHandlers/TerminateHandler.cs
+++ b/src/WorkflowCore/Services/ErrorHandlers/TerminateHandler.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using WorkflowCore.Models.LifeCycleEvents;
+
+namespace WorkflowCore.Services.ErrorHandlers
+{
+    public class TerminateHandler : IWorkflowErrorHandler
+    {
+        private readonly ILifeCycleEventHub _eventHub;
+        private readonly IDateTimeProvider _datetimeProvider;
+        public WorkflowErrorHandling Type => WorkflowErrorHandling.Terminate;
+
+        public TerminateHandler(ILifeCycleEventHub eventHub, IDateTimeProvider datetimeProvider)
+        {
+            _eventHub = eventHub;
+            _datetimeProvider = datetimeProvider;
+        }
+
+        public void Handle(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer pointer, WorkflowStep step, Exception exception, Queue<ExecutionPointer> bubbleUpQueue)
+        {
+            workflow.Status = WorkflowStatus.Terminated;
+            _eventHub.PublishNotification(new WorkflowTerminated()
+            {
+                EventTimeUtc = _datetimeProvider.Now,
+                Reference = workflow.Reference,
+                WorkflowInsanceId = workflow.Id,
+                WorkflowDefinitionId = workflow.WorkflowDefinitionId,
+                Version = workflow.Version
+            });
+        }
+    }
+}

--- a/src/WorkflowCore/Services/ErrorHandlers/TerminateHandler.cs
+++ b/src/WorkflowCore/Services/ErrorHandlers/TerminateHandler.cs
@@ -9,20 +9,20 @@ namespace WorkflowCore.Services.ErrorHandlers
 {
     public class TerminateHandler : IWorkflowErrorHandler
     {
-        private readonly ILifeCycleEventHub _eventHub;
+        private readonly ILifeCycleEventPublisher _eventPublisher;
         private readonly IDateTimeProvider _datetimeProvider;
         public WorkflowErrorHandling Type => WorkflowErrorHandling.Terminate;
 
-        public TerminateHandler(ILifeCycleEventHub eventHub, IDateTimeProvider datetimeProvider)
+        public TerminateHandler(ILifeCycleEventPublisher eventPublisher, IDateTimeProvider datetimeProvider)
         {
-            _eventHub = eventHub;
+            _eventPublisher = eventPublisher;
             _datetimeProvider = datetimeProvider;
         }
 
         public void Handle(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer pointer, WorkflowStep step, Exception exception, Queue<ExecutionPointer> bubbleUpQueue)
         {
             workflow.Status = WorkflowStatus.Terminated;
-            _eventHub.PublishNotification(new WorkflowTerminated()
+            _eventPublisher.PublishNotification(new WorkflowTerminated()
             {
                 EventTimeUtc = _datetimeProvider.Now,
                 Reference = workflow.Reference,

--- a/src/WorkflowCore/Services/ExecutionResultProcessor.cs
+++ b/src/WorkflowCore/Services/ExecutionResultProcessor.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.Extensions.Logging;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
+using WorkflowCore.Models.LifeCycleEvents;
 
 namespace WorkflowCore.Services
 {
@@ -12,12 +13,16 @@ namespace WorkflowCore.Services
         private readonly IExecutionPointerFactory _pointerFactory;
         private readonly IDateTimeProvider _datetimeProvider;
         private readonly ILogger _logger;
+        private readonly ILifeCycleEventHub _eventHub;
+        private readonly IEnumerable<IWorkflowErrorHandler> _errorHandlers;
         private readonly WorkflowOptions _options;
 
-        public ExecutionResultProcessor(IExecutionPointerFactory pointerFactory, IDateTimeProvider datetimeProvider, WorkflowOptions options, ILoggerFactory loggerFactory)
+        public ExecutionResultProcessor(IExecutionPointerFactory pointerFactory, IDateTimeProvider datetimeProvider, ILifeCycleEventHub eventHub, IEnumerable<IWorkflowErrorHandler> errorHandlers, WorkflowOptions options, ILoggerFactory loggerFactory)
         {
             _pointerFactory = pointerFactory;
             _datetimeProvider = datetimeProvider;
+            _eventHub = eventHub;
+            _errorHandlers = errorHandlers;
             _options = options;
             _logger = loggerFactory.CreateLogger<ExecutionResultProcessor>();
         }
@@ -72,105 +77,38 @@ namespace WorkflowCore.Services
             }
         }
 
-        public void HandleStepException(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer pointer, WorkflowStep step)
-        {            
-            pointer.Status = PointerStatus.Failed;            
-            var compensatingStepId = FindScopeCompensationStepId(workflow, def, pointer);
-            var errorOption = (step.ErrorBehavior ?? (compensatingStepId.HasValue ? WorkflowErrorHandling.Compensate : def.DefaultErrorBehavior));
-            SelectErrorStrategy(errorOption, workflow, def, pointer, step);
-        }
-
-        private void SelectErrorStrategy(WorkflowErrorHandling errorOption, WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer pointer, WorkflowStep step)
+        public void HandleStepException(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer pointer, WorkflowStep step, Exception exception)
         {
-            switch (errorOption)
+            _eventHub.PublishNotification(new WorkflowError()
             {
-                case WorkflowErrorHandling.Retry:
-                    pointer.RetryCount++;
-                    pointer.SleepUntil = _datetimeProvider.Now.ToUniversalTime().Add(step.RetryInterval ?? def.DefaultErrorRetryInterval ?? _options.ErrorRetryInterval);
-                    step.PrimeForRetry(pointer);
-                    break;
-                case WorkflowErrorHandling.Suspend:
-                    workflow.Status = WorkflowStatus.Suspended;
-                    break;
-                case WorkflowErrorHandling.Terminate:
-                    workflow.Status = WorkflowStatus.Terminated;
-                    break;
-                case WorkflowErrorHandling.Compensate:
-                    Compensate(workflow, def, pointer);
-                    break;
+                EventTimeUtc = _datetimeProvider.Now,
+                Reference = workflow.Reference,
+                WorkflowInsanceId = workflow.Id,
+                WorkflowDefinitionId = workflow.WorkflowDefinitionId,
+                Version = workflow.Version,
+                ExecutionPointerId = pointer.Id,
+                StepId = step.Id,
+                Message = exception.Message
+            });
+            pointer.Status = PointerStatus.Failed;
+            
+            var queue = new Queue<ExecutionPointer>();
+            queue.Enqueue(pointer);
+
+            while (queue.Count > 0)
+            {
+                var exceptionPointer = queue.Dequeue();
+                var exceptionStep = def.Steps.Find(x => x.Id == exceptionPointer.StepId);
+                var compensatingStepId = FindScopeCompensationStepId(workflow, def, exceptionPointer);
+                var errorOption = (exceptionStep.ErrorBehavior ?? (compensatingStepId.HasValue ? WorkflowErrorHandling.Compensate : def.DefaultErrorBehavior));
+
+                foreach (var handler in _errorHandlers.Where(x => x.Type == errorOption))
+                {
+                    handler.Handle(workflow, def, exceptionPointer, exceptionStep, exception, queue);
+                }
             }
         }
         
-        private void Compensate(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer exceptionPointer)
-        {            
-            var scope = new Stack<string>(exceptionPointer.Scope);
-            scope.Push(exceptionPointer.Id);
-
-            exceptionPointer.Active = false;
-            exceptionPointer.EndTime = _datetimeProvider.Now.ToUniversalTime();
-            exceptionPointer.Status = PointerStatus.Failed;
-
-            while (scope.Any())
-            {
-                var pointerId = scope.Pop();
-                var pointer = workflow.ExecutionPointers.First(x => x.Id == pointerId);
-                var step = def.Steps.First(x => x.Id == pointer.StepId);
-
-                var resume = true;
-                var revert = false;
-
-                if (scope.Any())
-                {
-                    var parentId = scope.Peek();
-                    var parentPointer = workflow.ExecutionPointers.First(x => x.Id == parentId);
-                    var parentStep = def.Steps.First(x => x.Id == parentPointer.StepId);
-                    resume = parentStep.ResumeChildrenAfterCompensation;
-                    revert = parentStep.RevertChildrenAfterCompensation;
-                }
-
-                if ((step.ErrorBehavior ?? WorkflowErrorHandling.Compensate) != WorkflowErrorHandling.Compensate)
-                {
-                    SelectErrorStrategy(step.ErrorBehavior ?? WorkflowErrorHandling.Retry, workflow, def, pointer, step);
-                    continue;
-                }
-
-                if (step.CompensationStepId.HasValue)
-                {
-                    pointer.Active = false;
-                    pointer.EndTime = _datetimeProvider.Now.ToUniversalTime();
-                    pointer.Status = PointerStatus.Compensated;
-
-                    var compensationPointer = _pointerFactory.BuildCompensationPointer(def, pointer, exceptionPointer, step.CompensationStepId.Value);
-                    workflow.ExecutionPointers.Add(compensationPointer);
-                    
-                    if (resume)
-                    {
-                        foreach (var outcomeTarget in step.Outcomes.Where(x => x.GetValue(workflow.Data) == null))
-                            workflow.ExecutionPointers.Add(_pointerFactory.BuildNextPointer(def, pointer, outcomeTarget));
-                    }
-                }
-
-                if (revert)
-                {
-                    var prevSiblings = workflow.ExecutionPointers
-                        .Where(x => pointer.Scope.SequenceEqual(x.Scope) && x.Id != pointer.Id && x.Status == PointerStatus.Complete)
-                        .OrderByDescending(x => x.EndTime)
-                        .ToList();
-
-                    foreach (var siblingPointer in prevSiblings)
-                    {
-                        var siblingStep = def.Steps.First(x => x.Id == siblingPointer.StepId);
-                        if (siblingStep.CompensationStepId.HasValue)
-                        {
-                            var compensationPointer = _pointerFactory.BuildCompensationPointer(def, siblingPointer, exceptionPointer, siblingStep.CompensationStepId.Value);
-                            workflow.ExecutionPointers.Add(compensationPointer);
-                            siblingPointer.Status = PointerStatus.Compensated;
-                        }
-                    }
-                }
-            }
-        }
-
         private int? FindScopeCompensationStepId(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer currentPointer)
         {
             var scope = new Stack<string>(currentPointer.Scope);

--- a/src/WorkflowCore/Services/ExecutionResultProcessor.cs
+++ b/src/WorkflowCore/Services/ExecutionResultProcessor.cs
@@ -64,6 +64,17 @@ namespace WorkflowCore.Services
                 {                    
                     workflow.ExecutionPointers.Add(_pointerFactory.BuildNextPointer(def, pointer, outcomeTarget));
                 }
+
+                _eventPublisher.PublishNotification(new StepCompleted()
+                {
+                    EventTimeUtc = _datetimeProvider.Now,
+                    Reference = workflow.Reference,
+                    ExecutionPointerId = pointer.Id,
+                    StepId = step.Id,
+                    WorkflowInsanceId = workflow.Id,
+                    WorkflowDefinitionId = workflow.WorkflowDefinitionId,
+                    Version = workflow.Version
+                });
             }
             else
             {

--- a/src/WorkflowCore/Services/ExecutionResultProcessor.cs
+++ b/src/WorkflowCore/Services/ExecutionResultProcessor.cs
@@ -13,15 +13,15 @@ namespace WorkflowCore.Services
         private readonly IExecutionPointerFactory _pointerFactory;
         private readonly IDateTimeProvider _datetimeProvider;
         private readonly ILogger _logger;
-        private readonly ILifeCycleEventHub _eventHub;
+        private readonly ILifeCycleEventPublisher _eventPublisher;
         private readonly IEnumerable<IWorkflowErrorHandler> _errorHandlers;
         private readonly WorkflowOptions _options;
 
-        public ExecutionResultProcessor(IExecutionPointerFactory pointerFactory, IDateTimeProvider datetimeProvider, ILifeCycleEventHub eventHub, IEnumerable<IWorkflowErrorHandler> errorHandlers, WorkflowOptions options, ILoggerFactory loggerFactory)
+        public ExecutionResultProcessor(IExecutionPointerFactory pointerFactory, IDateTimeProvider datetimeProvider, ILifeCycleEventPublisher eventPublisher, IEnumerable<IWorkflowErrorHandler> errorHandlers, WorkflowOptions options, ILoggerFactory loggerFactory)
         {
             _pointerFactory = pointerFactory;
             _datetimeProvider = datetimeProvider;
-            _eventHub = eventHub;
+            _eventPublisher = eventPublisher;
             _errorHandlers = errorHandlers;
             _options = options;
             _logger = loggerFactory.CreateLogger<ExecutionResultProcessor>();
@@ -79,7 +79,7 @@ namespace WorkflowCore.Services
 
         public void HandleStepException(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer pointer, WorkflowStep step, Exception exception)
         {
-            _eventHub.PublishNotification(new WorkflowError()
+            _eventPublisher.PublishNotification(new WorkflowError()
             {
                 EventTimeUtc = _datetimeProvider.Now,
                 Reference = workflow.Reference,

--- a/src/WorkflowCore/Services/LifeCycleEventPublisher.cs
+++ b/src/WorkflowCore/Services/LifeCycleEventPublisher.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using WorkflowCore.Interface;
+using WorkflowCore.Models.LifeCycleEvents;
+
+namespace WorkflowCore.Services
+{
+    public class LifeCycleEventPublisher : ILifeCycleEventPublisher
+    {
+        private readonly ILifeCycleEventHub _eventHub;
+        private readonly ILogger _logger;
+        private readonly ConcurrentQueue<LifeCycleEvent> _outbox;
+        protected Task DispatchTask;
+        private CancellationTokenSource _cancellationTokenSource;
+
+        public LifeCycleEventPublisher(ILifeCycleEventHub eventHub, ILoggerFactory loggerFactory)
+        {
+            _eventHub = eventHub;
+            _outbox = new ConcurrentQueue<LifeCycleEvent>();
+            _logger = loggerFactory.CreateLogger(GetType());
+        }
+
+        public void PublishNotification(LifeCycleEvent evt)
+        {
+            _outbox.Enqueue(evt);
+        }
+
+        public void Start()
+        {
+            if (DispatchTask != null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            _cancellationTokenSource = new CancellationTokenSource();
+
+            DispatchTask = new Task(Execute);
+            DispatchTask.Start();
+        }
+
+        public void Stop()
+        {
+            _cancellationTokenSource.Cancel();
+            DispatchTask.Wait();
+            DispatchTask = null;
+        }
+
+        private async void Execute()
+        {
+            var cancelToken = _cancellationTokenSource.Token;
+            
+            while (!cancelToken.IsCancellationRequested)
+            {
+                try
+                {
+                    if (!SpinWait.SpinUntil(() => _outbox.Count > 0, 1000))
+                    {
+                        continue;
+                    }
+
+                    if (_outbox.TryDequeue(out LifeCycleEvent evt))
+                    {
+                        await _eventHub.PublishNotification(evt);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex.Message);
+                }
+            }
+        }
+    }
+}

--- a/src/WorkflowCore/Services/WorkflowExecutor.cs
+++ b/src/WorkflowCore/Services/WorkflowExecutor.cs
@@ -20,17 +20,17 @@ namespace WorkflowCore.Services
         protected readonly IDateTimeProvider _datetimeProvider;
         protected readonly ILogger _logger;
         private readonly IExecutionResultProcessor _executionResultProcessor;
-        private readonly ILifeCycleEventHub _eventHub;
+        private readonly ILifeCycleEventPublisher _publisher;
         private readonly WorkflowOptions _options;
 
         private IWorkflowHost Host => _serviceProvider.GetService<IWorkflowHost>();
 
-        public WorkflowExecutor(IWorkflowRegistry registry, IServiceProvider serviceProvider, IDateTimeProvider datetimeProvider, IExecutionResultProcessor executionResultProcessor, ILifeCycleEventHub eventHub, WorkflowOptions options, ILoggerFactory loggerFactory)
+        public WorkflowExecutor(IWorkflowRegistry registry, IServiceProvider serviceProvider, IDateTimeProvider datetimeProvider, IExecutionResultProcessor executionResultProcessor, ILifeCycleEventPublisher publisher, WorkflowOptions options, ILoggerFactory loggerFactory)
         {
             _serviceProvider = serviceProvider;
             _registry = registry;
             _datetimeProvider = datetimeProvider;
-            _eventHub = eventHub;
+            _publisher = publisher;
             _options = options;
             _logger = loggerFactory.CreateLogger<WorkflowExecutor>();
             _executionResultProcessor = executionResultProcessor;
@@ -253,7 +253,7 @@ namespace WorkflowCore.Services
             
             workflow.Status = WorkflowStatus.Complete;
             workflow.CompleteTime = _datetimeProvider.Now.ToUniversalTime();
-            _eventHub.PublishNotification(new WorkflowCompleted()
+            _publisher.PublishNotification(new WorkflowCompleted()
             {
                 EventTimeUtc = _datetimeProvider.Now,
                 Reference = workflow.Reference,

--- a/src/WorkflowCore/Services/WorkflowExecutor.cs
+++ b/src/WorkflowCore/Services/WorkflowExecutor.cs
@@ -54,8 +54,7 @@ namespace WorkflowCore.Services
                 if (step != null)
                 {
                     try
-                    {
-                        pointer.Status = PointerStatus.Running;
+                    {                        
                         switch (step.InitForExecution(wfResult, def, workflow, pointer))
                         {
                             case ExecutionPipelineDirective.Defer:
@@ -64,6 +63,21 @@ namespace WorkflowCore.Services
                                 workflow.Status = WorkflowStatus.Complete;
                                 workflow.CompleteTime = _datetimeProvider.Now.ToUniversalTime();
                                 continue;
+                        }
+
+                        if (pointer.Status != PointerStatus.Running)
+                        {
+                            pointer.Status = PointerStatus.Running;
+                            _publisher.PublishNotification(new StepStarted()
+                            {
+                                EventTimeUtc = _datetimeProvider.Now,
+                                Reference = workflow.Reference,
+                                ExecutionPointerId = pointer.Id,
+                                StepId = step.Id,
+                                WorkflowInsanceId = workflow.Id,
+                                WorkflowDefinitionId = workflow.WorkflowDefinitionId,
+                                Version = workflow.Version
+                            });
                         }
 
                         if (!pointer.StartTime.HasValue)

--- a/src/WorkflowCore/WorkflowCore.csproj
+++ b/src/WorkflowCore/WorkflowCore.csproj
@@ -15,9 +15,9 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Description>Workflow Core is a light weight workflow engine targeting .NET Standard.</Description>
-    <Version>1.6.8</Version>
-    <AssemblyVersion>1.6.8.0</AssemblyVersion>
-    <FileVersion>1.6.8.0</FileVersion>
+    <Version>1.6.9</Version>
+    <AssemblyVersion>1.6.9.0</AssemblyVersion>
+    <FileVersion>1.6.9.0</FileVersion>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageIconUrl>https://github.com/danielgerlag/workflow-core/raw/master/src/logo.png</PackageIconUrl>
   </PropertyGroup>

--- a/test/WorkflowCore.UnitTests/Services/ExecutionResultProcessorFixture.cs
+++ b/test/WorkflowCore.UnitTests/Services/ExecutionResultProcessorFixture.cs
@@ -20,7 +20,7 @@ namespace WorkflowCore.UnitTests.Services
         protected IExecutionResultProcessor Subject;
         protected IExecutionPointerFactory PointerFactory;
         protected IDateTimeProvider DateTimeProvider;
-        protected ILifeCycleEventHub EventHub;
+        protected ILifeCycleEventPublisher EventHub;
         protected ICollection<IWorkflowErrorHandler> ErrorHandlers;
         protected WorkflowOptions Options;
 
@@ -28,7 +28,7 @@ namespace WorkflowCore.UnitTests.Services
         {
             PointerFactory = A.Fake<IExecutionPointerFactory>();
             DateTimeProvider = A.Fake<IDateTimeProvider>();
-            EventHub = A.Fake<ILifeCycleEventHub>();
+            EventHub = A.Fake<ILifeCycleEventPublisher>();
             ErrorHandlers = new HashSet<IWorkflowErrorHandler>();
 
             Options = new WorkflowOptions(A.Fake<IServiceCollection>());

--- a/test/WorkflowCore.UnitTests/Services/ExecutionResultProcessorFixture.cs
+++ b/test/WorkflowCore.UnitTests/Services/ExecutionResultProcessorFixture.cs
@@ -17,16 +17,19 @@ namespace WorkflowCore.UnitTests.Services
 {
     public class ExecutionResultProcessorFixture
     {
-        
         protected IExecutionResultProcessor Subject;
         protected IExecutionPointerFactory PointerFactory;
         protected IDateTimeProvider DateTimeProvider;
+        protected ILifeCycleEventHub EventHub;
+        protected ICollection<IWorkflowErrorHandler> ErrorHandlers;
         protected WorkflowOptions Options;
 
         public ExecutionResultProcessorFixture()
         {
             PointerFactory = A.Fake<IExecutionPointerFactory>();
             DateTimeProvider = A.Fake<IDateTimeProvider>();
+            EventHub = A.Fake<ILifeCycleEventHub>();
+            ErrorHandlers = new HashSet<IWorkflowErrorHandler>();
 
             Options = new WorkflowOptions(A.Fake<IServiceCollection>());
 
@@ -36,7 +39,7 @@ namespace WorkflowCore.UnitTests.Services
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddConsole(LogLevel.Debug);            
 
-            Subject = new ExecutionResultProcessor(PointerFactory, DateTimeProvider, Options, loggerFactory);
+            Subject = new ExecutionResultProcessor(PointerFactory, DateTimeProvider, EventHub, ErrorHandlers, Options, loggerFactory);
         }
 
         [Fact(DisplayName = "Should advance workflow")]

--- a/test/WorkflowCore.UnitTests/Services/WorkflowExecutorFixture.cs
+++ b/test/WorkflowCore.UnitTests/Services/WorkflowExecutorFixture.cs
@@ -22,7 +22,7 @@ namespace WorkflowCore.UnitTests.Services
         protected IPersistenceProvider PersistenceProvider;
         protected IWorkflowRegistry Registry;
         protected IExecutionResultProcessor ResultProcesser;
-        protected ILifeCycleEventHub EventHub;
+        protected ILifeCycleEventPublisher EventHub;
         protected IServiceProvider ServiceProvider;
         protected IDateTimeProvider DateTimeProvider;
         protected WorkflowOptions Options;
@@ -34,7 +34,7 @@ namespace WorkflowCore.UnitTests.Services
             ServiceProvider = A.Fake<IServiceProvider>();
             Registry = A.Fake<IWorkflowRegistry>();
             ResultProcesser = A.Fake<IExecutionResultProcessor>();
-            EventHub = A.Fake<ILifeCycleEventHub>();
+            EventHub = A.Fake<ILifeCycleEventPublisher>();
             DateTimeProvider = A.Fake<IDateTimeProvider>();
 
             Options = new WorkflowOptions(A.Fake<IServiceCollection>());

--- a/test/WorkflowCore.UnitTests/Services/WorkflowExecutorFixture.cs
+++ b/test/WorkflowCore.UnitTests/Services/WorkflowExecutorFixture.cs
@@ -22,6 +22,7 @@ namespace WorkflowCore.UnitTests.Services
         protected IPersistenceProvider PersistenceProvider;
         protected IWorkflowRegistry Registry;
         protected IExecutionResultProcessor ResultProcesser;
+        protected ILifeCycleEventHub EventHub;
         protected IServiceProvider ServiceProvider;
         protected IDateTimeProvider DateTimeProvider;
         protected WorkflowOptions Options;
@@ -33,6 +34,7 @@ namespace WorkflowCore.UnitTests.Services
             ServiceProvider = A.Fake<IServiceProvider>();
             Registry = A.Fake<IWorkflowRegistry>();
             ResultProcesser = A.Fake<IExecutionResultProcessor>();
+            EventHub = A.Fake<ILifeCycleEventHub>();
             DateTimeProvider = A.Fake<IDateTimeProvider>();
 
             Options = new WorkflowOptions(A.Fake<IServiceCollection>());
@@ -43,7 +45,7 @@ namespace WorkflowCore.UnitTests.Services
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddConsole(LogLevel.Debug);            
 
-            Subject = new WorkflowExecutor(Registry, ServiceProvider, DateTimeProvider, ResultProcesser, Options, loggerFactory);
+            Subject = new WorkflowExecutor(Registry, ServiceProvider, DateTimeProvider, ResultProcesser, EventHub, Options, loggerFactory);
         }
 
         [Fact(DisplayName = "Should execute active step")]
@@ -298,7 +300,7 @@ namespace WorkflowCore.UnitTests.Services
 
             //assert
             A.CallTo(() => step1Body.RunAsync(A<IStepExecutionContext>.Ignored)).MustHaveHappened();
-            A.CallTo(() => ResultProcesser.HandleStepException(instance, A<WorkflowDefinition>.Ignored, A<ExecutionPointer>.Ignored, step1)).MustHaveHappened();
+            A.CallTo(() => ResultProcesser.HandleStepException(instance, A<WorkflowDefinition>.Ignored, A<ExecutionPointer>.Ignored, step1, A<Exception>.Ignored)).MustHaveHappened();
             A.CallTo(() => ResultProcesser.ProcessExecutionResult(instance, A<WorkflowDefinition>.Ignored, A<ExecutionPointer>.Ignored, step1, A<ExecutionResult>.Ignored, A<WorkflowExecutorResult>.Ignored)).MustNotHaveHappened();            
         }
 


### PR DESCRIPTION
Hi all,

This PR adds functionality to subscribe to workflow life cycle events (WorkflowStarted, WorkflowComplete, WorkflowError, WorkflowSuspended, WorkflowResumed, etc...)
This can be achieved by either grabbing the EventHub from the IoC container and subscribing to events there, or attach an event on the workflow host class.
This implementation only publishes events to the local node... we will still need to implement a distributed version of the EventHub to solve the problem for multi-node clusters.