### PR TITLE
Search Index API & Elasticsearch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ There are several persistence providers available as separate Nuget packages.
 * [Sqlite](src/providers/WorkflowCore.Persistence.Sqlite)
 * Redis *(coming soon...)*
 
+## Search
+
+A search index provider can be plugged in to Workflow Core, enabling you to index your workflows and search against the data and state of them.
+These are also available as separate Nuget packages.
+* [Elasticsearch](src/providers/WorkflowCore.Providers.Elasticsearch)
+
 ## Extensions
 
 * [User (human) workflows](src/extensions/WorkflowCore.Users)

--- a/WorkflowCore.sln
+++ b/WorkflowCore.sln
@@ -126,7 +126,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Tests.DynamoDB
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Providers.Redis", "src\providers\WorkflowCore.Providers.Redis\WorkflowCore.Providers.Redis.csproj", "{435C6263-C6F8-4E93-B417-D861E9C22E18}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkflowCore.Providers.Elasticsearch", "src\providers\WorkflowCore.Providers.Elasticsearch\WorkflowCore.Providers.Elasticsearch.csproj", "{F6348170-B695-4D97-BAE6-4F0F643F3BEF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Providers.Elasticsearch", "src\providers\WorkflowCore.Providers.Elasticsearch\WorkflowCore.Providers.Elasticsearch.csproj", "{F6348170-B695-4D97-BAE6-4F0F643F3BEF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkflowCore.Tests.Elasticsearch", "test\WorkflowCore.Tests.Elasticsearch\WorkflowCore.Tests.Elasticsearch.csproj", "{44644716-0CE8-4837-B189-AB65AE2106AA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -322,6 +324,10 @@ Global
 		{F6348170-B695-4D97-BAE6-4F0F643F3BEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F6348170-B695-4D97-BAE6-4F0F643F3BEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F6348170-B695-4D97-BAE6-4F0F643F3BEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44644716-0CE8-4837-B189-AB65AE2106AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44644716-0CE8-4837-B189-AB65AE2106AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44644716-0CE8-4837-B189-AB65AE2106AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44644716-0CE8-4837-B189-AB65AE2106AA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -377,6 +383,7 @@ Global
 		{3ECEC028-7E2C-4983-B928-26C073B51BB7} = {E6CEAD8D-F565-471E-A0DC-676F54EAEDEB}
 		{435C6263-C6F8-4E93-B417-D861E9C22E18} = {2EEE6ABD-EE9B-473F-AF2D-6DABB85D7BA2}
 		{F6348170-B695-4D97-BAE6-4F0F643F3BEF} = {2EEE6ABD-EE9B-473F-AF2D-6DABB85D7BA2}
+		{44644716-0CE8-4837-B189-AB65AE2106AA} = {E6CEAD8D-F565-471E-A0DC-676F54EAEDEB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DC0FA8D3-6449-4FDA-BB46-ECF58FAD23B4}

--- a/WorkflowCore.sln
+++ b/WorkflowCore.sln
@@ -126,6 +126,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Tests.DynamoDB
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Providers.Redis", "src\providers\WorkflowCore.Providers.Redis\WorkflowCore.Providers.Redis.csproj", "{435C6263-C6F8-4E93-B417-D861E9C22E18}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkflowCore.Providers.Elasticsearch", "src\providers\WorkflowCore.Providers.Elasticsearch\WorkflowCore.Providers.Elasticsearch.csproj", "{F6348170-B695-4D97-BAE6-4F0F643F3BEF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -316,6 +318,10 @@ Global
 		{435C6263-C6F8-4E93-B417-D861E9C22E18}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{435C6263-C6F8-4E93-B417-D861E9C22E18}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{435C6263-C6F8-4E93-B417-D861E9C22E18}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6348170-B695-4D97-BAE6-4F0F643F3BEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6348170-B695-4D97-BAE6-4F0F643F3BEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6348170-B695-4D97-BAE6-4F0F643F3BEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6348170-B695-4D97-BAE6-4F0F643F3BEF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -370,6 +376,7 @@ Global
 		{DF7F7ECA-1771-40C9-9CD0-AFEFC44E60DE} = {E6CEAD8D-F565-471E-A0DC-676F54EAEDEB}
 		{3ECEC028-7E2C-4983-B928-26C073B51BB7} = {E6CEAD8D-F565-471E-A0DC-676F54EAEDEB}
 		{435C6263-C6F8-4E93-B417-D861E9C22E18} = {2EEE6ABD-EE9B-473F-AF2D-6DABB85D7BA2}
+		{F6348170-B695-4D97-BAE6-4F0F643F3BEF} = {2EEE6ABD-EE9B-473F-AF2D-6DABB85D7BA2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DC0FA8D3-6449-4FDA-BB46-ECF58FAD23B4}

--- a/src/WorkflowCore/Interface/IPersistenceProvider.cs
+++ b/src/WorkflowCore/Interface/IPersistenceProvider.cs
@@ -17,6 +17,7 @@ namespace WorkflowCore.Interface
 
         Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt);
 
+        [Obsolete]
         Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(WorkflowStatus? status, string type, DateTime? createdFrom, DateTime? createdTo, int skip, int take);
 
         Task<WorkflowInstance> GetWorkflowInstance(string Id);

--- a/src/WorkflowCore/Interface/ISearchIndex.cs
+++ b/src/WorkflowCore/Interface/ISearchIndex.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using WorkflowCore.Models;
+using WorkflowCore.Models.Search;
+
+namespace WorkflowCore.Interface
+{
+    public interface ISearchIndex
+    {
+        Task IndexWorkflow(WorkflowInstance workflow);
+
+        Task<Page<WorkflowSearchResult>> Search(string terms, int skip, int take);
+
+        Task Start();
+
+        Task Stop();
+    }
+}

--- a/src/WorkflowCore/Interface/ISearchIndex.cs
+++ b/src/WorkflowCore/Interface/ISearchIndex.cs
@@ -11,7 +11,7 @@ namespace WorkflowCore.Interface
     {
         Task IndexWorkflow(WorkflowInstance workflow);
 
-        Task<Page<WorkflowSearchResult>> Search(string terms, int skip, int take);
+        Task<Page<WorkflowSearchResult>> Search(string terms, int skip, int take, params SearchFilter[] filters);
 
         Task Start();
 

--- a/src/WorkflowCore/Interface/ISearchable.cs
+++ b/src/WorkflowCore/Interface/ISearchable.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WorkflowCore.Interface
+{
+    public interface ISearchable
+    {
+        IEnumerable<string> GetSearchTokens();
+    }
+}

--- a/src/WorkflowCore/Models/Search/Page.cs
+++ b/src/WorkflowCore/Models/Search/Page.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WorkflowCore.Models.Search
+{
+    public class Page<T>
+    {
+        public ICollection<T> Data { get; set; }
+        public long Total { get; set; }
+    }
+}

--- a/src/WorkflowCore/Models/Search/SearchFilter.cs
+++ b/src/WorkflowCore/Models/Search/SearchFilter.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WorkflowCore.Models.Search
+{
+    public abstract class SearchFilter
+    {
+    }
+
+    public class ReferenceFilter : SearchFilter
+    {
+        public string Value { get; set; }
+
+        public static ReferenceFilter Equals(string value) => new ReferenceFilter()
+        {
+            Value = value
+        };
+    }
+
+    public class StatusFilter : SearchFilter
+    {
+        public WorkflowStatus Value { get; set; }
+
+        public static StatusFilter Equals(WorkflowStatus value) => new StatusFilter()
+        {
+            Value = value
+        };
+    }
+
+    public class WorkflowDefinitionFilter : SearchFilter
+    {
+        public string Value { get; set; }
+
+        public static WorkflowDefinitionFilter Equals(string value) => new WorkflowDefinitionFilter()
+        {
+            Value = value
+        };
+    }
+
+    public class CreateDateFilter : SearchFilter
+    {
+        public DateTime? BeforeValue { get; set; }
+        public DateTime? AfterValue { get; set; }
+
+        public static CreateDateFilter Before(DateTime value) => new CreateDateFilter()
+        {
+            BeforeValue = value
+        };
+
+        public static CreateDateFilter After(DateTime value) => new CreateDateFilter()
+        {
+            AfterValue = value
+        };
+
+        public static CreateDateFilter Between(DateTime start, DateTime end) => new CreateDateFilter()
+        {
+            BeforeValue = end,
+            AfterValue = start
+        };
+    }
+
+    public class CompleteDateFilter : SearchFilter
+    {
+        public DateTime? BeforeValue { get; set; }
+        public DateTime? AfterValue { get; set; }
+
+        public static CompleteDateFilter Before(DateTime value) => new CompleteDateFilter()
+        {
+            BeforeValue = value
+        };
+
+        public static CompleteDateFilter After(DateTime value) => new CompleteDateFilter()
+        {
+            AfterValue = value
+        };
+
+        public static CompleteDateFilter Between(DateTime start, DateTime end) => new CompleteDateFilter()
+        {
+            BeforeValue = end,
+            AfterValue = start
+        };
+    }
+}

--- a/src/WorkflowCore/Models/Search/SearchFilter.cs
+++ b/src/WorkflowCore/Models/Search/SearchFilter.cs
@@ -10,6 +10,11 @@ namespace WorkflowCore.Models.Search
         public bool IsData { get; set; }
         public Type DataType { get; set; }
         public Expression Property { get; set; }
+
+        static Func<T, V> Lambda<T, V>(Func<T, V> del)
+        {
+            return del;
+        }
     }
 
     public class ScalarFilter : SearchFilter
@@ -58,6 +63,7 @@ namespace WorkflowCore.Models.Search
         public static DateRangeFilter Before<T>(Expression<Func<T, object>> property, DateTime value) => new DateRangeFilter()
         {
             IsData = true,
+            DataType = typeof(T),
             Property = property,
             BeforeValue = value
         };
@@ -65,6 +71,7 @@ namespace WorkflowCore.Models.Search
         public static DateRangeFilter After<T>(Expression<Func<T, object>> property, DateTime value) => new DateRangeFilter()
         {
             IsData = true,
+            DataType = typeof(T),
             Property = property,
             AfterValue = value
         };
@@ -72,6 +79,7 @@ namespace WorkflowCore.Models.Search
         public static DateRangeFilter Between<T>(Expression<Func<T, object>> property, DateTime start, DateTime end) => new DateRangeFilter()
         {
             IsData = true,
+            DataType = typeof(T),
             Property = property,
             BeforeValue = end,
             AfterValue = start
@@ -105,6 +113,7 @@ namespace WorkflowCore.Models.Search
         public static NumericRangeFilter LessThan<T>(Expression<Func<T, object>> property, double value) => new NumericRangeFilter()
         {
             IsData = true,
+            DataType = typeof(T),
             Property = property,
             LessValue = value
         };
@@ -112,6 +121,7 @@ namespace WorkflowCore.Models.Search
         public static NumericRangeFilter GreaterThan<T>(Expression<Func<T, object>> property, double value) => new NumericRangeFilter()
         {
             IsData = true,
+            DataType = typeof(T),
             Property = property,
             GreaterValue = value
         };
@@ -119,6 +129,7 @@ namespace WorkflowCore.Models.Search
         public static NumericRangeFilter Between<T>(Expression<Func<T, object>> property, double start, double end) => new NumericRangeFilter()
         {
             IsData = true,
+            DataType = typeof(T),
             Property = property,
             LessValue = end,
             GreaterValue = start

--- a/src/WorkflowCore/Models/Search/SearchFilter.cs
+++ b/src/WorkflowCore/Models/Search/SearchFilter.cs
@@ -7,6 +7,8 @@ namespace WorkflowCore.Models.Search
 {
     public abstract class SearchFilter
     {
+        public bool IsData { get; set; }
+        public Type DataType { get; set; }
         public Expression Property { get; set; }
     }
 
@@ -20,8 +22,10 @@ namespace WorkflowCore.Models.Search
             Value = value
         };
 
-        public static SearchFilter Equals<T>(Expression<Func<WorkflowSearchResult<T>, object>> property, object value) => new ScalarFilter()
+        public static SearchFilter Equals<T>(Expression<Func<T, object>> property, object value) => new ScalarFilter()
         {
+            IsData = true,
+            DataType = typeof(T),
             Property = property,
             Value = value
         };
@@ -51,20 +55,23 @@ namespace WorkflowCore.Models.Search
             AfterValue = start
         };
 
-        public static DateRangeFilter Before<T>(Expression<Func<WorkflowSearchResult<T>, object>> property, DateTime value) => new DateRangeFilter()
+        public static DateRangeFilter Before<T>(Expression<Func<T, object>> property, DateTime value) => new DateRangeFilter()
         {
+            IsData = true,
             Property = property,
             BeforeValue = value
         };
 
-        public static DateRangeFilter After<T>(Expression<Func<WorkflowSearchResult<T>, object>> property, DateTime value) => new DateRangeFilter()
+        public static DateRangeFilter After<T>(Expression<Func<T, object>> property, DateTime value) => new DateRangeFilter()
         {
+            IsData = true,
             Property = property,
             AfterValue = value
         };
 
-        public static DateRangeFilter Between<T>(Expression<Func<WorkflowSearchResult<T>, object>> property, DateTime start, DateTime end) => new DateRangeFilter()
+        public static DateRangeFilter Between<T>(Expression<Func<T, object>> property, DateTime start, DateTime end) => new DateRangeFilter()
         {
+            IsData = true,
             Property = property,
             BeforeValue = end,
             AfterValue = start
@@ -95,20 +102,23 @@ namespace WorkflowCore.Models.Search
             GreaterValue = start
         };
 
-        public static NumericRangeFilter LessThan<T>(Expression<Func<WorkflowSearchResult<T>, object>> property, double value) => new NumericRangeFilter()
+        public static NumericRangeFilter LessThan<T>(Expression<Func<T, object>> property, double value) => new NumericRangeFilter()
         {
+            IsData = true,
             Property = property,
             LessValue = value
         };
 
-        public static NumericRangeFilter GreaterThan<T>(Expression<Func<WorkflowSearchResult<T>, object>> property, double value) => new NumericRangeFilter()
+        public static NumericRangeFilter GreaterThan<T>(Expression<Func<T, object>> property, double value) => new NumericRangeFilter()
         {
+            IsData = true,
             Property = property,
             GreaterValue = value
         };
 
-        public static NumericRangeFilter Between<T>(Expression<Func<WorkflowSearchResult<T>, object>> property, double start, double end) => new NumericRangeFilter()
+        public static NumericRangeFilter Between<T>(Expression<Func<T, object>> property, double start, double end) => new NumericRangeFilter()
         {
+            IsData = true,
             Property = property,
             LessValue = end,
             GreaterValue = start

--- a/src/WorkflowCore/Models/Search/SearchFilter.cs
+++ b/src/WorkflowCore/Models/Search/SearchFilter.cs
@@ -1,84 +1,132 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Text;
 
 namespace WorkflowCore.Models.Search
 {
     public abstract class SearchFilter
     {
+        public Expression Property { get; set; }
     }
 
-    public class ReferenceFilter : SearchFilter
+    public class ScalarFilter : SearchFilter
     {
-        public string Value { get; set; }
+        public object Value { get; set; }
 
-        public static ReferenceFilter Equals(string value) => new ReferenceFilter()
+        public static SearchFilter Equals(Expression<Func<WorkflowSearchResult, object>> property, object value) => new ScalarFilter()
         {
+            Property = property,
+            Value = value
+        };
+
+        public static SearchFilter Equals<T>(Expression<Func<WorkflowSearchResult<T>, object>> property, object value) => new ScalarFilter()
+        {
+            Property = property,
             Value = value
         };
     }
 
-    public class StatusFilter : SearchFilter
+    public class DateRangeFilter : SearchFilter
     {
-        public WorkflowStatus Value { get; set; }
+        public DateTime? BeforeValue { get; set; }
+        public DateTime? AfterValue { get; set; }
+
+        public static DateRangeFilter Before(Expression<Func<WorkflowSearchResult, object>> property, DateTime value) => new DateRangeFilter()
+        {
+            Property = property,
+            BeforeValue = value
+        };
+
+        public static DateRangeFilter After(Expression<Func<WorkflowSearchResult, object>> property, DateTime value) => new DateRangeFilter()
+        {
+            Property = property,
+            AfterValue = value
+        };
+
+        public static DateRangeFilter Between(Expression<Func<WorkflowSearchResult, object>> property, DateTime start, DateTime end) => new DateRangeFilter()
+        {
+            Property = property,
+            BeforeValue = end,
+            AfterValue = start
+        };
+
+        public static DateRangeFilter Before<T>(Expression<Func<WorkflowSearchResult<T>, object>> property, DateTime value) => new DateRangeFilter()
+        {
+            Property = property,
+            BeforeValue = value
+        };
+
+        public static DateRangeFilter After<T>(Expression<Func<WorkflowSearchResult<T>, object>> property, DateTime value) => new DateRangeFilter()
+        {
+            Property = property,
+            AfterValue = value
+        };
+
+        public static DateRangeFilter Between<T>(Expression<Func<WorkflowSearchResult<T>, object>> property, DateTime start, DateTime end) => new DateRangeFilter()
+        {
+            Property = property,
+            BeforeValue = end,
+            AfterValue = start
+        };
+    }
+
+    public class NumericRangeFilter : SearchFilter
+    {
+        public double? LessValue { get; set; }
+        public double? GreaterValue { get; set; }
+
+        public static NumericRangeFilter LessThan(Expression<Func<WorkflowSearchResult, object>> property, double value) => new NumericRangeFilter()
+        {
+            Property = property,
+            LessValue = value
+        };
+
+        public static NumericRangeFilter GreaterThan(Expression<Func<WorkflowSearchResult, object>> property, double value) => new NumericRangeFilter()
+        {
+            Property = property,
+            GreaterValue = value
+        };
+
+        public static NumericRangeFilter Between(Expression<Func<WorkflowSearchResult, object>> property, double start, double end) => new NumericRangeFilter()
+        {
+            Property = property,
+            LessValue = end,
+            GreaterValue = start
+        };
+
+        public static NumericRangeFilter LessThan<T>(Expression<Func<WorkflowSearchResult<T>, object>> property, double value) => new NumericRangeFilter()
+        {
+            Property = property,
+            LessValue = value
+        };
+
+        public static NumericRangeFilter GreaterThan<T>(Expression<Func<WorkflowSearchResult<T>, object>> property, double value) => new NumericRangeFilter()
+        {
+            Property = property,
+            GreaterValue = value
+        };
+
+        public static NumericRangeFilter Between<T>(Expression<Func<WorkflowSearchResult<T>, object>> property, double start, double end) => new NumericRangeFilter()
+        {
+            Property = property,
+            LessValue = end,
+            GreaterValue = start
+        };
+    }
+
+    public class StatusFilter : ScalarFilter
+    {
+        protected StatusFilter()
+        {
+            Expression<Func<WorkflowSearchResult, object>> lambda = (WorkflowSearchResult x) => x.Status;
+            Property = lambda;
+        }
 
         public static StatusFilter Equals(WorkflowStatus value) => new StatusFilter()
         {
-            Value = value
+            Value = value.ToString()
         };
     }
 
-    public class WorkflowDefinitionFilter : SearchFilter
-    {
-        public string Value { get; set; }
-
-        public static WorkflowDefinitionFilter Equals(string value) => new WorkflowDefinitionFilter()
-        {
-            Value = value
-        };
-    }
-
-    public class CreateDateFilter : SearchFilter
-    {
-        public DateTime? BeforeValue { get; set; }
-        public DateTime? AfterValue { get; set; }
-
-        public static CreateDateFilter Before(DateTime value) => new CreateDateFilter()
-        {
-            BeforeValue = value
-        };
-
-        public static CreateDateFilter After(DateTime value) => new CreateDateFilter()
-        {
-            AfterValue = value
-        };
-
-        public static CreateDateFilter Between(DateTime start, DateTime end) => new CreateDateFilter()
-        {
-            BeforeValue = end,
-            AfterValue = start
-        };
-    }
-
-    public class CompleteDateFilter : SearchFilter
-    {
-        public DateTime? BeforeValue { get; set; }
-        public DateTime? AfterValue { get; set; }
-
-        public static CompleteDateFilter Before(DateTime value) => new CompleteDateFilter()
-        {
-            BeforeValue = value
-        };
-
-        public static CompleteDateFilter After(DateTime value) => new CompleteDateFilter()
-        {
-            AfterValue = value
-        };
-
-        public static CompleteDateFilter Between(DateTime start, DateTime end) => new CompleteDateFilter()
-        {
-            BeforeValue = end,
-            AfterValue = start
-        };
-    }
 }

--- a/src/WorkflowCore/Models/Search/StepInfo.cs
+++ b/src/WorkflowCore/Models/Search/StepInfo.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WorkflowCore.Models.Search
+{
+    public class StepInfo
+    {
+        public int StepId { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/src/WorkflowCore/Models/Search/WorkflowSearchResult.cs
+++ b/src/WorkflowCore/Models/Search/WorkflowSearchResult.cs
@@ -22,6 +22,8 @@ namespace WorkflowCore.Models.Search
 
         public object Data { get; set; }
 
+        public string DataTokens { get; set; }
+
         public DateTime CreateTime { get; set; }
 
         public DateTime? CompleteTime { get; set; }

--- a/src/WorkflowCore/Models/Search/WorkflowSearchResult.cs
+++ b/src/WorkflowCore/Models/Search/WorkflowSearchResult.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Reflection;
 using WorkflowCore.Interface;
 
 namespace WorkflowCore.Models.Search
 {
-    public class WorkflowSearchResult<TData>
+    public class WorkflowSearchResult
     {
         public string Id { get; set; }
 
@@ -19,12 +19,10 @@ namespace WorkflowCore.Models.Search
 
         public DateTime? NextExecutionUtc { get; set; }
 
-        public string Status { get; set; }
+        public WorkflowStatus Status { get; set; }
 
-        public TData Data { get; set; }
-
-        public IEnumerable<string> DataTokens { get; set; }
-
+        public object Data { get; set; }
+        
         public DateTime CreateTime { get; set; }
 
         public DateTime? CompleteTime { get; set; }
@@ -35,63 +33,12 @@ namespace WorkflowCore.Models.Search
 
         public ICollection<StepInfo> FailedSteps { get; set; } = new HashSet<StepInfo>();
 
+
     }
 
-    public class WorkflowSearchResult : WorkflowSearchResult<object>
+    public class WorkflowSearchResult<TData> : WorkflowSearchResult
     {
-        public static WorkflowSearchResult FromWorkflowInstance(WorkflowInstance workflow)
-        {
-            var result = new WorkflowSearchResult
-            {
-                Id = workflow.Id,
-                WorkflowDefinitionId = workflow.WorkflowDefinitionId,
-                Description = workflow.Description,
-                Reference = workflow.Reference,
-                Data = workflow.Data,
-                CompleteTime = workflow.CompleteTime,
-                CreateTime = workflow.CreateTime,
-                Version = workflow.Version,
-                Status = workflow.Status.ToString()
-            };
-
-            if (workflow.NextExecution.HasValue)
-                result.NextExecutionUtc = new DateTime(workflow.NextExecution.Value);
-
-            if (workflow.Data is ISearchable)
-                result.DataTokens = (workflow.Data as ISearchable).GetSearchTokens();
-
-            foreach (var ep in workflow.ExecutionPointers)
-            {
-                if (ep.Status == PointerStatus.Sleeping)
-                {
-                    result.SleepingSteps.Add(new StepInfo()
-                    {
-                        StepId = ep.StepId,
-                        Name = ep.StepName
-                    });
-                }
-
-                if (ep.Status == PointerStatus.WaitingForEvent)
-                {
-                    result.WaitingSteps.Add(new StepInfo()
-                    {
-                        StepId = ep.StepId,
-                        Name = ep.StepName
-                    });
-                }
-
-                if (ep.Status == PointerStatus.Failed)
-                {
-                    result.FailedSteps.Add(new StepInfo()
-                    {
-                        StepId = ep.StepId,
-                        Name = ep.StepName
-                    });
-                }
-            }
-
-            return result;
-        }
+        public new TData Data { get; set; }
     }
     
 }

--- a/src/WorkflowCore/Models/Search/WorkflowSearchResult.cs
+++ b/src/WorkflowCore/Models/Search/WorkflowSearchResult.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WorkflowCore.Models.Search
+{
+    public class WorkflowSearchResult
+    {
+        public string Id { get; set; }
+
+        public string WorkflowDefinitionId { get; set; }
+
+        public int Version { get; set; }
+
+        public string Description { get; set; }
+
+        public string Reference { get; set; }
+                 
+        public DateTime? NextExecutionUtc { get; set; }
+
+        public string Status { get; set; }
+
+        public object Data { get; set; }
+
+        public DateTime CreateTime { get; set; }
+
+        public DateTime? CompleteTime { get; set; }
+
+        public ICollection<StepInfo> WaitingSteps { get; set; } = new HashSet<StepInfo>();
+
+        public ICollection<StepInfo> SleepingSteps { get; set; } = new HashSet<StepInfo>();
+
+        public ICollection<StepInfo> FailedSteps { get; set; } = new HashSet<StepInfo>();
+
+        public static WorkflowSearchResult FromWorkflowInstance(WorkflowInstance workflow)
+        {
+            var result = new WorkflowSearchResult
+            {
+                Id = workflow.Id,
+                WorkflowDefinitionId = workflow.WorkflowDefinitionId,
+                Description = workflow.Description,
+                Reference = workflow.Reference,
+                Data = workflow.Data,
+                CompleteTime = workflow.CompleteTime,
+                CreateTime = workflow.CreateTime,
+                Version = workflow.Version,
+                Status = workflow.Status.ToString()                
+            };
+
+            if (workflow.NextExecution.HasValue)
+                result.NextExecutionUtc = new DateTime(workflow.NextExecution.Value);
+            
+
+            return result;
+        }
+    }
+}

--- a/src/WorkflowCore/Models/WorkflowOptions.cs
+++ b/src/WorkflowCore/Models/WorkflowOptions.cs
@@ -12,6 +12,7 @@ namespace WorkflowCore.Models
         internal Func<IServiceProvider, IQueueProvider> QueueFactory;
         internal Func<IServiceProvider, IDistributedLockProvider> LockFactory;
         internal Func<IServiceProvider, ILifeCycleEventHub> EventHubFactory;
+        internal Func<IServiceProvider, ISearchIndex> SearchIndexFactory;
         internal TimeSpan PollInterval;
         internal TimeSpan IdleTime;
         internal TimeSpan ErrorRetryInterval;
@@ -28,6 +29,7 @@ namespace WorkflowCore.Models
             QueueFactory = new Func<IServiceProvider, IQueueProvider>(sp => new SingleNodeQueueProvider());
             LockFactory = new Func<IServiceProvider, IDistributedLockProvider>(sp => new SingleNodeLockProvider());
             PersistanceFactory = new Func<IServiceProvider, IPersistenceProvider>(sp => new MemoryPersistenceProvider());
+            SearchIndexFactory = new Func<IServiceProvider, ISearchIndex>(sp => new InMemorySearchIndex());
             EventHubFactory = new Func<IServiceProvider, ILifeCycleEventHub>(sp => new SingleNodeEventHub(sp.GetService<ILoggerFactory>()));
         }
 
@@ -49,6 +51,11 @@ namespace WorkflowCore.Models
         public void UseEventHub(Func<IServiceProvider, ILifeCycleEventHub> factory)
         {
             EventHubFactory = factory;
+        }
+
+        public void UseSearchIndex(Func<IServiceProvider, ISearchIndex> factory)
+        {
+            SearchIndexFactory = factory;
         }
 
         public void UsePollInterval(TimeSpan interval)

--- a/src/WorkflowCore/Models/WorkflowOptions.cs
+++ b/src/WorkflowCore/Models/WorkflowOptions.cs
@@ -29,7 +29,7 @@ namespace WorkflowCore.Models
             QueueFactory = new Func<IServiceProvider, IQueueProvider>(sp => new SingleNodeQueueProvider());
             LockFactory = new Func<IServiceProvider, IDistributedLockProvider>(sp => new SingleNodeLockProvider());
             PersistanceFactory = new Func<IServiceProvider, IPersistenceProvider>(sp => new MemoryPersistenceProvider());
-            SearchIndexFactory = new Func<IServiceProvider, ISearchIndex>(sp => new InMemorySearchIndex());
+            SearchIndexFactory = new Func<IServiceProvider, ISearchIndex>(sp => new NullSearchIndex());
             EventHubFactory = new Func<IServiceProvider, ILifeCycleEventHub>(sp => new SingleNodeEventHub(sp.GetService<ILoggerFactory>()));
         }
 

--- a/src/WorkflowCore/ServiceCollectionExtensions.cs
+++ b/src/WorkflowCore/ServiceCollectionExtensions.cs
@@ -28,9 +28,11 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IQueueProvider>(options.QueueFactory);
             services.AddSingleton<IDistributedLockProvider>(options.LockFactory);
             services.AddSingleton<ILifeCycleEventHub>(options.EventHubFactory);
+            services.AddSingleton<ISearchIndex>(options.SearchIndexFactory);
+
             services.AddSingleton<IWorkflowRegistry, WorkflowRegistry>();
             services.AddSingleton<WorkflowOptions>(options);
-            services.AddSingleton<ILifeCycleEventPublisher, LifeCycleEventPublisher>();
+            services.AddSingleton<ILifeCycleEventPublisher, LifeCycleEventPublisher>();            
 
             services.AddTransient<IBackgroundTask, WorkflowConsumer>();
             services.AddTransient<IBackgroundTask, EventConsumer>();

--- a/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
@@ -12,17 +12,19 @@ namespace WorkflowCore.Services.BackgroundTasks
     {
         private readonly IDistributedLockProvider _lockProvider;
         private readonly IDateTimeProvider _datetimeProvider;
+        private readonly ISearchIndex _searchIndex;
         private readonly ObjectPool<IPersistenceProvider> _persistenceStorePool;
         private readonly ObjectPool<IWorkflowExecutor> _executorPool;
 
         protected override QueueType Queue => QueueType.Workflow;
 
-        public WorkflowConsumer(IPooledObjectPolicy<IPersistenceProvider> persistencePoolPolicy, IQueueProvider queueProvider, ILoggerFactory loggerFactory, IServiceProvider serviceProvider, IWorkflowRegistry registry, IDistributedLockProvider lockProvider, IPooledObjectPolicy<IWorkflowExecutor> executorPoolPolicy, IDateTimeProvider datetimeProvider, WorkflowOptions options)
+        public WorkflowConsumer(IPooledObjectPolicy<IPersistenceProvider> persistencePoolPolicy, IQueueProvider queueProvider, ILoggerFactory loggerFactory, IServiceProvider serviceProvider, IWorkflowRegistry registry, IDistributedLockProvider lockProvider, IPooledObjectPolicy<IWorkflowExecutor> executorPoolPolicy, IDateTimeProvider datetimeProvider, ISearchIndex searchIndex, WorkflowOptions options)
             : base(queueProvider, loggerFactory, options)
         {
             _persistenceStorePool = new DefaultObjectPool<IPersistenceProvider>(persistencePoolPolicy);
             _executorPool = new DefaultObjectPool<IWorkflowExecutor>(executorPoolPolicy);
             _lockProvider = lockProvider;
+            _searchIndex = searchIndex;
             _datetimeProvider = datetimeProvider;
         }
 
@@ -50,6 +52,7 @@ namespace WorkflowCore.Services.BackgroundTasks
                             {
                                 _executorPool.Return(executor);
                                 await persistenceStore.PersistWorkflow(workflow);
+                                await _searchIndex.IndexWorkflow(workflow);
                             }
                         }
                     }

--- a/src/WorkflowCore/Services/DefaultProviders/InMemorySearchIndex.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/InMemorySearchIndex.cs
@@ -15,7 +15,7 @@ namespace WorkflowCore.Services
             return Task.CompletedTask;
         }
 
-        public Task<Page<WorkflowSearchResult>> Search(string terms, int skip, int take)
+        public Task<Page<WorkflowSearchResult>> Search(string terms, int skip, int take, params SearchFilter[] filters)
         {
             throw new NotImplementedException();
         }

--- a/src/WorkflowCore/Services/DefaultProviders/InMemorySearchIndex.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/InMemorySearchIndex.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using WorkflowCore.Models.Search;
+
+namespace WorkflowCore.Services
+{
+    public class InMemorySearchIndex : ISearchIndex
+    {
+        public Task IndexWorkflow(WorkflowInstance workflow)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<Page<WorkflowSearchResult>> Search(string terms, int skip, int take)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Start()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task Stop()
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/WorkflowCore/Services/DefaultProviders/NullSearchIndex.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/NullSearchIndex.cs
@@ -8,7 +8,7 @@ using WorkflowCore.Models.Search;
 
 namespace WorkflowCore.Services
 {
-    public class InMemorySearchIndex : ISearchIndex
+    public class NullSearchIndex : ISearchIndex
     {
         public Task IndexWorkflow(WorkflowInstance workflow)
         {

--- a/src/WorkflowCore/Services/WorkflowController.cs
+++ b/src/WorkflowCore/Services/WorkflowController.cs
@@ -19,9 +19,10 @@ namespace WorkflowCore.Services
         private readonly IQueueProvider _queueProvider;
         private readonly IExecutionPointerFactory _pointerFactory;
         private readonly ILifeCycleEventHub _eventHub;
+        private readonly ISearchIndex _searchIndex;
         private readonly ILogger _logger;
 
-        public WorkflowController(IPersistenceProvider persistenceStore, IDistributedLockProvider lockProvider, IWorkflowRegistry registry, IQueueProvider queueProvider, IExecutionPointerFactory pointerFactory, ILifeCycleEventHub eventHub, ILoggerFactory loggerFactory)
+        public WorkflowController(IPersistenceProvider persistenceStore, IDistributedLockProvider lockProvider, IWorkflowRegistry registry, IQueueProvider queueProvider, IExecutionPointerFactory pointerFactory, ILifeCycleEventHub eventHub, ISearchIndex searchIndex, ILoggerFactory loggerFactory)
         {
             _persistenceStore = persistenceStore;
             _lockProvider = lockProvider;
@@ -29,6 +30,7 @@ namespace WorkflowCore.Services
             _queueProvider = queueProvider;
             _pointerFactory = pointerFactory;
             _eventHub = eventHub;
+            _searchIndex = searchIndex;
             _logger = loggerFactory.CreateLogger<WorkflowController>();
         }
 
@@ -82,6 +84,7 @@ namespace WorkflowCore.Services
 
             string id = await _persistenceStore.CreateNewWorkflow(wf);
             await _queueProvider.QueueWork(id, QueueType.Workflow);
+            await _searchIndex.IndexWorkflow(wf);
             await _eventHub.PublishNotification(new WorkflowStarted()
             {
                 EventTimeUtc = DateTime.UtcNow,
@@ -124,6 +127,7 @@ namespace WorkflowCore.Services
                 {
                     wf.Status = WorkflowStatus.Suspended;
                     await _persistenceStore.PersistWorkflow(wf);
+                    await _searchIndex.IndexWorkflow(wf);
                     await _eventHub.PublishNotification(new WorkflowSuspended()
                     {
                         EventTimeUtc = DateTime.UtcNow,
@@ -159,6 +163,7 @@ namespace WorkflowCore.Services
                     wf.Status = WorkflowStatus.Runnable;
                     await _persistenceStore.PersistWorkflow(wf);
                     requeue = true;
+                    await _searchIndex.IndexWorkflow(wf);
                     await _eventHub.PublishNotification(new WorkflowResumed()
                     {
                         EventTimeUtc = DateTime.UtcNow,
@@ -192,6 +197,7 @@ namespace WorkflowCore.Services
                 var wf = await _persistenceStore.GetWorkflowInstance(workflowId);
                 wf.Status = WorkflowStatus.Terminated;
                 await _persistenceStore.PersistWorkflow(wf);
+                await _searchIndex.IndexWorkflow(wf);
                 await _eventHub.PublishNotification(new WorkflowTerminated()
                 {
                     EventTimeUtc = DateTime.UtcNow,

--- a/src/WorkflowCore/Services/WorkflowHost.cs
+++ b/src/WorkflowCore/Services/WorkflowHost.cs
@@ -32,8 +32,9 @@ namespace WorkflowCore.Services
         public ILogger Logger { get; private set; }
 
         private readonly ILifeCycleEventHub _lifeCycleEventHub;
+        private readonly ISearchIndex _searchIndex;
 
-        public WorkflowHost(IPersistenceProvider persistenceStore, IQueueProvider queueProvider, WorkflowOptions options, ILoggerFactory loggerFactory, IServiceProvider serviceProvider, IWorkflowRegistry registry, IDistributedLockProvider lockProvider, IEnumerable<IBackgroundTask> backgroundTasks, IWorkflowController workflowController, ILifeCycleEventHub lifeCycleEventHub)
+        public WorkflowHost(IPersistenceProvider persistenceStore, IQueueProvider queueProvider, WorkflowOptions options, ILoggerFactory loggerFactory, IServiceProvider serviceProvider, IWorkflowRegistry registry, IDistributedLockProvider lockProvider, IEnumerable<IBackgroundTask> backgroundTasks, IWorkflowController workflowController, ILifeCycleEventHub lifeCycleEventHub, ISearchIndex searchIndex)
         {
             PersistenceStore = persistenceStore;
             QueueProvider = queueProvider;
@@ -44,6 +45,7 @@ namespace WorkflowCore.Services
             LockProvider = lockProvider;
             _backgroundTasks = backgroundTasks;
             _workflowController = workflowController;
+            _searchIndex = searchIndex;
             _lifeCycleEventHub = lifeCycleEventHub;
             _lifeCycleEventHub.Subscribe(HandleLifeCycleEvent);
         }
@@ -82,6 +84,7 @@ namespace WorkflowCore.Services
             QueueProvider.Start().Wait();
             LockProvider.Start().Wait();
             _lifeCycleEventHub.Start().Wait();
+            _searchIndex.Start().Wait();
             
             Logger.LogInformation("Starting backgroud tasks");
 
@@ -101,6 +104,7 @@ namespace WorkflowCore.Services
 
             QueueProvider.Stop().Wait();
             LockProvider.Stop().Wait();
+            _searchIndex.Stop().Wait();
             _lifeCycleEventHub.Stop().Wait();
         }
 

--- a/src/WorkflowCore/WorkflowCore.csproj
+++ b/src/WorkflowCore/WorkflowCore.csproj
@@ -15,9 +15,9 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Description>Workflow Core is a light weight workflow engine targeting .NET Standard.</Description>
-    <Version>1.7.0</Version>
-    <AssemblyVersion>1.7.0.0</AssemblyVersion>
-    <FileVersion>1.7.0.0</FileVersion>
+    <Version>1.8.0</Version>
+    <AssemblyVersion>1.8.0.0</AssemblyVersion>
+    <FileVersion>1.8.0.0</FileVersion>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageIconUrl>https://github.com/danielgerlag/workflow-core/raw/master/src/logo.png</PackageIconUrl>
   </PropertyGroup>

--- a/src/providers/WorkflowCore.Providers.Elasticsearch/Models/WorkflowSearchModel.cs
+++ b/src/providers/WorkflowCore.Providers.Elasticsearch/Models/WorkflowSearchModel.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using WorkflowCore.Models.Search;
+
+namespace WorkflowCore.Providers.Elasticsearch.Models
+{
+    public class WorkflowSearchModel
+    {
+        public string Id { get; set; }
+
+        public string WorkflowDefinitionId { get; set; }
+
+        public int Version { get; set; }
+
+        public string Description { get; set; }
+
+        public string Reference { get; set; }
+
+        public DateTime? NextExecutionUtc { get; set; }
+
+        public string Status { get; set; }
+
+        public Dictionary<string, object> Data { get; set; } = new Dictionary<string, object>();
+
+        public IEnumerable<string> DataTokens { get; set; }
+
+        public DateTime CreateTime { get; set; }
+
+        public DateTime? CompleteTime { get; set; }
+
+        public ICollection<StepInfo> WaitingSteps { get; set; } = new HashSet<StepInfo>();
+
+        public ICollection<StepInfo> SleepingSteps { get; set; } = new HashSet<StepInfo>();
+
+        public ICollection<StepInfo> FailedSteps { get; set; } = new HashSet<StepInfo>();
+
+        public WorkflowSearchResult ToSearchResult()
+        {
+            var result = new WorkflowSearchResult()
+            {
+                Id = Id,
+                CompleteTime = CompleteTime,
+                CreateTime = CreateTime,
+                Description = Description,
+                NextExecutionUtc = NextExecutionUtc,
+                Reference = Reference,
+                Status = (WorkflowStatus) Enum.Parse(typeof(WorkflowStatus), Status, true),
+                Version = Version,
+                WorkflowDefinitionId = WorkflowDefinitionId,
+                FailedSteps = FailedSteps,
+                SleepingSteps = SleepingSteps,
+                WaitingSteps = WaitingSteps
+            };
+
+            if (Data.Count > 0)
+                result.Data = Data.First().Value;
+
+            return result;
+        }
+
+        public static WorkflowSearchModel FromWorkflowInstance(WorkflowInstance workflow)
+        {
+            var result = new WorkflowSearchModel();
+
+            result.Id = workflow.Id;
+            result.WorkflowDefinitionId = workflow.WorkflowDefinitionId;
+            result.Description = workflow.Description;
+            result.Reference = workflow.Reference;
+
+            if (workflow.Data != null)
+                result.Data.Add(workflow.Data.GetType().FullName, workflow.Data);
+
+            result.CompleteTime = workflow.CompleteTime;
+            result.CreateTime = workflow.CreateTime;
+            result.Version = workflow.Version;
+            result.Status = workflow.Status.ToString();
+
+            if (workflow.NextExecution.HasValue)
+                result.NextExecutionUtc = new DateTime(workflow.NextExecution.Value);
+
+            if (workflow.Data is ISearchable)
+                result.DataTokens = (workflow.Data as ISearchable).GetSearchTokens();
+
+            foreach (var ep in workflow.ExecutionPointers)
+            {
+                if (ep.Status == PointerStatus.Sleeping)
+                {
+                    result.SleepingSteps.Add(new StepInfo()
+                    {
+                        StepId = ep.StepId,
+                        Name = ep.StepName
+                    });
+                }
+
+                if (ep.Status == PointerStatus.WaitingForEvent)
+                {
+                    result.WaitingSteps.Add(new StepInfo()
+                    {
+                        StepId = ep.StepId,
+                        Name = ep.StepName
+                    });
+                }
+
+                if (ep.Status == PointerStatus.Failed)
+                {
+                    result.FailedSteps.Add(new StepInfo()
+                    {
+                        StepId = ep.StepId,
+                        Name = ep.StepName
+                    });
+                }
+            }
+
+            return result;
+        }
+        
+    }
+
+    public class TypedWorkflowSearchModel<T> : WorkflowSearchModel
+    {
+        public new Dictionary<string, T> Data { get; set; }
+    }
+}

--- a/src/providers/WorkflowCore.Providers.Elasticsearch/README.md
+++ b/src/providers/WorkflowCore.Providers.Elasticsearch/README.md
@@ -1,0 +1,35 @@
+﻿# Elasticsearch plugin for Workflow Core
+
+...
+
+## Installing
+
+Install the NuGet package "WorkflowCore.Providers.Elasticsearch"
+
+Using Nuget package console
+    ```
+    PM> Install-Package WorkflowCore.Providers.Elasticsearch
+    ```
+Using .NET CLI
+    ```
+    dotnet add package WorkflowCore.Providers.Elasticsearch
+    ```
+
+
+## Configuration
+
+Use the `.UseElasticsearch` extension method on `IServiceCollection` when building your service provider
+
+```C#
+using Nest;
+...
+services.AddWorkflow(cfg =>
+{
+	...
+	cfg.UseElasticsearch(new ConnectionSettings(new Uri("http://localhost:9200")), "index_name");
+});
+```
+
+## Usage
+
+...

--- a/src/providers/WorkflowCore.Providers.Elasticsearch/README.md
+++ b/src/providers/WorkflowCore.Providers.Elasticsearch/README.md
@@ -1,19 +1,20 @@
 ﻿# Elasticsearch plugin for Workflow Core
 
-...
+A search index plugin for Workflow Core backed by Elasticsearch, enabling you to index your workflows and search against the data and state of them.
 
 ## Installing
 
 Install the NuGet package "WorkflowCore.Providers.Elasticsearch"
 
 Using Nuget package console
-    ```
-    PM> Install-Package WorkflowCore.Providers.Elasticsearch
-    ```
+```
+PM> Install-Package WorkflowCore.Providers.Elasticsearch
+```
+
 Using .NET CLI
-    ```
-    dotnet add package WorkflowCore.Providers.Elasticsearch
-    ```
+```
+dotnet add package WorkflowCore.Providers.Elasticsearch
+```
 
 
 ## Configuration
@@ -32,4 +33,100 @@ services.AddWorkflow(cfg =>
 
 ## Usage
 
-...
+Inject the `ISearchIndex` service into your code and use the `Search` method.
+
+```
+Search(string terms, int skip, int take, params SearchFilter[] filters)
+```
+
+#### terms
+
+A whitespace separated string of search terms, an empty string will match everything.
+This will do a full text search on the following default fields
+ * Reference
+ * Description
+ * Status
+ * Workflow Definition
+
+ In addition you can search data within your own custom data object if it implements `ISearchable`
+
+ ```c#
+ using WorkflowCore.Interfaces;
+ ...
+ public class MyData : ISearchable
+{
+    public string StrValue1 { get; set; }
+    public string StrValue2 { get; set; }
+
+    public IEnumerable<string> GetSearchTokens()
+    {
+        return new List<string>()
+        {
+            StrValue1,
+            StrValue2
+        };    
+    }
+}
+ ```
+
+ ##### Examples
+
+ Search all fields for "puppies"
+ ```c#
+ searchIndex.Search("puppies", 0, 10);
+ ```
+
+#### skip & take
+
+Use `skip` and `take` to page your search results.  Where `skip` is the result number to start from and `take` is the page size.
+
+#### filters
+
+You can also supply a list of filters to apply to the search, these can be applied to both the standard fields as well as any field within your custom data objects.
+There is no need to implement `ISearchable` on your data object in order to use filters against it.
+
+The following filter types are available
+ * ScalarFilter
+ * DateRangeFilter
+ * NumericRangeFilter
+ * StatusFilter
+
+ These exist in the `WorkflowCore.Models.Search` namespace.
+
+ ##### Examples
+
+ Filtering by reference
+ ```c#
+ using WorkflowCore.Models.Search;
+ ...
+
+ searchIndex.Search("", 0, 10, ScalarFilter.Equals(x => x.Reference, "My Reference"));
+ ```
+
+ Filtering by workflows started after a date
+ ```c#
+ searchIndex.Search("", 0, 10, DateRangeFilter.After(x => x.CreateTime, startDate));
+ ```
+
+ Filtering by workflows completed within a period
+ ```c#
+ searchIndex.Search("", 0, 10, DateRangeFilter.Between(x => x.CompleteTime, startDate, endDate));
+ ```
+
+ Filtering by workflows in a state
+ ```c#
+ searchIndex.Search("", 0, 10, StatusFilter.Equals(WorkflowStatus.Complete));
+ ```
+
+ Filtering against your own custom data class
+ ```c#
+
+ class MyData
+ {
+	public string Value1 { get; set; }
+	public int Value2 { get; set; }
+ }
+
+ searchIndex.Search("", 0, 10, ScalarFilter.Equals<MyData>(x => x.Data.Value1, "blue moon"));
+ searchIndex.Search("", 0, 10, NumericRangeFilter.LessThan<MyData>(x => x.Data.Value2, 5))
+ ```

--- a/src/providers/WorkflowCore.Providers.Elasticsearch/README.md
+++ b/src/providers/WorkflowCore.Providers.Elasticsearch/README.md
@@ -127,6 +127,6 @@ The following filter types are available
 	public int Value2 { get; set; }
  }
 
- searchIndex.Search("", 0, 10, ScalarFilter.Equals<MyData>(x => x.Data.Value1, "blue moon"));
- searchIndex.Search("", 0, 10, NumericRangeFilter.LessThan<MyData>(x => x.Data.Value2, 5))
+ searchIndex.Search("", 0, 10, ScalarFilter.Equals<MyData>(x => x.Value1, "blue moon"));
+ searchIndex.Search("", 0, 10, NumericRangeFilter.LessThan<MyData>(x => x.Value2, 5))
  ```

--- a/src/providers/WorkflowCore.Providers.Elasticsearch/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Providers.Elasticsearch/ServiceCollectionExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using Nest;
+using WorkflowCore.Models;
+using WorkflowCore.Providers.Elasticsearch.Services;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static WorkflowOptions UseElasticsearch(this WorkflowOptions options, ConnectionSettings settings, string indexName)
+        {
+            options.UseSearchIndex(sp => new ElasticsearchIndexer(settings, indexName, sp.GetService<ILoggerFactory>()));
+            return options;
+        }
+    }
+}

--- a/src/providers/WorkflowCore.Providers.Elasticsearch/Services/ElasticsearchIndexer.cs
+++ b/src/providers/WorkflowCore.Providers.Elasticsearch/Services/ElasticsearchIndexer.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.Extensions.Logging;
+using Nest;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using WorkflowCore.Models.Search;
+
+namespace WorkflowCore.Providers.Elasticsearch.Services
+{
+    public class ElasticsearchIndexer : ISearchIndex
+    {
+        private readonly ConnectionSettings _settings;
+        private readonly string _indexName;
+        private IElasticClient _client;
+
+        public ElasticsearchIndexer(ConnectionSettings settings, string indexName, ILoggerFactory loggerFactory)
+        {
+            _settings = settings;
+            _indexName = indexName;
+        }
+
+        public async Task IndexWorkflow(WorkflowInstance workflow)
+        {
+            if (_client == null)
+                throw new InvalidOperationException();
+
+            var denormModel = WorkflowSearchResult.FromWorkflowInstance(workflow);
+            await _client.IndexAsync(denormModel, x => x.Index(_indexName));
+        }
+
+        public async Task<Page<WorkflowSearchResult>> Search(string terms, int skip, int take)
+        {
+            if (_client == null)
+                throw new InvalidOperationException();
+
+            var result = await _client.SearchAsync<WorkflowSearchResult>(s => s
+                .Index(_indexName)
+                .Skip(skip)
+                .Take(take));
+
+            return new Page<WorkflowSearchResult>
+            {
+                Total = result.Total,
+                Data = result.Hits.Select(x => x.Source).ToList()
+            };
+        }
+
+        public Task Start()
+        {
+            _client = new ElasticClient(_settings);
+            return Task.CompletedTask;
+        }
+
+        public Task Stop()
+        {
+            _client = null;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/providers/WorkflowCore.Providers.Elasticsearch/WorkflowCore.Providers.Elasticsearch.csproj
+++ b/src/providers/WorkflowCore.Providers.Elasticsearch/WorkflowCore.Providers.Elasticsearch.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="NEST" Version="6.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\WorkflowCore\WorkflowCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/providers/WorkflowCore.Providers.Elasticsearch/WorkflowCore.Providers.Elasticsearch.csproj
+++ b/src/providers/WorkflowCore.Providers.Elasticsearch/WorkflowCore.Providers.Elasticsearch.csproj
@@ -2,11 +2,19 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>1.8.0</Version>
+    <PackageLicenseUrl>https://github.com/danielgerlag/workflow-core/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/danielgerlag/workflow-core</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/danielgerlag/workflow-core.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <Authors>Daniel Gerlag</Authors>
+    <Product>WorkflowCore</Product>
+    <Description>A search index plugin for Workflow Core backed by Elasticsearch, enabling you to index your workflows and search against the data and state of them.</Description>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
-    <PackageReference Include="NEST" Version="6.4.1" />
+    <PackageReference Include="NEST" Version="6.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/samples/WorkflowCore.Sample03/MyDataClass.cs
+++ b/src/samples/WorkflowCore.Sample03/MyDataClass.cs
@@ -1,16 +1,25 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using WorkflowCore.Interface;
 
 namespace WorkflowCore.Sample03
 {
-    public class MyDataClass
+    public class MyDataClass : ISearchable
     {
         public int Value1 { get; set; }
 
         public int Value2 { get; set; }
 
         public int Value3 { get; set; }
+
+        public string ValueStr { get; set; }
+
+        public IEnumerable<string> GetSearchTokens()
+        {
+            yield return ValueStr;
+        }
     }
 }

--- a/src/samples/WorkflowCore.Sample03/MyDataClass.cs
+++ b/src/samples/WorkflowCore.Sample03/MyDataClass.cs
@@ -7,7 +7,7 @@ using WorkflowCore.Interface;
 
 namespace WorkflowCore.Sample03
 {
-    public class MyDataClass : ISearchable
+    public class MyDataClass
     {
         public int Value1 { get; set; }
 
@@ -15,11 +15,5 @@ namespace WorkflowCore.Sample03
 
         public int Value3 { get; set; }
 
-        public string ValueStr { get; set; }
-
-        public IEnumerable<string> GetSearchTokens()
-        {
-            yield return ValueStr;
-        }
     }
 }

--- a/src/samples/WorkflowCore.Sample04/EventSampleWorkflow.cs
+++ b/src/samples/WorkflowCore.Sample04/EventSampleWorkflow.cs
@@ -19,9 +19,9 @@ namespace WorkflowCore.Sample04
             builder
                 .StartWith(context => ExecutionResult.Next())
                 .WaitFor("MyEvent", (data, context) => context.Workflow.Id, data => DateTime.Now)
-                    .Output(data => data.StrValue, step => step.EventData)
+                    .Output(data => data.Value1, step => step.EventData)
                 .Then<CustomMessage>()
-                    .Input(step => step.Message, data => "The data from the event is " + data.StrValue)
+                    .Input(step => step.Message, data => "The data from the event is " + data.Value1)
                 .Then(context => Console.WriteLine("workflow complete"));
         }
     }

--- a/src/samples/WorkflowCore.Sample04/MyDataClass.cs
+++ b/src/samples/WorkflowCore.Sample04/MyDataClass.cs
@@ -7,6 +7,6 @@ namespace WorkflowCore.Sample04
 {
     public class MyDataClass
     {
-        public string StrValue { get; set; }
+        public string Value1 { get; set; }
     }
 }

--- a/src/samples/WorkflowCore.Sample07/web.config
+++ b/src/samples/WorkflowCore.Sample07/web.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-
   <!--
     Configure your application settings in appsettings.json. Learn more at http://go.microsoft.com/fwlink/?LinkId=786380
   -->
-
   <system.webServer>
     <handlers>
-      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false">
+      <environmentVariables />
+    </aspNetCore>
   </system.webServer>
 </configuration>

--- a/test/ScratchPad/Program.cs
+++ b/test/ScratchPad/Program.cs
@@ -30,7 +30,11 @@ namespace ScratchPad
             host.Start();
             //host.StartWorkflow<object>("HelloWorld", null, "ref1").Wait();
 
-            var searchResult = searchIndex.Search("ref2", 0, 10).Result;
+            var searchResult1 = searchIndex.Search("ref1", 0, 10).Result;
+            var searchResult2 = searchIndex.Search("ref2", 0, 10).Result;
+            var searchResult3 = searchIndex.Search("HelloWorld", 0, 10).Result;
+            var searchResult4 = searchIndex.Search("fox", 0, 10).Result;
+            var searchResult5 = searchIndex.Search("dog", 0, 10).Result;
 
             Console.ReadLine();
             host.Stop();

--- a/test/ScratchPad/Program.cs
+++ b/test/ScratchPad/Program.cs
@@ -12,6 +12,7 @@ using Amazon;
 using Amazon.DynamoDBv2;
 using Amazon.Runtime;
 using Nest;
+using WorkflowCore.Models.Search;
 
 namespace ScratchPad
 {
@@ -30,7 +31,7 @@ namespace ScratchPad
             host.Start();
             //host.StartWorkflow<object>("HelloWorld", null, "ref1").Wait();
 
-            var searchResult1 = searchIndex.Search("ref1", 0, 10).Result;
+            var searchResult1 = searchIndex.Search("ref1", 0, 10, CreateDateFilter.Between(new DateTime(2020, 1, 1), new DateTime(2021, 1, 1))).Result;
             var searchResult2 = searchIndex.Search("ref2", 0, 10).Result;
             var searchResult3 = searchIndex.Search("HelloWorld", 0, 10).Result;
             var searchResult4 = searchIndex.Search("fox", 0, 10).Result;
@@ -56,6 +57,7 @@ namespace ScratchPad
                 //cfg.UseAwsDynamoLocking(new EnvironmentVariablesAWSCredentials(), new AmazonDynamoDBConfig() { RegionEndpoint = RegionEndpoint.USWest2 }, "workflow-core-locks");
             });
 
+            services.AddTransient<WorkflowCore.Sample01.Steps.GoodbyeWorld>();
 
             var serviceProvider = services.BuildServiceProvider();
 

--- a/test/ScratchPad/Program.cs
+++ b/test/ScratchPad/Program.cs
@@ -11,6 +11,7 @@ using System.Text;
 using Amazon;
 using Amazon.DynamoDBv2;
 using Amazon.Runtime;
+using Nest;
 
 namespace ScratchPad
 {
@@ -18,36 +19,21 @@ namespace ScratchPad
     {
         public static void Main(string[] args)
         {
-            //var s = typeof(HelloWorld).AssemblyQualifiedName;
-
-
             IServiceProvider serviceProvider = ConfigureServices();
 
             //start the workflow host
             var host = serviceProvider.GetService<IWorkflowHost>();
-            var persistence = serviceProvider.GetService<IPersistenceProvider>();
+            var searchIndex = serviceProvider.GetService<ISearchIndex>();
 
-            var wf = new WorkflowInstance()
-            {
-                Description = "test",
-                CreateTime = DateTime.UtcNow,
-                Status = WorkflowStatus.Terminated,
-                Version = 1,
-                WorkflowDefinitionId = "def"
-            };
-            var id = persistence.CreateNewWorkflow(wf).Result;
+            host.RegisterWorkflow<WorkflowCore.Sample01.HelloWorldWorkflow>();
 
-            //var loader = serviceProvider.GetService<IDefinitionLoader>();
-            //var str = ScratchPad.Properties.Resources.HelloWorld; //Encoding.UTF8.GetString(ScratchPad.Properties.Resources.HelloWorld);
-            //loader.LoadDefinition(str);
-            //host.RegisterWorkflow<HelloWorldWorkflow>();
-            //host.Start();
+            host.Start();
+            //host.StartWorkflow<object>("HelloWorld", null, "ref1").Wait();
 
-            //host.StartWorkflow("HelloWorld", 1, new MyDataClass() { Value3 = "hi there" });
-
+            var searchResult = searchIndex.Search("ref2", 0, 10).Result;
 
             Console.ReadLine();
-            //host.Stop();
+            host.Stop();
         }
 
         private static IServiceProvider ConfigureServices()
@@ -59,14 +45,13 @@ namespace ScratchPad
             //services.AddWorkflow(x => x.UseMongoDB(@"mongodb://localhost:27017", "workflow"));
             services.AddWorkflow(cfg =>
             {
-                var ddbConfig = new AmazonDynamoDBConfig() { RegionEndpoint = RegionEndpoint.USWest2 };
-                cfg.UseAwsDynamoPersistence(new EnvironmentVariablesAWSCredentials(), ddbConfig, "sample31");
+                //var ddbConfig = new AmazonDynamoDBConfig() { RegionEndpoint = RegionEndpoint.USWest2 };
+                //cfg.UseAwsDynamoPersistence(new EnvironmentVariablesAWSCredentials(), ddbConfig, "elastic");
+                cfg.UseElasticsearch(new ConnectionSettings(new Uri("http://localhost:9200")), "workflows");
                 //cfg.UseAwsSimpleQueueService(new EnvironmentVariablesAWSCredentials(), new AmazonSQSConfig() { RegionEndpoint = RegionEndpoint.USWest2 });
                 //cfg.UseAwsDynamoLocking(new EnvironmentVariablesAWSCredentials(), new AmazonDynamoDBConfig() { RegionEndpoint = RegionEndpoint.USWest2 }, "workflow-core-locks");
             });
 
-
-            services.AddTransient<GoodbyeWorld>();
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -77,62 +62,6 @@ namespace ScratchPad
         }
 
     }
-
-    public class HelloWorld : StepBody
-    {
-        public override ExecutionResult Run(IStepExecutionContext context)
-        {
-            Console.WriteLine("Hello world");
-            return ExecutionResult.Next();
-        }
-    }
-    public class GoodbyeWorld : StepBody
-    {
-        public override ExecutionResult Run(IStepExecutionContext context)
-        {
-            Console.WriteLine("Goodbye world");
-            return ExecutionResult.Next();
-        }
-    }
-
-    public class Throw : StepBody
-    {
-        public override ExecutionResult Run(IStepExecutionContext context)
-        {
-            Console.WriteLine("throwing...");
-            throw new Exception("up");
-        }
-    }
-
-    public class PrintMessage : StepBody
-    {
-        public string Message { get; set; }
-
-        public override ExecutionResult Run(IStepExecutionContext context)
-        {
-            Console.WriteLine(Message);
-            return ExecutionResult.Next();
-        }
-    }
-
-    public class GenerateMessage : StepBody
-    {
-        public string Message { get; set; }
-
-        public override ExecutionResult Run(IStepExecutionContext context)
-        {
-            Message = "Generated message";
-            return ExecutionResult.Next();
-        }
-    }
-
-    public class MyDataClass
-    {
-        public int Value1 { get; set; }
-
-        public int Value2 { get; set; }
-
-        public string Value3 { get; set; }
-    }
+        
 }
 

--- a/test/ScratchPad/Program.cs
+++ b/test/ScratchPad/Program.cs
@@ -26,16 +26,32 @@ namespace ScratchPad
             var host = serviceProvider.GetService<IWorkflowHost>();
             var searchIndex = serviceProvider.GetService<ISearchIndex>();
 
-            host.RegisterWorkflow<WorkflowCore.Sample01.HelloWorldWorkflow>();
+            host.RegisterWorkflow<WorkflowCore.Sample03.PassingDataWorkflow, WorkflowCore.Sample03.MyDataClass>();
+            host.RegisterWorkflow<WorkflowCore.Sample04.EventSampleWorkflow, WorkflowCore.Sample04.MyDataClass>();
 
             host.Start();
-            //host.StartWorkflow<object>("HelloWorld", null, "ref1").Wait();
+            //var data = new WorkflowCore.Sample03.MyDataClass() { ValueStr = "blue moon", Value1 = 2, Value2 = 3 };
+            //host.StartWorkflow<object>("PassingDataWorkflow", data, "pass2").Wait();
 
-            var searchResult1 = searchIndex.Search("ref1", 0, 10, CreateDateFilter.Between(new DateTime(2020, 1, 1), new DateTime(2021, 1, 1))).Result;
+            //var data = new WorkflowCore.Sample04.MyDataClass() { StrValue = "test" };
+            //host.StartWorkflow("EventSampleWorkflow", data, "alt1").Wait();
+
+            var searchResult1 = searchIndex.Search("ref1", 0, 10, DateRangeFilter.Between(x => x.CompleteTime, new DateTime(2018, 1, 1), new DateTime(2021, 1, 1))).Result;
             var searchResult2 = searchIndex.Search("ref2", 0, 10).Result;
-            var searchResult3 = searchIndex.Search("HelloWorld", 0, 10).Result;
+            var searchResult3 = searchIndex.Search("PassingDataWorkflow", 0, 10).Result;
             var searchResult4 = searchIndex.Search("fox", 0, 10).Result;
-            var searchResult5 = searchIndex.Search("dog", 0, 10).Result;
+            var searchResult5 = searchIndex.Search("dogs", 0, 10).Result;
+            var searchResult6 = searchIndex.Search("", 0, 10).Result;
+            var searchResult7 = searchIndex.Search("", 0, 10, ScalarFilter.Equals(x => x.Reference, "pass1")).Result;
+            var searchResult8 = searchIndex.Search("", 0, 10, DateRangeFilter.Between(x => x.CompleteTime, new DateTime(2018, 1, 1), new DateTime(2021, 1, 1))).Result;
+            var searchResult9 = searchIndex.Search("", 0, 10, ScalarFilter.Equals<WorkflowCore.Sample03.MyDataClass>(x => x.Data.ValueStr, "blue moon")).Result;
+            var searchResult10 = searchIndex.Search("", 0, 10, ScalarFilter.Equals<WorkflowCore.Sample03.MyDataClass>(x => x.Data.Value1, 0)).Result;
+            var searchResult11 = searchIndex.Search("", 0, 10, ScalarFilter.Equals<WorkflowCore.Sample04.MyDataClass>(x => x.Data.StrValue, "test")).Result;
+
+            var searchResult12 = searchIndex.Search("", 0, 10, StatusFilter.Equals(WorkflowStatus.Runnable)).Result;
+            var searchResult13 = searchIndex.Search("", 0, 10, StatusFilter.Equals(WorkflowStatus.Complete)).Result;
+
+            var searchResult14 = searchIndex.Search("", 0, 10, NumericRangeFilter.LessThan<WorkflowCore.Sample03.MyDataClass>(x => x.Data.Value1, 6)).Result;
 
             Console.ReadLine();
             host.Stop();

--- a/test/ScratchPad/Program.cs
+++ b/test/ScratchPad/Program.cs
@@ -30,18 +30,18 @@ namespace ScratchPad
             host.RegisterWorkflow<WorkflowCore.Sample04.EventSampleWorkflow, WorkflowCore.Sample04.MyDataClass>();
 
             host.Start();
-            //var data1 = new WorkflowCore.Sample03.MyDataClass() { Value1 = 2, Value2 = 3 };
-            //host.StartWorkflow("PassingDataWorkflow", data1, "quick dog").Wait();
+            var data1 = new WorkflowCore.Sample03.MyDataClass() { Value1 = 2, Value2 = 3 };
+            host.StartWorkflow("PassingDataWorkflow", data1, "quick dog").Wait();
 
-            //var data2 = new WorkflowCore.Sample04.MyDataClass() { Value1 = "test" };
-            //host.StartWorkflow("EventSampleWorkflow", data2, "alt1 boom").Wait();
+            var data2 = new WorkflowCore.Sample04.MyDataClass() { Value1 = "test" };
+            host.StartWorkflow("EventSampleWorkflow", data2, "alt1 boom").Wait();
 
 
             var searchResult1 = searchIndex.Search("dog", 0, 10).Result;
             var searchResult2 = searchIndex.Search("quick dog", 0, 10).Result;
-            var searchResult3 = searchIndex.Search("quick", 0, 10).Result;
+            var searchResult3 = searchIndex.Search("fast", 0, 10).Result;
             var searchResult4 = searchIndex.Search("alt1", 0, 10).Result;
-            var searchResult5 = searchIndex.Search("slow", 0, 10).Result;
+            var searchResult5 = searchIndex.Search("dogs", 0, 10).Result;
             var searchResult6 = searchIndex.Search("test", 0, 10).Result;
             var searchResult7 = searchIndex.Search("", 0, 10).Result;
             var searchResult8 = searchIndex.Search("", 0, 10, ScalarFilter.Equals(x => x.Reference, "quick dog")).Result;

--- a/test/ScratchPad/Program.cs
+++ b/test/ScratchPad/Program.cs
@@ -30,28 +30,22 @@ namespace ScratchPad
             host.RegisterWorkflow<WorkflowCore.Sample04.EventSampleWorkflow, WorkflowCore.Sample04.MyDataClass>();
 
             host.Start();
-            //var data = new WorkflowCore.Sample03.MyDataClass() { ValueStr = "blue moon", Value1 = 2, Value2 = 3 };
-            //host.StartWorkflow<object>("PassingDataWorkflow", data, "pass2").Wait();
+            //var data1 = new WorkflowCore.Sample03.MyDataClass() { Value1 = 2, Value2 = 3 };
+            //host.StartWorkflow("PassingDataWorkflow", data1, "quick dog").Wait();
 
-            //var data = new WorkflowCore.Sample04.MyDataClass() { StrValue = "test" };
-            //host.StartWorkflow("EventSampleWorkflow", data, "alt1").Wait();
+            //var data2 = new WorkflowCore.Sample04.MyDataClass() { Value1 = "test" };
+            //host.StartWorkflow("EventSampleWorkflow", data2, "alt1 boom").Wait();
 
-            var searchResult1 = searchIndex.Search("ref1", 0, 10, DateRangeFilter.Between(x => x.CompleteTime, new DateTime(2018, 1, 1), new DateTime(2021, 1, 1))).Result;
-            var searchResult2 = searchIndex.Search("ref2", 0, 10).Result;
-            var searchResult3 = searchIndex.Search("PassingDataWorkflow", 0, 10).Result;
-            var searchResult4 = searchIndex.Search("fox", 0, 10).Result;
-            var searchResult5 = searchIndex.Search("dogs", 0, 10).Result;
-            var searchResult6 = searchIndex.Search("", 0, 10).Result;
-            var searchResult7 = searchIndex.Search("", 0, 10, ScalarFilter.Equals(x => x.Reference, "pass1")).Result;
-            var searchResult8 = searchIndex.Search("", 0, 10, DateRangeFilter.Between(x => x.CompleteTime, new DateTime(2018, 1, 1), new DateTime(2021, 1, 1))).Result;
-            var searchResult9 = searchIndex.Search("", 0, 10, ScalarFilter.Equals<WorkflowCore.Sample03.MyDataClass>(x => x.Data.ValueStr, "blue moon")).Result;
-            var searchResult10 = searchIndex.Search("", 0, 10, ScalarFilter.Equals<WorkflowCore.Sample03.MyDataClass>(x => x.Data.Value1, 0)).Result;
-            var searchResult11 = searchIndex.Search("", 0, 10, ScalarFilter.Equals<WorkflowCore.Sample04.MyDataClass>(x => x.Data.StrValue, "test")).Result;
 
-            var searchResult12 = searchIndex.Search("", 0, 10, StatusFilter.Equals(WorkflowStatus.Runnable)).Result;
-            var searchResult13 = searchIndex.Search("", 0, 10, StatusFilter.Equals(WorkflowStatus.Complete)).Result;
-
-            var searchResult14 = searchIndex.Search("", 0, 10, NumericRangeFilter.LessThan<WorkflowCore.Sample03.MyDataClass>(x => x.Data.Value1, 6)).Result;
+            var searchResult1 = searchIndex.Search("dog", 0, 10).Result;
+            var searchResult2 = searchIndex.Search("quick dog", 0, 10).Result;
+            var searchResult3 = searchIndex.Search("quick", 0, 10).Result;
+            var searchResult4 = searchIndex.Search("alt1", 0, 10).Result;
+            var searchResult5 = searchIndex.Search("slow", 0, 10).Result;
+            var searchResult6 = searchIndex.Search("test", 0, 10).Result;
+            var searchResult7 = searchIndex.Search("", 0, 10).Result;
+            var searchResult8 = searchIndex.Search("", 0, 10, ScalarFilter.Equals(x => x.Reference, "quick dog")).Result;
+            var searchResult9 = searchIndex.Search("", 0, 10, ScalarFilter.Equals<WorkflowCore.Sample03.MyDataClass>(x => x.Value1, 2)).Result;
 
             Console.ReadLine();
             host.Stop();

--- a/test/ScratchPad/ScratchPad.csproj
+++ b/test/ScratchPad/ScratchPad.csproj
@@ -14,6 +14,11 @@
     <ProjectReference Include="..\..\src\providers\WorkflowCore.Persistence.PostgreSQL\WorkflowCore.Persistence.PostgreSQL.csproj" />
     <ProjectReference Include="..\..\src\providers\WorkflowCore.Persistence.SqlServer\WorkflowCore.Persistence.SqlServer.csproj" />
     <ProjectReference Include="..\..\src\providers\WorkflowCore.Providers.AWS\WorkflowCore.Providers.AWS.csproj" />
+    <ProjectReference Include="..\..\src\providers\WorkflowCore.Providers.Elasticsearch\WorkflowCore.Providers.Elasticsearch.csproj" />
+    <ProjectReference Include="..\..\src\samples\WorkflowCore.Sample01\WorkflowCore.Sample01.csproj" />
+    <ProjectReference Include="..\..\src\samples\WorkflowCore.Sample02\WorkflowCore.Sample02.csproj" />
+    <ProjectReference Include="..\..\src\samples\WorkflowCore.Sample03\WorkflowCore.Sample03.csproj" />
+    <ProjectReference Include="..\..\src\samples\WorkflowCore.Sample04\WorkflowCore.Sample04.csproj" />
     <ProjectReference Include="..\..\src\WorkflowCore\WorkflowCore.csproj" />
   </ItemGroup>
 

--- a/test/WorkflowCore.IntegrationTests/SearchIndexTests.cs
+++ b/test/WorkflowCore.IntegrationTests/SearchIndexTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+
+namespace WorkflowCore.IntegrationTests
+{
+    public abstract class SearchIndexTests
+    {
+        protected abstract ISearchIndex CreateService();
+        protected ISearchIndex Subject { get; set; }
+
+        protected IEnumerable<WorkflowInstance> BuildTestData()
+        {
+            var result = new List<WorkflowInstance>();
+
+            result.Add(new WorkflowInstance()
+            {
+                Id = "1",
+                CreateTime = new DateTime(2000, 1, 1),
+                Status = WorkflowStatus.Runnable,
+                Reference = "ref1"
+            });
+
+            result.Add(new WorkflowInstance()
+            {
+                Id = "2",
+                CreateTime = new DateTime(2000, 1, 1),
+                Status = WorkflowStatus.Runnable,
+                Reference = "ref2",
+                Data = new DataObject()
+                {
+                    IntValue = 7
+                }
+            });
+
+            result.Add(new WorkflowInstance()
+            {
+                Id = "3",
+                CreateTime = new DateTime(2000, 1, 1),
+                Status = WorkflowStatus.Complete,
+                Reference = "ref3",
+                Data = new DataObject()
+                {
+                    IntValue = 5,
+                    StrValue1 = "quick fox",
+                    StrValue2 = "lazy dog" 
+                }
+            });
+
+            return result;
+        }
+
+        [OneTimeSetUp]
+        public async void Setup()
+        {
+            Subject = CreateService();
+            await Subject.Start();
+
+            foreach (var item in BuildTestData())
+                await Subject.IndexWorkflow(item);
+        }
+
+        [Test]
+        public async void should_search_on_reference()
+        {
+            var result1 = await Subject.Search("ref1", 0, 10);
+            var result2 = await Subject.Search("ref2", 0, 10);
+
+            
+        }
+
+        class DataObject : ISearchable
+        {
+            public string StrValue1 { get; set; }
+            public string StrValue2 { get; set; }
+
+            public int IntValue { get; set; }
+
+            public IEnumerable<string> GetSearchTokens()
+            {
+                return new List<string>()
+                {
+                    StrValue1,
+                    StrValue2
+                };    
+            }
+        }
+    }
+}

--- a/test/WorkflowCore.IntegrationTests/SearchIndexTests.cs
+++ b/test/WorkflowCore.IntegrationTests/SearchIndexTests.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using FluentAssertions;
+using FluentAssertions.Collections;
+using FluentAssertions.Equivalency;
+using FluentAssertions.Common;
 using NUnit.Framework;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
+using WorkflowCore.Models.Search;
 
 namespace WorkflowCore.IntegrationTests
 {
@@ -19,7 +23,7 @@ namespace WorkflowCore.IntegrationTests
             result.Add(new WorkflowInstance()
             {
                 Id = "1",
-                CreateTime = new DateTime(2000, 1, 1),
+                CreateTime = new DateTime(2010, 1, 1),
                 Status = WorkflowStatus.Runnable,
                 Reference = "ref1"
             });
@@ -27,7 +31,7 @@ namespace WorkflowCore.IntegrationTests
             result.Add(new WorkflowInstance()
             {
                 Id = "2",
-                CreateTime = new DateTime(2000, 1, 1),
+                CreateTime = new DateTime(2020, 1, 1),
                 Status = WorkflowStatus.Runnable,
                 Reference = "ref2",
                 Data = new DataObject()
@@ -39,7 +43,7 @@ namespace WorkflowCore.IntegrationTests
             result.Add(new WorkflowInstance()
             {
                 Id = "3",
-                CreateTime = new DateTime(2000, 1, 1),
+                CreateTime = new DateTime(2010, 1, 1),
                 Status = WorkflowStatus.Complete,
                 Reference = "ref3",
                 Data = new DataObject()
@@ -69,7 +73,63 @@ namespace WorkflowCore.IntegrationTests
             var result1 = await Subject.Search("ref1", 0, 10);
             var result2 = await Subject.Search("ref2", 0, 10);
 
-            
+            result1.Data.Should().Contain(x => x.Id == "1");
+            result1.Data.Should().NotContain(x => x.Id == "2");
+            result1.Data.Should().NotContain(x => x.Id == "3");
+
+            result2.Data.Should().NotContain(x => x.Id == "1");
+            result2.Data.Should().Contain(x => x.Id == "2");
+            result2.Data.Should().NotContain(x => x.Id == "3");
+        }
+        
+        [Test]
+        public async void should_search_on_custom_data()
+        {
+            var result = await Subject.Search("dog fox", 0, 10);
+
+            result.Data.Should().NotContain(x => x.Id == "1");
+            result.Data.Should().NotContain(x => x.Id == "2");
+            result.Data.Should().Contain(x => x.Id == "3");
+        }
+
+        [Test]
+        public async void should_filter_on_custom_data()
+        {
+            var result = await Subject.Search(null, 0, 10, ScalarFilter.Equals<DataObject>(x => x.Data.IntValue, 7));
+
+            result.Data.Should().NotContain(x => x.Id == "1");
+            result.Data.Should().Contain(x => x.Id == "2");
+            result.Data.Should().NotContain(x => x.Id == "3");
+        }
+
+        [Test]
+        public async void should_filter_on_reference()
+        {
+            var result = await Subject.Search(null, 0, 10, ScalarFilter.Equals(x => x.Reference, "ref2"));
+
+            result.Data.Should().NotContain(x => x.Id == "1");
+            result.Data.Should().Contain(x => x.Id == "2");
+            result.Data.Should().NotContain(x => x.Id == "3");
+        }
+
+        [Test]
+        public async void should_filter_on_status()
+        {
+            var result = await Subject.Search(null, 0, 10, StatusFilter.Equals(WorkflowStatus.Runnable));
+
+            result.Data.Should().NotContain(x => x.Status != WorkflowStatus.Runnable.ToString());
+            result.Data.Should().Contain(x => x.Status == WorkflowStatus.Runnable.ToString());
+        }
+
+        [Test]
+        public async void should_filter_on_date_range()
+        {
+            var start = new DateTime(2000, 1, 1);
+            var end = new DateTime(2015, 1, 1);
+            var result = await Subject.Search(null, 0, 10, DateRangeFilter.Between(x => x.CreateTime, start, end));
+
+            result.Data.Should().NotContain(x => x.CreateTime < start || x.CreateTime > end);
+            result.Data.Should().Contain(x => x.CreateTime > start && x.CreateTime < end);
         }
 
         class DataObject : ISearchable

--- a/test/WorkflowCore.Tests.Elasticsearch/ElasticsearchDockerSetup.cs
+++ b/test/WorkflowCore.Tests.Elasticsearch/ElasticsearchDockerSetup.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using Docker.Testify;
+using Nest;
+using Xunit;
+
+namespace WorkflowCore.Tests.Elasticsearch
+{
+    public class ElasticsearchDockerSetup : DockerSetup
+    {
+        public static string ConnectionString { get; set; }
+        
+        public override string ImageName => @"elasticsearch";
+        public override string ImageTag => "6.5.4";
+        public override int InternalPort => 9200;
+
+        public override void PublishConnectionInfo()
+        {
+            ConnectionString = $"http://localhost:{ExternalPort}";
+        }
+
+        public override bool TestReady()
+        {
+            try
+            {
+                var client = new ElasticClient(new ConnectionSettings(new Uri($"http://localhost:{ExternalPort}")));
+                var ping = client.Ping();
+                return ping.IsValid;
+            }
+            catch
+            {
+                return false;
+            }
+
+        }
+    }
+
+    [CollectionDefinition("Elasticsearch collection")]
+    public class DynamoDbCollection : ICollectionFixture<ElasticsearchDockerSetup>
+    {
+    }
+}

--- a/test/WorkflowCore.Tests.Elasticsearch/ElasticsearchIndexerTests.cs
+++ b/test/WorkflowCore.Tests.Elasticsearch/ElasticsearchIndexerTests.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Nest;
+using WorkflowCore.IntegrationTests;
+using WorkflowCore.Interface;
+using WorkflowCore.Providers.Elasticsearch.Services;
+using Xunit;
+
+namespace WorkflowCore.Tests.Elasticsearch
+{
+    [Collection("Elasticsearch collection")]
+    public class ElasticsearchIndexerTests : SearchIndexTests
+    {
+        ElasticsearchDockerSetup _dockerSetup;
+
+        public ElasticsearchIndexerTests(ElasticsearchDockerSetup dockerSetup)
+        {
+            _dockerSetup = dockerSetup;
+        }
+
+        protected override ISearchIndex CreateService()
+        {
+            var settings = new ConnectionSettings(new Uri(ElasticsearchDockerSetup.ConnectionString));
+            return new ElasticsearchIndexer(settings, "workflowcore.tests", new LoggerFactory());
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.Elasticsearch/WorkflowCore.Tests.Elasticsearch.csproj
+++ b/test/WorkflowCore.Tests.Elasticsearch/WorkflowCore.Tests.Elasticsearch.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NEST" Version="6.4.2" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\providers\WorkflowCore.Providers.Elasticsearch\WorkflowCore.Providers.Elasticsearch.csproj" />
+    <ProjectReference Include="..\Docker.Testify\Docker.Testify.csproj" />
+    <ProjectReference Include="..\WorkflowCore.IntegrationTests\WorkflowCore.IntegrationTests.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
# Elasticsearch plugin for Workflow Core

A search index plugin for Workflow Core backed by Elasticsearch, enabling you to index your workflows and search against the data and state of them.

## Configuration

Use the `.UseElasticsearch` extension method on `IServiceCollection` when building your service provider

```C#
using Nest;
...
services.AddWorkflow(cfg =>
{
	...
	cfg.UseElasticsearch(new ConnectionSettings(new Uri("http://localhost:9200")), "index_name");
});
```

## Usage

Inject the `ISearchIndex` service into your code and use the `Search` method.

```
Search(string terms, int skip, int take, params SearchFilter[] filters)
```

#### terms

A whitespace separated string of search terms, an empty string will match everything.
This will do a full text search on the following default fields
 * Reference
 * Description
 * Status
 * Workflow Definition

 In addition you can search data within your own custom data object if it implements `ISearchable`

 ```c#
 using WorkflowCore.Interfaces;
 ...
 public class MyData : ISearchable
{
    public string StrValue1 { get; set; }
    public string StrValue2 { get; set; }

    public IEnumerable<string> GetSearchTokens()
    {
        return new List<string>()
        {
            StrValue1,
            StrValue2
        };    
    }
}
 ```

 ##### Examples

 Search all fields for "puppies"
 ```c#
 searchIndex.Search("puppies", 0, 10);
 ```

#### skip & take

Use `skip` and `take` to page your search results.  Where `skip` is the result number to start from and `take` is the page size.

#### filters

You can also supply a list of filters to apply to the search, these can be applied to both the standard fields as well as any field within your custom data objects.
There is no need to implement `ISearchable` on your data object in order to use filters against it.

The following filter types are available
 * ScalarFilter
 * DateRangeFilter
 * NumericRangeFilter
 * StatusFilter

 These exist in the `WorkflowCore.Models.Search` namespace.

 ##### Examples

 Filtering by reference
 ```c#
 using WorkflowCore.Models.Search;
 ...

 searchIndex.Search("", 0, 10, ScalarFilter.Equals(x => x.Reference, "My Reference"));
 ```

 Filtering by workflows started after a date
 ```c#
 searchIndex.Search("", 0, 10, DateRangeFilter.After(x => x.CreateTime, startDate));
 ```

 Filtering by workflows completed within a period
 ```c#
 searchIndex.Search("", 0, 10, DateRangeFilter.Between(x => x.CompleteTime, startDate, endDate));
 ```

 Filtering by workflows in a state
 ```c#
 searchIndex.Search("", 0, 10, StatusFilter.Equals(WorkflowStatus.Complete));
 ```

 Filtering against your own custom data class
 ```c#

 class MyData
 {
	public string Value1 { get; set; }
	public int Value2 { get; set; }
 }

 searchIndex.Search("", 0, 10, ScalarFilter.Equals<MyData>(x => x.Value1, "blue moon"));
 searchIndex.Search("", 0, 10, NumericRangeFilter.LessThan<MyData>(x => x.Value2, 5))
 ```
