### PR TITLE
Enhanced to allow scoped dependencies to be injected into steps

### DIFF
--- a/src/WorkflowCore/Interface/IScopeProvider.cs
+++ b/src/WorkflowCore/Interface/IScopeProvider.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace WorkflowCore.Interface
+{
+    /// <remarks>
+    /// The implemention of this interface will be responsible for
+    /// providing a new service scope for a DI container   
+    /// </remarks>
+    public interface IScopeProvider
+    {
+        /// <summary>
+        /// Create a new service scope
+        /// </summary>
+        /// <returns></returns>
+        IServiceScope CreateScope();
+    }
+}

--- a/src/WorkflowCore/ServiceCollectionExtensions.cs
+++ b/src/WorkflowCore/ServiceCollectionExtensions.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddSingleton<IWorkflowController, WorkflowController>();
             services.AddSingleton<IWorkflowHost, WorkflowHost>();
+            services.AddTransient<IScopeProvider, ScopeProvider>();
             services.AddTransient<IWorkflowExecutor, WorkflowExecutor>();
             services.AddTransient<ICancellationProcessor, CancellationProcessor>();
             services.AddTransient<IWorkflowBuilder, WorkflowBuilder>();

--- a/src/WorkflowCore/Services/ScopeProvider.cs
+++ b/src/WorkflowCore/Services/ScopeProvider.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using WorkflowCore.Interface;
+
+namespace WorkflowCore.Services
+{
+    /// <summary>
+    /// A concrete implementation for the IScopeProvider interface
+    /// Largely to get around the problems of unit testing an extension method (CreateScope())
+    /// </summary>
+    public class ScopeProvider : IScopeProvider
+    {
+        private readonly IServiceProvider provider;
+
+        public ScopeProvider(IServiceProvider provider)
+        {
+            this.provider = provider;
+        }
+
+        public IServiceScope CreateScope()
+        {
+            return provider.CreateScope();
+        }
+    }
+}

--- a/src/WorkflowCore/Services/WorkflowExecutor.cs
+++ b/src/WorkflowCore/Services/WorkflowExecutor.cs
@@ -14,6 +14,7 @@ namespace WorkflowCore.Services
     {
         protected readonly IWorkflowRegistry _registry;
         protected readonly IServiceProvider _serviceProvider;
+        protected readonly IScopeProvider _scopeProvider;
         protected readonly IDateTimeProvider _datetimeProvider;
         protected readonly ILogger _logger;
         private readonly IExecutionResultProcessor _executionResultProcessor;
@@ -23,9 +24,10 @@ namespace WorkflowCore.Services
 
         private IWorkflowHost Host => _serviceProvider.GetService<IWorkflowHost>();
 
-        public WorkflowExecutor(IWorkflowRegistry registry, IServiceProvider serviceProvider, IDateTimeProvider datetimeProvider, IExecutionResultProcessor executionResultProcessor, ILifeCycleEventPublisher publisher, ICancellationProcessor cancellationProcessor, WorkflowOptions options, ILoggerFactory loggerFactory)
+        public WorkflowExecutor(IWorkflowRegistry registry, IServiceProvider serviceProvider, IScopeProvider scopeProvider, IDateTimeProvider datetimeProvider, IExecutionResultProcessor executionResultProcessor, ILifeCycleEventPublisher publisher, ICancellationProcessor cancellationProcessor, WorkflowOptions options, ILoggerFactory loggerFactory)
         {
             _serviceProvider = serviceProvider;
+            _scopeProvider = scopeProvider;
             _registry = registry;
             _datetimeProvider = datetimeProvider;
             _publisher = publisher;
@@ -87,7 +89,7 @@ namespace WorkflowCore.Services
                             pointer.StartTime = _datetimeProvider.Now.ToUniversalTime();
                         }
 
-                        using (var scope = _serviceProvider.CreateScope())
+                        using (var scope = _scopeProvider.CreateScope())
                         {
                             _logger.LogDebug("Starting step {0} on workflow {1}", step.Name, workflow.Id);
 

--- a/test/WorkflowCore.IntegrationTests/Scenarios/DiScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/DiScenario.cs
@@ -37,14 +37,14 @@ namespace WorkflowCore.IntegrationTests.Scenarios
 
     public class Dependency1
     {
-        public static int InstanceCounter = 0;
+        private static int InstanceCounter = 0;
 
         public int Instance { get; set; } = ++InstanceCounter;
     }
 
     public class Dependency2
     {
-        public readonly Dependency1 dependency1;
+        public Dependency1 dependency1 { get; private set; }
 
         public Dependency2(Dependency1 dependency1)
         {
@@ -54,8 +54,8 @@ namespace WorkflowCore.IntegrationTests.Scenarios
 
     public class DiStep1 : StepBody
     {
-        public readonly Dependency1 dependency1;
-        public readonly Dependency2 dependency2;
+        public Dependency1 dependency1 { get; private set; }
+        public Dependency2 dependency2 { get; private set; }
 
         public DiStep1(Dependency1 dependency1, Dependency2 dependency2)
         {

--- a/test/WorkflowCore.IntegrationTests/Scenarios/DiScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/DiScenario.cs
@@ -1,0 +1,255 @@
+﻿using System;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using Xunit;
+using FluentAssertions;
+using WorkflowCore.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Autofac.Extensions.DependencyInjection;
+using Autofac;
+using System.Diagnostics;
+
+namespace WorkflowCore.IntegrationTests.Scenarios
+{
+    public class DiWorkflow : IWorkflow<DiData>
+    {
+        public string Id => "DiWorkflow";
+        public int Version => 1;
+
+        public void Build(IWorkflowBuilder<DiData> builder)
+        {
+            builder
+                .StartWith<DiStep1>()
+                    .Output(_ => _.instance1, _ => _.dependency1.Instance)
+                    .Output(_ => _.instance2, _ => _.dependency2.dependency1.Instance)
+                .Then(context =>
+                {
+                    return ExecutionResult.Next();
+                });
+        }
+    }
+
+    public class DiData
+    {
+        public int instance1 { get; set; } = -1;
+        public int instance2 { get; set; } = -1;
+    }
+
+    public class Dependency1
+    {
+        public static int InstanceCounter = 0;
+
+        public int Instance { get; set; } = ++InstanceCounter;
+    }
+
+    public class Dependency2
+    {
+        public readonly Dependency1 dependency1;
+
+        public Dependency2(Dependency1 dependency1)
+        {
+            this.dependency1 = dependency1;
+        }
+    }
+
+    public class DiStep1 : StepBody
+    {
+        public readonly Dependency1 dependency1;
+        public readonly Dependency2 dependency2;
+
+        public DiStep1(Dependency1 dependency1, Dependency2 dependency2)
+        {
+            this.dependency1 = dependency1;
+            this.dependency2 = dependency2;
+        }
+
+        public override ExecutionResult Run(IStepExecutionContext context)
+        {
+            return ExecutionResult.Next();
+        }
+    }
+
+    /// <summary>
+    /// The DI scenarios are design to test whether the scoped / transient dependecies are honoured with
+    /// various IoC container implementations. The basic premise is that a step has a dependency on
+    /// two services, one of which has a dependency on the other.
+    /// 
+    /// We then use the instance numbers of the services to determine whether the container has created a
+    /// transient instance or a scoped instance
+    /// 
+    /// if step.dependency2.dependency1.instance == step.dependency1.instance then
+    /// we can be assured that dependency1 was created in the same scope as dependency 2
+    /// 
+    /// otherwise if the instances are different, they were created as transient
+    /// 
+    /// </summary>
+    public abstract class DiScenario : WorkflowTest<DiWorkflow, DiData>
+    {
+        protected void ConfigureHost(IServiceProvider serviceProvider)
+        {
+            PersistenceProvider = serviceProvider.GetService<IPersistenceProvider>();
+            Host = serviceProvider.GetService<IWorkflowHost>();
+            Host.RegisterWorkflow<DiWorkflow, DiData>();
+            Host.OnStepError += Host_OnStepError;
+            Host.Start();
+        }
+    }
+
+    /// <summary>
+    /// Because of the static InMemory Persistence provider, this test must run in issolation
+    /// to prevent other hosts from picking up steps intended for this host and incorrectly 
+    /// cross-referencing the scoped / transient IoC container for step constrcution
+    /// </summary>
+    [CollectionDefinition("DiMsTransientScenario", DisableParallelization = true)]
+    [Collection("DiMsTransientScenario")]
+    public class DiMsTransientScenario : DiScenario
+    {
+        public DiMsTransientScenario()
+        {
+            //setup dependency injection
+            IServiceCollection services = new ServiceCollection();
+            services.AddTransient<Dependency1>();
+            services.AddTransient<Dependency2>();
+            services.AddTransient<DiStep1>();
+            services.AddLogging();
+            ConfigureServices(services);
+
+            var serviceProvider = services.BuildServiceProvider();
+            ConfigureHost(serviceProvider);
+        }
+
+        [Fact]
+        public void Scenario()
+        {
+            var workflowId = StartWorkflow(new DiData());
+            WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(5));
+            var data = GetData(workflowId);
+
+            // DI provider should have created two transient instances, with different instance ids
+            data.instance1.Should().NotBe(-1);
+            data.instance2.Should().NotBe(-1);
+            data.instance1.Should().NotBe(data.instance2);
+        }
+    }
+
+    /// <summary>
+    /// Because of the static InMemory Persistence provider, this test must run in issolation
+    /// to prevent other hosts from picking up steps intended for this host and incorrectly 
+    /// cross-referencing the scoped / transient IoC container for step constrcution
+    /// </summary>
+    [CollectionDefinition("DiMsScopedScenario", DisableParallelization = true)]
+    [Collection("DiMsScopedScenario")]
+    public class DiMsScopedScenario : DiScenario
+    {
+        public DiMsScopedScenario()
+        {
+            //setup dependency injection
+            IServiceCollection services = new ServiceCollection();
+            services.AddScoped<Dependency1>();
+            services.AddScoped<Dependency2>();
+            services.AddTransient<DiStep1>();
+            services.AddLogging();
+            ConfigureServices(services);
+
+            var serviceProvider = services.BuildServiceProvider();
+            ConfigureHost(serviceProvider);
+        }
+
+        [Fact]
+        public void Scenario()
+        {
+            var workflowId = StartWorkflow(new DiData());
+            WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(5));
+            var data = GetData(workflowId);
+
+            // scope provider should have created one scoped instance, with the same instance ids
+            data.instance1.Should().NotBe(-1);
+            data.instance2.Should().NotBe(-1);
+            data.instance1.Should().Be(data.instance2);
+        }
+    }
+
+    /// <summary>
+    /// Because of the static InMemory Persistence provider, this test must run in issolation
+    /// to prevent other hosts from picking up steps intended for this host and incorrectly 
+    /// cross-referencing the scoped / transient IoC container for step constrcution
+    /// </summary>
+    [CollectionDefinition("DiAutoFacTransientScenario", DisableParallelization = true)]
+    [Collection("DiAutoFacTransientScenario")]
+    public class DiAutoFacTransientScenario : DiScenario
+    {
+        public DiAutoFacTransientScenario()
+        {
+            //setup dependency injection
+            IServiceCollection services = new ServiceCollection();
+            services.AddLogging();
+            ConfigureServices(services);
+
+            //setup dependency injection
+            var builder = new ContainerBuilder();
+            builder.Populate(services);
+            builder.RegisterType<Dependency1>().InstancePerDependency();
+            builder.RegisterType<Dependency2>().InstancePerDependency();
+            builder.RegisterType<DiStep1>().InstancePerDependency();
+            var container = builder.Build();
+
+            var serviceProvider = new AutofacServiceProvider(container);
+            ConfigureHost(serviceProvider);
+        }
+
+        [Fact]
+        public void Scenario()
+        {
+            var workflowId = StartWorkflow(new DiData());
+            WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(5));
+            var data = GetData(workflowId);
+
+            // scope provider should have created one scoped instance, with the same instance ids
+            data.instance1.Should().NotBe(-1);
+            data.instance2.Should().NotBe(-1);
+            data.instance1.Should().NotBe(data.instance2);
+        }
+    }
+
+    /// <summary>
+    /// Because of the static InMemory Persistence provider, this test must run in issolation
+    /// to prevent other hosts from picking up steps intended for this host and incorrectly 
+    /// cross-referencing the scoped / transient IoC container for step constrcution
+    /// </summary>
+    [CollectionDefinition("DiAutoFacScopedScenario", DisableParallelization = true)]
+    [Collection("DiAutoFacScopedScenario")]
+    public class DiAutoFacScopedScenario : DiScenario
+    {
+        public DiAutoFacScopedScenario()
+        {
+            //setup dependency injection
+            IServiceCollection services = new ServiceCollection();
+            services.AddLogging();
+            ConfigureServices(services);
+
+            //setup dependency injection
+            var builder = new ContainerBuilder();
+            builder.Populate(services);
+            builder.RegisterType<Dependency1>().InstancePerLifetimeScope();
+            builder.RegisterType<Dependency2>().InstancePerLifetimeScope();
+            builder.RegisterType<DiStep1>().InstancePerLifetimeScope();
+            var container = builder.Build();
+
+            var serviceProvider = new AutofacServiceProvider(container);
+            ConfigureHost(serviceProvider);
+        }
+
+        [Fact]
+        public void Scenario()
+        {
+            var workflowId = StartWorkflow(null);
+            WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(5));
+            var data = GetData(workflowId);
+
+            // scope provider should have created one scoped instance, with the same instance ids
+            data.instance1.Should().NotBe(-1);
+            data.instance2.Should().NotBe(-1);
+            data.instance1.Should().Be(data.instance2);
+        }
+    }
+}

--- a/test/WorkflowCore.IntegrationTests/WorkflowCore.IntegrationTests.csproj
+++ b/test/WorkflowCore.IntegrationTests/WorkflowCore.IntegrationTests.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />

--- a/test/WorkflowCore.Testing/WorkflowTest.cs
+++ b/test/WorkflowCore.Testing/WorkflowTest.cs
@@ -39,7 +39,7 @@ namespace WorkflowCore.Testing
             Host.Start();
         }
 
-        private void Host_OnStepError(WorkflowInstance workflow, WorkflowStep step, Exception exception)
+        protected void Host_OnStepError(WorkflowInstance workflow, WorkflowStep step, Exception exception)
         {
             UnhandledStepErrors.Add(new StepError()
             {

--- a/test/WorkflowCore.UnitTests/Services/WorkflowExecutorFixture.cs
+++ b/test/WorkflowCore.UnitTests/Services/WorkflowExecutorFixture.cs
@@ -25,6 +25,7 @@ namespace WorkflowCore.UnitTests.Services
         protected ILifeCycleEventPublisher EventHub;
         protected ICancellationProcessor CancellationProcessor;
         protected IServiceProvider ServiceProvider;
+        protected IScopeProvider ScopeProvider;
         protected IDateTimeProvider DateTimeProvider;
         protected WorkflowOptions Options;
 
@@ -33,6 +34,7 @@ namespace WorkflowCore.UnitTests.Services
             Host = A.Fake<IWorkflowHost>();
             PersistenceProvider = A.Fake<IPersistenceProvider>();
             ServiceProvider = A.Fake<IServiceProvider>();
+            ScopeProvider = A.Fake<IScopeProvider>();
             Registry = A.Fake<IWorkflowRegistry>();
             ResultProcesser = A.Fake<IExecutionResultProcessor>();
             EventHub = A.Fake<ILifeCycleEventPublisher>();
@@ -41,13 +43,17 @@ namespace WorkflowCore.UnitTests.Services
 
             Options = new WorkflowOptions(A.Fake<IServiceCollection>());
 
+            var scope = A.Fake<IServiceScope>();
+            A.CallTo(() => ScopeProvider.CreateScope()).Returns(scope);
+            A.CallTo(() => scope.ServiceProvider).Returns(ServiceProvider);
+
             A.CallTo(() => DateTimeProvider.Now).Returns(DateTime.Now);
 
             //config logging
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddConsole(LogLevel.Debug);            
 
-            Subject = new WorkflowExecutor(Registry, ServiceProvider, DateTimeProvider, ResultProcesser, EventHub, CancellationProcessor, Options, loggerFactory);
+            Subject = new WorkflowExecutor(Registry, ServiceProvider, ScopeProvider, DateTimeProvider, ResultProcesser, EventHub, CancellationProcessor, Options, loggerFactory);
         }
 
         [Fact(DisplayName = "Should execute active step")]


### PR DESCRIPTION
Step creation was failing with error "WorkflowCore.Services.WorkflowExecutor:Error: Workflow e8c62d2b-249a-4f25-add5-06771c16b33f raised error on step 0 Message: Cannot resolve 'abc' from root provider because it requires scoped service 'def"

Enhanced code to create a scope for the step execution, so that scoped dependencies can be correctly instantiated before injecting.