### PR TITLE
EF WorkflowInstance.ToPersistable change to not recreate ExecutionPointers

### DIFF
--- a/src/providers/WorkflowCore.Persistence.EntityFramework/ExtensionMethods.cs
+++ b/src/providers/WorkflowCore.Persistence.EntityFramework/ExtensionMethods.cs
@@ -27,7 +27,7 @@ namespace WorkflowCore.Persistence.EntityFramework
             persistable.Status = instance.Status;
             persistable.CreateTime = instance.CreateTime;
             persistable.CompleteTime = instance.CompleteTime;
-            persistable.ExecutionPointers = persistance.ExecutionPointers ?? new PersistedExecutionPointerCollection(instance.ExecutionPointers.Count);
+            persistable.ExecutionPointers = persistable.ExecutionPointers ?? new PersistedExecutionPointerCollection(instance.ExecutionPointers.Count);
             
             foreach (var ep in instance.ExecutionPointers)
             {

--- a/src/providers/WorkflowCore.Persistence.EntityFramework/ExtensionMethods.cs
+++ b/src/providers/WorkflowCore.Persistence.EntityFramework/ExtensionMethods.cs
@@ -27,7 +27,7 @@ namespace WorkflowCore.Persistence.EntityFramework
             persistable.Status = instance.Status;
             persistable.CreateTime = instance.CreateTime;
             persistable.CompleteTime = instance.CompleteTime;
-            persistable.ExecutionPointers = new PersistedExecutionPointerCollection(instance.ExecutionPointers.Count);
+            persistable.ExecutionPointers = persistance.ExecutionPointers ?? new PersistedExecutionPointerCollection(instance.ExecutionPointers.Count);
             
             foreach (var ep in instance.ExecutionPointers)
             {


### PR DESCRIPTION
A fix for an issue where on each workflow persist all executionpointers were re-created.
Creation of new persistance.ExecutionPointers collection object causes the EntityFramework to delete existing previous records in database on SaveChanges.
The fix causes existing records to be untouched if no changes occur, otherwise the existing records are updated (instead of insert).