### PR TITLE
Fixing issue with waiting for same event a 2nd time on the same step.

### DIFF
--- a/src/WorkflowCore/Models/ExecutionResult.cs
+++ b/src/WorkflowCore/Models/ExecutionResult.cs
@@ -19,6 +19,8 @@ namespace WorkflowCore.Models
 
         public DateTime EventAsOf { get; set; }
 
+        public bool EventReWait { get; private set; }
+
         public List<object> BranchValues { get; set; } = new List<object>();
 
         public ExecutionResult()
@@ -86,6 +88,18 @@ namespace WorkflowCore.Models
                 EventName = eventName,
                 EventKey = eventKey,
                 EventAsOf = effectiveDate.ToUniversalTime()
+            };
+        }
+
+        public static ExecutionResult ReWaitForEvent(string eventName, string eventKey, DateTime effectiveDate)
+        {
+            return new ExecutionResult()
+            {
+                Proceed = false,
+                EventName = eventName,
+                EventKey = eventKey,
+                EventAsOf = effectiveDate.ToUniversalTime(),
+                EventReWait = true
             };
         }
     }

--- a/src/WorkflowCore/Services/ExecutionResultProcessor.cs
+++ b/src/WorkflowCore/Services/ExecutionResultProcessor.cs
@@ -41,7 +41,6 @@ namespace WorkflowCore.Services
             {
                 pointer.EventName = result.EventName;
                 pointer.EventKey = result.EventKey;
-                pointer.EventPublished = false;
                 pointer.Active = false;
                 pointer.Status = PointerStatus.WaitingForEvent;
 
@@ -55,6 +54,11 @@ namespace WorkflowCore.Services
                 });
             }
 
+            if (result.EventReWait)
+            {
+                pointer.EventPublished = false;
+            }
+
             if (result.Proceed)
             {
                 pointer.Active = false;
@@ -62,7 +66,7 @@ namespace WorkflowCore.Services
                 pointer.Status = PointerStatus.Complete;
 
                 foreach (var outcomeTarget in step.Outcomes.Where(x => object.Equals(x.GetValue(workflow.Data), result.OutcomeValue) || x.GetValue(workflow.Data) == null))
-                {                    
+                {
                     workflow.ExecutionPointers.Add(_pointerFactory.BuildNextPointer(def, pointer, outcomeTarget));
                 }
 
@@ -82,8 +86,8 @@ namespace WorkflowCore.Services
                 foreach (var branch in result.BranchValues)
                 {
                     foreach (var childDefId in step.Children)
-                    {   
-                        workflow.ExecutionPointers.Add(_pointerFactory.BuildChildPointer(def, pointer, childDefId, branch));                        
+                    {
+                        workflow.ExecutionPointers.Add(_pointerFactory.BuildChildPointer(def, pointer, childDefId, branch));
                     }
                 }
             }
@@ -103,7 +107,7 @@ namespace WorkflowCore.Services
                 Message = exception.Message
             });
             pointer.Status = PointerStatus.Failed;
-            
+
             var queue = new Queue<ExecutionPointer>();
             queue.Enqueue(pointer);
 
@@ -120,7 +124,7 @@ namespace WorkflowCore.Services
                 }
             }
         }
-        
+
         private bool ShouldCompensate(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer currentPointer)
         {
             var scope = new Stack<string>(currentPointer.Scope);

--- a/src/WorkflowCore/Services/ExecutionResultProcessor.cs
+++ b/src/WorkflowCore/Services/ExecutionResultProcessor.cs
@@ -41,6 +41,7 @@ namespace WorkflowCore.Services
             {
                 pointer.EventName = result.EventName;
                 pointer.EventKey = result.EventKey;
+                pointer.EventPublished = false;
                 pointer.Active = false;
                 pointer.Status = PointerStatus.WaitingForEvent;
 

--- a/test/WorkflowCore.IntegrationTests/Scenarios/ReWaitEventScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/ReWaitEventScenario.cs
@@ -32,7 +32,7 @@ namespace WorkflowCore.IntegrationTests.Scenarios
                         if (data.Value > 3)
                             return ExecutionResult.Next();
 
-                        return ExecutionResult.WaitForEvent("MyEvent", data.Value + "", DateTime.Now);
+                        return ExecutionResult.ReWaitForEvent("MyEvent", data.Value + "", DateTime.Now);
                     });
             }
         }

--- a/test/WorkflowCore.IntegrationTests/Scenarios/ReWaitEventScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/ReWaitEventScenario.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using Xunit;
+using FluentAssertions;
+using System.Linq;
+using WorkflowCore.Testing;
+
+namespace WorkflowCore.IntegrationTests.Scenarios
+{
+    public class ReWaitEventScenario : WorkflowTest<ReWaitEventScenario.EventWorkflow, ReWaitEventScenario.MyIntClass>
+    {
+        public class MyIntClass
+        {
+            public int Value { get; set; }
+        }
+
+        public class EventWorkflow : IWorkflow<ReWaitEventScenario.MyIntClass>
+        {
+            public string Id => "EventWorkflow2";
+            public int Version => 1;
+            public void Build(IWorkflowBuilder<ReWaitEventScenario.MyIntClass> builder)
+            {
+                builder
+                    .StartWith(context =>
+                    {
+                        var data = (context.Workflow.Data as MyIntClass ?? new MyIntClass { Value = 0 });
+                        data.Value++;
+
+                        if (data.Value > 3)
+                            return ExecutionResult.Next();
+
+                        return ExecutionResult.WaitForEvent("MyEvent", data.Value + "", DateTime.Now);
+                    });
+            }
+        }
+
+        public ReWaitEventScenario()
+        {
+            Setup();
+        }
+
+        [Fact]
+        public void Scenario()
+        {
+            var workflowId = StartWorkflow(new MyIntClass { Value = 0 });
+            WaitForEventSubscription("MyEvent", "1", TimeSpan.FromSeconds(30));
+            Host.PublishEvent("MyEvent", "1", null);
+
+            WaitForEventSubscription("MyEvent", "2", TimeSpan.FromSeconds(30));
+            Host.PublishEvent("MyEvent", "2", null);
+
+            WaitForEventSubscription("MyEvent", "3", TimeSpan.FromSeconds(30));
+            Host.PublishEvent("MyEvent", "3", null);
+
+            WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(30));
+
+            GetData(workflowId).Value.Should().Be(4);
+            GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
+            UnhandledStepErrors.Count.Should().Be(0);
+        }
+    }
+}


### PR DESCRIPTION
I want to allow an event to fire a workflow in the same step more than once, so at the end of a step, I wait for the same event again.  This was not working after the first event.  I did some debugging and to me it looks like this change is required for this to work.  Don't know enough about the usage of the EventPublished property to know if there are ramifications of doing this.  But, I think if you're potentially changing the name and key on the pointer, it's also safe to change the EventPublished flag.

I added an integration test scenario.  I ran all the integration and unit tests and they pass.

