### PR TITLE
Typo in a log message has been fixed (WorkflowHost.cs)

### DIFF
--- a/src/WorkflowCore/Services/WorkflowHost.cs
+++ b/src/WorkflowCore/Services/WorkflowHost.cs
@@ -86,7 +86,7 @@ namespace WorkflowCore.Services
             _lifeCycleEventHub.Start().Wait();
             _searchIndex.Start().Wait();
             
-            Logger.LogInformation("Starting backgroud tasks");
+            Logger.LogInformation("Starting background tasks");
 
             foreach (var task in _backgroundTasks)
                 task.Start();


### PR DESCRIPTION
Typo in a log message has been fixed (WorkflowHost.cs)
"Starting backgroud tasks" -> "Starting background tasks"