### PR TITLE
Added StepExecutionContextAccessor

### DIFF
--- a/src/WorkflowCore/Interface/IStepExecutionContextAccessor.cs
+++ b/src/WorkflowCore/Interface/IStepExecutionContextAccessor.cs
@@ -1,0 +1,7 @@
+﻿namespace WorkflowCore.Interface
+{
+    public interface IStepExecutionContextAccessor
+    {
+        IStepExecutionContext StepExecutionContext { get; }
+    }
+}

--- a/src/WorkflowCore/ServiceCollectionExtensions.cs
+++ b/src/WorkflowCore/ServiceCollectionExtensions.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddTransient<Foreach>();
 
+            services.AddSingleton<IStepExecutionContextAccessor, StepExecutionContextAccessor>();
+
             return services;
         }
     }

--- a/src/WorkflowCore/Services/StepExecutionContextAccessor.cs
+++ b/src/WorkflowCore/Services/StepExecutionContextAccessor.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading;
+using WorkflowCore.Interface;
+
+namespace WorkflowCore.Services
+{
+    public class StepExecutionContextAccessor : IStepExecutionContextAccessor
+    {
+        private static readonly AsyncLocal<IStepExecutionContext> _contextCurrent = new AsyncLocal<IStepExecutionContext>();
+
+        public IStepExecutionContext StepExecutionContext
+        {
+            get => _contextCurrent.Value;
+            set => _contextCurrent.Value = value;
+        }
+    }
+}

--- a/src/WorkflowCore/Services/WorkflowExecutor.cs
+++ b/src/WorkflowCore/Services/WorkflowExecutor.cs
@@ -141,6 +141,21 @@ namespace WorkflowCore.Services
             {
                 _logger.LogDebug("Starting step {0} on workflow {1}", step.Name, workflow.Id);
 
+                IStepExecutionContext context = new StepExecutionContext()
+                {
+                    Workflow = workflow,
+                    Step = step,
+                    PersistenceData = pointer.PersistenceData,
+                    ExecutionPointer = pointer,
+                    Item = pointer.ContextItem
+                };
+
+                if (scope.ServiceProvider.GetService<IStepExecutionContextAccessor>()
+                    is StepExecutionContextAccessor accessor)
+                {
+                    accessor.StepExecutionContext = context;
+                }
+
                 IStepBody body = step.ConstructBody(scope.ServiceProvider);
 
                 if (body == null)
@@ -156,15 +171,6 @@ namespace WorkflowCore.Services
                     });
                     return;
                 }
-
-                IStepExecutionContext context = new StepExecutionContext()
-                {
-                    Workflow = workflow,
-                    Step = step,
-                    PersistenceData = pointer.PersistenceData,
-                    ExecutionPointer = pointer,
-                    Item = pointer.ContextItem
-                };
 
                 foreach (var input in step.Inputs)
                     input.AssignInput(workflow.Data, body, context);


### PR DESCRIPTION
**Purpose**
My team needed the ability to get the StepExecutionContext through DI. Specifically to be used within a CorrelationIdDelegationHandler class, which populates the X-Correlation-Id header with the executing Workflow-Instance-Id.

**Implementation**
The implementation uses a StepExecutionContextAccessor based on the HttpContextAccessor from ASP.NET Core, which uses AsyncLocal to store the context. This is needed in order to be used within Http DelegationHandlers, because when using HttpClientFactory the HttpClient and DelegationHandlers are cached and thereby not tied to the DI lifetime.

