### PR TITLE
Sample 8: Workflow never stops, can't select 'no' approval

### DIFF
--- a/src/samples/WorkflowCore.Sample08/Program.cs
+++ b/src/samples/WorkflowCore.Sample08/Program.cs
@@ -40,14 +40,18 @@ namespace WorkflowCore.Sample08
                 }
 
                 //Thread.Sleep(500);
-                
-                Console.ReadLine();
-                Console.WriteLine();
-                Console.WriteLine("Choosing " + item.Options.First().Key);
 
-                host.PublishUserAction(openItems.First().Key, @"domain\john", item.Options.First().Value).Wait();
+                var input = Console.ReadLine();
+                Console.WriteLine();
+                var optionselected = item.Options.Single(x => x.Value == input);
+                Console.WriteLine("Choosing " + optionselected.Key);
+
+                host.PublishUserAction(optionselected.Key, @"domain\john", optionselected.Value).Wait();
             }
 
+            timer.Dispose();
+            timer = null;
+            Console.WriteLine("Workflow ended.");
             Console.ReadLine();
             host.Stop();
         }
@@ -85,6 +89,6 @@ namespace WorkflowCore.Sample08
             return serviceProvider;
         }
 
-        
+
     }
 }

--- a/src/samples/WorkflowCore.Sample08/Program.cs
+++ b/src/samples/WorkflowCore.Sample08/Program.cs
@@ -43,12 +43,16 @@ namespace WorkflowCore.Sample08
 
                 var input = Console.ReadLine();
                 Console.WriteLine();
-                var optionselected = item.Options.Single(x => x.Value == input);
-                Console.WriteLine("Choosing " + optionselected.Key);
 
-                host.PublishUserAction(optionselected.Key, @"domain\john", optionselected.Value).Wait();
+                string key = item.Key;
+                string value = item.Options.Single(x => x.Value == input).Value;
+
+                Console.WriteLine("Choosing key:" + key + " value:" + value);
+
+                host.PublishUserAction(key, @"domain\john", value).Wait();
             }
-
+            Thread.Sleep(1000);
+            Console.WriteLine("Open user actions left:" + host.GetOpenUserActions(workflowId).Count().ToString());
             timer.Dispose();
             timer = null;
             Console.WriteLine("Workflow ended.");


### PR DESCRIPTION
Fix bug where workflow timer kept running after workflow completed. 
Fix bug where no approval chose yes instead.