### PR TITLE
Fixing a typo on IPersistenceProvider for GetSubscriptions method

### DIFF
--- a/src/WorkflowCore/Interface/IPersistenceProvider.cs
+++ b/src/WorkflowCore/Interface/IPersistenceProvider.cs
@@ -26,7 +26,10 @@ namespace WorkflowCore.Interface
 
         Task<string> CreateEventSubscription(EventSubscription subscription);
 
-        Task<IEnumerable<EventSubscription>> GetSubcriptions(string eventName, string eventKey, DateTime asOf);
+        [Obsolete("Use GetSubscriptions")]
+        Task <IEnumerable<EventSubscription>> GetSubcriptions(string eventName, string eventKey, DateTime asOf);
+
+        Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf);
 
         Task TerminateSubscription(string eventSubscriptionId);
 

--- a/src/WorkflowCore/Services/BackgroundTasks/EventConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/EventConsumer.cs
@@ -39,7 +39,7 @@ namespace WorkflowCore.Services.BackgroundTasks
                 var evt = await _persistenceStore.GetEvent(itemId);
                 if (evt.EventTime <= _datetimeProvider.Now.ToUniversalTime())
                 {
-                    var subs = await _persistenceStore.GetSubcriptions(evt.EventName, evt.EventKey, evt.EventTime);
+                    var subs = await _persistenceStore.GetSubscriptions(evt.EventName, evt.EventKey, evt.EventTime);
                     var toQueue = new List<string>();
                     var complete = true;
 

--- a/src/WorkflowCore/Services/DefaultProviders/MemoryPersistenceProvider.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/MemoryPersistenceProvider.cs
@@ -115,7 +115,9 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task<IEnumerable<EventSubscription>> GetSubcriptions(string eventName, string eventKey, DateTime asOf)
+        public Task<IEnumerable<EventSubscription>> GetSubcriptions(string eventName, string eventKey, DateTime asOf) => GetSubscriptions(eventName, eventKey, asOf);
+
+        public async Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf)
         {
             lock (_subscriptions)
             {

--- a/src/WorkflowCore/Services/DefaultProviders/TransientMemoryPersistenceProvider.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/TransientMemoryPersistenceProvider.cs
@@ -32,7 +32,9 @@ namespace WorkflowCore.Services
 
         public Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt) => _innerService.GetRunnableInstances(asAt);
 
-        public Task<IEnumerable<EventSubscription>> GetSubcriptions(string eventName, string eventKey, DateTime asOf) => _innerService.GetSubcriptions(eventName, eventKey, asOf);
+        public Task<IEnumerable<EventSubscription>> GetSubcriptions(string eventName, string eventKey, DateTime asOf) => GetSubscriptions(eventName, eventKey, asOf);
+
+        public Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf) => _innerService.GetSubscriptions(eventName, eventKey, asOf);
 
         public Task<WorkflowInstance> GetWorkflowInstance(string Id) => _innerService.GetWorkflowInstance(Id);
 

--- a/src/providers/WorkflowCore.Persistence.EntityFramework/Services/EntityFrameworkPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.EntityFramework/Services/EntityFrameworkPersistenceProvider.cs
@@ -182,7 +182,9 @@ namespace WorkflowCore.Persistence.EntityFramework.Services
             }
         }
 
-        public async Task<IEnumerable<EventSubscription>> GetSubcriptions(string eventName, string eventKey, DateTime asOf)
+        public Task<IEnumerable<EventSubscription>> GetSubcriptions(string eventName, string eventKey, DateTime asOf) => GetSubscriptions(eventName, eventKey, asOf);
+
+        public async Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf)
         {
             using (var db = ConstructDbContext())
             {

--- a/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
@@ -158,7 +158,9 @@ namespace WorkflowCore.Persistence.MongoDB.Services
 
         }
 
-        public async Task<IEnumerable<EventSubscription>> GetSubcriptions(string eventName, string eventKey, DateTime asOf)
+        public Task<IEnumerable<EventSubscription>> GetSubcriptions(string eventName, string eventKey, DateTime asOf) => GetSubscriptions(eventName, eventKey, asOf);
+
+        public async Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf)
         {
             var query = EventSubscriptions
                 .Find(x => x.EventName == eventName && x.EventKey == eventKey && x.SubscribeAsOf <= asOf);

--- a/src/providers/WorkflowCore.Providers.AWS/Services/DynamoPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/Services/DynamoPersistenceProvider.cs
@@ -177,7 +177,9 @@ namespace WorkflowCore.Providers.AWS.Services
             return subscription.Id;
         }
 
-        public async Task<IEnumerable<EventSubscription>> GetSubcriptions(string eventName, string eventKey, DateTime asOf)
+        public Task<IEnumerable<EventSubscription>> GetSubcriptions(string eventName, string eventKey, DateTime asOf) => GetSubscriptions(eventName, eventKey, asOf);
+
+        public async Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf)
         {
             var result = new List<EventSubscription>();
             var asOfTicks = asOf.ToUniversalTime().Ticks;

--- a/src/providers/WorkflowCore.Providers.Redis/Services/RedisPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Providers.Redis/Services/RedisPersistenceProvider.cs
@@ -97,7 +97,9 @@ namespace WorkflowCore.Providers.Redis.Services
             return subscription.Id;
         }
 
-        public async Task<IEnumerable<EventSubscription>> GetSubcriptions(string eventName, string eventKey, DateTime asOf)
+        public Task<IEnumerable<EventSubscription>> GetSubcriptions(string eventName, string eventKey, DateTime asOf) => GetSubscriptions(eventName, eventKey, asOf);
+
+        public async Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf)
         {
             var result = new List<EventSubscription>();
             var data = await _redis.SortedSetRangeByScoreAsync($"{_prefix}.{SUBSCRIPTION_SET}.{EVENTSLUG_INDEX}.{eventName}-{eventKey}", -1, asOf.Ticks);

--- a/test/WorkflowCore.Testing/JsonWorkflowTest.cs
+++ b/test/WorkflowCore.Testing/JsonWorkflowTest.cs
@@ -75,7 +75,7 @@ namespace WorkflowCore.Testing
 
         protected IEnumerable<EventSubscription> GetActiveSubscriptons(string eventName, string eventKey)
         {
-            return PersistenceProvider.GetSubcriptions(eventName, eventKey, DateTime.MaxValue).Result;
+            return PersistenceProvider.GetSubscriptions(eventName, eventKey, DateTime.MaxValue).Result;
         }
 
         protected void WaitForEventSubscription(string eventName, string eventKey, TimeSpan timeOut)

--- a/test/WorkflowCore.Testing/WorkflowTest.cs
+++ b/test/WorkflowCore.Testing/WorkflowTest.cs
@@ -75,7 +75,7 @@ namespace WorkflowCore.Testing
 
         protected IEnumerable<EventSubscription> GetActiveSubscriptons(string eventName, string eventKey)
         {
-            return PersistenceProvider.GetSubcriptions(eventName, eventKey, DateTime.MaxValue).Result;
+            return PersistenceProvider.GetSubscriptions(eventName, eventKey, DateTime.MaxValue).Result;
         }
 
         protected void WaitForEventSubscription(string eventName, string eventKey, TimeSpan timeOut)

--- a/test/WorkflowCore.Testing/YamlWorkflowTest.cs
+++ b/test/WorkflowCore.Testing/YamlWorkflowTest.cs
@@ -75,7 +75,7 @@ namespace WorkflowCore.Testing
 
         protected IEnumerable<EventSubscription> GetActiveSubscriptons(string eventName, string eventKey)
         {
-            return PersistenceProvider.GetSubcriptions(eventName, eventKey, DateTime.MaxValue).Result;
+            return PersistenceProvider.GetSubscriptions(eventName, eventKey, DateTime.MaxValue).Result;
         }
 
         protected void WaitForEventSubscription(string eventName, string eventKey, TimeSpan timeOut)


### PR DESCRIPTION
Fixing a typo on IPersistenceProvider for GetSubscriptions method. Marking the existing one as obsolete, adding one with the typo fixed. Updating IPersistenceProvider implementations to implement the new interface method, and redirecting existing implementation to this one.