### PR TITLE
Workflow purger

### DIFF
--- a/ReleaseNotes/2.1.2.md
+++ b/ReleaseNotes/2.1.2.md
@@ -1,0 +1,9 @@
+# Workflow Core 2.1.2
+
+* Adds a feature to purge old workflows from the persistence store.
+
+New `IWorkflowPurger` service that can be injected from the IoC container
+```c#
+Task PurgeWorkflows(WorkflowStatus status, DateTime olderThan)
+```
+Implementations are currently only for SQL Server, Postgres and MongoDB

--- a/WorkflowCore.sln
+++ b/WorkflowCore.sln
@@ -100,6 +100,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ReleaseNotes", "ReleaseNote
 		ReleaseNotes\1.9.3.md = ReleaseNotes\1.9.3.md
 		ReleaseNotes\2.0.0.md = ReleaseNotes\2.0.0.md
 		ReleaseNotes\2.1.0.md = ReleaseNotes\2.1.0.md
+		ReleaseNotes\2.1.2.md = ReleaseNotes\2.1.2.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Sample14", "src\samples\WorkflowCore.Sample14\WorkflowCore.Sample14.csproj", "{6BC66637-B42A-4334-ADFB-DBEC9F29D293}"

--- a/src/WorkflowCore/Interface/IWorkflowPurger.cs
+++ b/src/WorkflowCore/Interface/IWorkflowPurger.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading.Tasks;
+using WorkflowCore.Models;
+
+namespace WorkflowCore.Interface
+{
+    public interface IWorkflowPurger
+    {
+        Task PurgeWorkflows(WorkflowStatus status, DateTime olderThan);
+    }
+}

--- a/src/WorkflowCore/WorkflowCore.csproj
+++ b/src/WorkflowCore/WorkflowCore.csproj
@@ -15,9 +15,9 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Description>Workflow Core is a light weight workflow engine targeting .NET Standard.</Description>
-    <Version>2.1.1</Version>
-    <AssemblyVersion>2.1.1.0</AssemblyVersion>
-    <FileVersion>2.1.1.0</FileVersion>
+    <Version>2.1.2</Version>
+    <AssemblyVersion>2.1.2.0</AssemblyVersion>
+    <FileVersion>2.1.2.0</FileVersion>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageIconUrl>https://github.com/danielgerlag/workflow-core/raw/master/src/logo.png</PackageIconUrl>
   </PropertyGroup>

--- a/src/providers/WorkflowCore.Persistence.EntityFramework/Services/WorkflowPurger.cs
+++ b/src/providers/WorkflowCore.Persistence.EntityFramework/Services/WorkflowPurger.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using System.Linq.Dynamic.Core;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using WorkflowCore.Persistence.EntityFramework.Interfaces;
+using WorkflowCore.Persistence.EntityFramework.Models;
+
+namespace WorkflowCore.Persistence.EntityFramework.Services
+{
+    public class WorkflowPurger : IWorkflowPurger
+    {
+        private readonly IWorkflowDbContextFactory _contextFactory;
+
+        public WorkflowPurger(IWorkflowDbContextFactory contextFactory)
+        {
+            _contextFactory = contextFactory;
+        }
+        
+        public async Task PurgeWorkflows(WorkflowStatus status, DateTime olderThan)
+        {
+            var olderThanUtc = olderThan.ToUniversalTime();
+            using (var db = ConstructDbContext())
+            {
+                var workflows = await db.Set<PersistedWorkflow>().Where(x => x.Status == status && x.CompleteTime < olderThanUtc).ToListAsync();
+                foreach (var wf in workflows)
+                {
+                    foreach (var pointer in wf.ExecutionPointers)
+                    {
+                        foreach (var extAttr in pointer.ExtensionAttributes)
+                        {
+                            db.Remove(extAttr);
+                        }
+
+                        db.Remove(pointer);
+                    }
+                    db.Remove(wf);
+                }
+
+                await db.SaveChangesAsync();
+            }
+        }
+        
+        
+        private WorkflowDbContext ConstructDbContext()
+        {
+            return _contextFactory.Build();
+        }
+    }
+}

--- a/src/providers/WorkflowCore.Persistence.EntityFramework/WorkflowCore.Persistence.EntityFramework.csproj
+++ b/src/providers/WorkflowCore.Persistence.EntityFramework/WorkflowCore.Persistence.EntityFramework.csproj
@@ -14,10 +14,10 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.0.1</Version>
+    <Version>2.1.1</Version>
     <Description>Base package for Workflow-core peristence providers using entity framework</Description>
-    <AssemblyVersion>2.0.1.0</AssemblyVersion>
-    <FileVersion>2.0.1.0</FileVersion>
+    <AssemblyVersion>2.1.1.0</AssemblyVersion>
+    <FileVersion>2.1.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/providers/WorkflowCore.Persistence.MongoDB/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using WorkflowCore.Interface;
 using WorkflowCore.Models;
 using WorkflowCore.Persistence.MongoDB.Services;
 
@@ -18,6 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 var db = client.GetDatabase(databaseName);
                 return new MongoPersistenceProvider(db);
             });
+            options.Services.AddTransient<IWorkflowPurger, WorkflowPurger>();
             return options;
         }
     }

--- a/src/providers/WorkflowCore.Persistence.MongoDB/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/ServiceCollectionExtensions.cs
@@ -19,7 +19,12 @@ namespace Microsoft.Extensions.DependencyInjection
                 var db = client.GetDatabase(databaseName);
                 return new MongoPersistenceProvider(db);
             });
-            options.Services.AddTransient<IWorkflowPurger, WorkflowPurger>();
+            options.Services.AddTransient<IWorkflowPurger>(sp =>
+            {
+                var client = new MongoClient(mongoUrl);
+                var db = client.GetDatabase(databaseName);
+                return new WorkflowPurger(db);
+            });
             return options;
         }
     }

--- a/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
@@ -13,6 +13,7 @@ namespace WorkflowCore.Persistence.MongoDB.Services
 {
     public class MongoPersistenceProvider : IPersistenceProvider
     {
+        internal const string WorkflowCollectionName = "wfc.workflows";
         private readonly IMongoDatabase _database;
 
         public MongoPersistenceProvider(IMongoDatabase database)
@@ -77,7 +78,7 @@ namespace WorkflowCore.Persistence.MongoDB.Services
             }
         }
 
-        private IMongoCollection<WorkflowInstance> WorkflowInstances => _database.GetCollection<WorkflowInstance>("wfc.workflows");
+        private IMongoCollection<WorkflowInstance> WorkflowInstances => _database.GetCollection<WorkflowInstance>(WorkflowCollectionName);
 
         private IMongoCollection<EventSubscription> EventSubscriptions => _database.GetCollection<EventSubscription>("wfc.subscriptions");
 

--- a/src/providers/WorkflowCore.Persistence.MongoDB/Services/WorkflowPurger.cs
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/Services/WorkflowPurger.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using WorkflowCore.Models;
+using WorkflowCore.Interface;
+
+namespace WorkflowCore.Persistence.MongoDB.Services
+{
+    public class WorkflowPurger : IWorkflowPurger
+    {
+        private readonly IMongoDatabase _database;
+        private IMongoCollection<WorkflowInstance> WorkflowInstances => _database.GetCollection<WorkflowInstance>(MongoPersistenceProvider.WorkflowCollectionName);
+
+
+        public WorkflowPurger(IMongoDatabase database)
+        {
+            _database = database;
+        }
+        
+        public async Task PurgeWorkflows(WorkflowStatus status, DateTime olderThan)
+        {
+            var olderThanUtc = olderThan.ToUniversalTime();
+            await WorkflowInstances.DeleteManyAsync(x => x.Status == status && x.CompleteTime < olderThanUtc);
+        }
+    }
+}

--- a/src/providers/WorkflowCore.Persistence.MongoDB/WorkflowCore.Persistence.MongoDB.csproj
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/WorkflowCore.Persistence.MongoDB.csproj
@@ -14,10 +14,10 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <Description>Provides support to persist workflows running on Workflow Core to a MongoDB database.</Description>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/providers/WorkflowCore.Persistence.MySQL/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.MySQL/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using WorkflowCore.Interface;
 using WorkflowCore.Models;
 using WorkflowCore.Persistence.EntityFramework.Services;
 using WorkflowCore.Persistence.MySQL;
@@ -11,6 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static WorkflowOptions UseMySQL(this WorkflowOptions options, string connectionString, bool canCreateDB, bool canMigrateDB, Action<MySqlDbContextOptionsBuilder> mysqlOptionsAction = null)
         {
             options.UsePersistence(sp => new EntityFrameworkPersistenceProvider(new MysqlContextFactory(connectionString, mysqlOptionsAction), canCreateDB, canMigrateDB));
+            options.Services.AddTransient<IWorkflowPurger, WorkflowPurger>();
             return options;
         }
     }

--- a/src/providers/WorkflowCore.Persistence.MySQL/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.MySQL/ServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static WorkflowOptions UseMySQL(this WorkflowOptions options, string connectionString, bool canCreateDB, bool canMigrateDB, Action<MySqlDbContextOptionsBuilder> mysqlOptionsAction = null)
         {
             options.UsePersistence(sp => new EntityFrameworkPersistenceProvider(new MysqlContextFactory(connectionString, mysqlOptionsAction), canCreateDB, canMigrateDB));
-            options.Services.AddTransient<IWorkflowPurger, WorkflowPurger>();
+            options.Services.AddTransient<IWorkflowPurger>(sp => new WorkflowPurger(new MysqlContextFactory(connectionString, mysqlOptionsAction)));
             return options;
         }
     }

--- a/src/providers/WorkflowCore.Persistence.MySQL/WorkflowCore.Persistence.MySQL.csproj
+++ b/src/providers/WorkflowCore.Persistence.MySQL/WorkflowCore.Persistence.MySQL.csproj
@@ -16,9 +16,9 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Description>Provides support to persist workflows running on Workflow Core to a MySQL database.</Description>
-    <Version>1.2.0</Version>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
+    <Version>1.2.1</Version>
+    <AssemblyVersion>1.2.1.0</AssemblyVersion>
+    <FileVersion>1.2.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/providers/WorkflowCore.Persistence.PostgreSQL/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.PostgreSQL/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using WorkflowCore.Interface;
 using WorkflowCore.Models;
 using WorkflowCore.Persistence.EntityFramework.Services;
 using WorkflowCore.Persistence.PostgreSQL;
@@ -14,6 +15,7 @@ namespace Microsoft.Extensions.DependencyInjection
             string connectionString, bool canCreateDB, bool canMigrateDB, string schemaName="wfc")
         {
             options.UsePersistence(sp => new EntityFrameworkPersistenceProvider(new PostgresContextFactory(connectionString, schemaName), canCreateDB, canMigrateDB));
+            options.Services.AddTransient<IWorkflowPurger, WorkflowPurger>();
             return options;
         }
     }

--- a/src/providers/WorkflowCore.Persistence.PostgreSQL/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.PostgreSQL/ServiceCollectionExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.DependencyInjection
             string connectionString, bool canCreateDB, bool canMigrateDB, string schemaName="wfc")
         {
             options.UsePersistence(sp => new EntityFrameworkPersistenceProvider(new PostgresContextFactory(connectionString, schemaName), canCreateDB, canMigrateDB));
-            options.Services.AddTransient<IWorkflowPurger, WorkflowPurger>();
+            options.Services.AddTransient<IWorkflowPurger>(sp => new WorkflowPurger(new PostgresContextFactory(connectionString, schemaName)));
             return options;
         }
     }

--- a/src/providers/WorkflowCore.Persistence.PostgreSQL/WorkflowCore.Persistence.PostgreSQL.csproj
+++ b/src/providers/WorkflowCore.Persistence.PostgreSQL/WorkflowCore.Persistence.PostgreSQL.csproj
@@ -15,9 +15,9 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Description>Provides support to persist workflows running on Workflow Core to a PostgreSQL database.</Description>
-    <Version>2.0.2</Version>
-    <AssemblyVersion>2.0.2.0</AssemblyVersion>
-    <FileVersion>2.0.2.0</FileVersion>
+    <Version>2.1.1</Version>
+    <AssemblyVersion>2.1.1.0</AssemblyVersion>
+    <FileVersion>2.1.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/providers/WorkflowCore.Persistence.SqlServer/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.SqlServer/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using WorkflowCore.Interface;
 using WorkflowCore.Models;
 using WorkflowCore.Persistence.EntityFramework.Interfaces;
 using WorkflowCore.Persistence.EntityFramework.Services;
@@ -11,6 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static WorkflowOptions UseSqlServer(this WorkflowOptions options, string connectionString, bool canCreateDB, bool canMigrateDB)
         {
             options.UsePersistence(sp => new EntityFrameworkPersistenceProvider(new SqlContextFactory(connectionString), canCreateDB, canMigrateDB));
+            options.Services.AddTransient<IWorkflowPurger, WorkflowPurger>();
             return options;
         }
     }

--- a/src/providers/WorkflowCore.Persistence.SqlServer/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.SqlServer/ServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static WorkflowOptions UseSqlServer(this WorkflowOptions options, string connectionString, bool canCreateDB, bool canMigrateDB)
         {
             options.UsePersistence(sp => new EntityFrameworkPersistenceProvider(new SqlContextFactory(connectionString), canCreateDB, canMigrateDB));
-            options.Services.AddTransient<IWorkflowPurger, WorkflowPurger>();
+            options.Services.AddTransient<IWorkflowPurger>(sp => new WorkflowPurger(new SqlContextFactory(connectionString)));
             return options;
         }
     }

--- a/src/providers/WorkflowCore.Persistence.SqlServer/WorkflowCore.Persistence.SqlServer.csproj
+++ b/src/providers/WorkflowCore.Persistence.SqlServer/WorkflowCore.Persistence.SqlServer.csproj
@@ -15,10 +15,10 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.0.1</Version>
+    <Version>2.1.1</Version>
     <Description>Provides support to persist workflows running on Workflow Core to a SQL Server database.</Description>
-    <AssemblyVersion>2.0.1.0</AssemblyVersion>
-    <FileVersion>2.0.1.0</FileVersion>
+    <AssemblyVersion>2.1.1.0</AssemblyVersion>
+    <FileVersion>2.1.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/providers/WorkflowCore.Persistence.Sqlite/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.Sqlite/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using WorkflowCore.Interface;
 using WorkflowCore.Models;
 using WorkflowCore.Persistence.EntityFramework.Services;
 using WorkflowCore.Persistence.Sqlite;
@@ -13,6 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static WorkflowOptions UseSqlite(this WorkflowOptions options, string connectionString, bool canCreateDB)
         {
             options.UsePersistence(sp => new EntityFrameworkPersistenceProvider(new SqliteContextFactory(connectionString), canCreateDB, false));
+            options.Services.AddTransient<IWorkflowPurger, WorkflowPurger>();
             return options;
         }
     }

--- a/src/providers/WorkflowCore.Persistence.Sqlite/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.Sqlite/ServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static WorkflowOptions UseSqlite(this WorkflowOptions options, string connectionString, bool canCreateDB)
         {
             options.UsePersistence(sp => new EntityFrameworkPersistenceProvider(new SqliteContextFactory(connectionString), canCreateDB, false));
-            options.Services.AddTransient<IWorkflowPurger, WorkflowPurger>();
+            options.Services.AddTransient<IWorkflowPurger>(sp => new WorkflowPurger(new SqliteContextFactory(connectionString)));
             return options;
         }
     }

--- a/src/providers/WorkflowCore.Persistence.Sqlite/WorkflowCore.Persistence.Sqlite.csproj
+++ b/src/providers/WorkflowCore.Persistence.Sqlite/WorkflowCore.Persistence.Sqlite.csproj
@@ -16,9 +16,9 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Description>Provides support to persist workflows running on Workflow Core to a Sqlite database.</Description>
-    <Version>1.9.2</Version>
-    <AssemblyVersion>1.9.2.0</AssemblyVersion>
-    <FileVersion>1.9.2.0</FileVersion>
+    <Version>1.9.3</Version>
+    <AssemblyVersion>1.9.3.0</AssemblyVersion>
+    <FileVersion>1.9.3.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds a feature to purge old workflows from the persistence store.

New `IWorkflowPurger` service that can be injected from the IoC container
```c#
Task PurgeWorkflows(WorkflowStatus status, DateTime olderThan)
```
Implementations are currently only for SQL Server, Postgres and MongoDB
