### PR TITLE
Ability to add data directly to a workflow

### DIFF
--- a/src/WorkflowCore/Interface/IWorkflowController.cs
+++ b/src/WorkflowCore/Interface/IWorkflowController.cs
@@ -12,7 +12,8 @@ namespace WorkflowCore.Interface
         Task<string> StartWorkflow<TData>(string workflowId, TData data = null, string reference=null) where TData : class, new();
         Task<string> StartWorkflow<TData>(string workflowId, int? version, TData data = null, string reference=null) where TData : class, new();
 
-        Task PublishEvent(string eventName, string eventKey, object eventData, DateTime? effectiveDate = null);
+        void AddWorkflowData(string workflowId, string key, object data);
+		Task PublishEvent(string eventName, string eventKey, object eventData, DateTime? effectiveDate = null);
         void RegisterWorkflow<TWorkflow>() where TWorkflow : IWorkflow, new();
         void RegisterWorkflow<TWorkflow, TData>() where TWorkflow : IWorkflow<TData>, new() where TData : new();
 

--- a/src/WorkflowCore/Services/WorkflowController.cs
+++ b/src/WorkflowCore/Services/WorkflowController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -94,7 +95,25 @@ namespace WorkflowCore.Services
             return id;
         }
 
-        public async Task PublishEvent(string eventName, string eventKey, object eventData, DateTime? effectiveDate = null)
+
+        public async void AddWorkflowData(string workflowId, string key, object data)
+        {
+	        var wf = await _persistenceStore.GetWorkflowInstance(workflowId);
+	        var dict = (wf.Data as IDictionary<string, object>);
+	        if (dict == null) throw new NullReferenceException("unable to load workflow data as dictionary");
+	        if (dict.ContainsKey(key))
+	        {
+		        dict[key] = data;
+	        }
+	        else
+	        {
+		        dict.Add(key, data);
+	        }
+
+	        await _persistenceStore.PersistWorkflow(wf);
+        }
+
+		public async Task PublishEvent(string eventName, string eventKey, object eventData, DateTime? effectiveDate = null)
         {
             _logger.LogDebug("Creating event {0} {1}", eventName, eventKey);
             Event evt = new Event();

--- a/src/WorkflowCore/Services/WorkflowHost.cs
+++ b/src/WorkflowCore/Services/WorkflowHost.cs
@@ -72,7 +72,12 @@ namespace WorkflowCore.Services
             return _workflowController.StartWorkflow(workflowId, version, data, reference);
         }
 
-        public Task PublishEvent(string eventName, string eventKey, object eventData, DateTime? effectiveDate = null)
+        public async void AddWorkflowData(string workflowId, string key, object data)
+        {
+	        _workflowController.AddWorkflowData(workflowId, key, data);
+        }
+
+		public Task PublishEvent(string eventName, string eventKey, object eventData, DateTime? effectiveDate = null)
         {
             return _workflowController.PublishEvent(eventName, eventKey, eventData, effectiveDate);
         }


### PR DESCRIPTION
This method can be used to directly update workflow data, we use this function via a REST api to add state data to the work flow instance allowing us to use that data in later steps and for reporting purposes. 

This can be useful when calling out to an extenal process (e.g. a REST API) from the workflow, where the external process may do multiple functions and need to push data back to the workflow during any one of those steps. Or when there is a long running function external to the workflow, but the work flow should be updated to that state of that function.

E.g. We have a have a workflow which kicks off a survey.
The survey has multiple pages and can be saved and returned to over a number of weeks.
We use this method to store the current state and page number of the survey so that returning user is displayed the correct page, and so that the administrators can see where in the process the user is.

We can also push some survey data into the workflow and use IF steps to change outcomes based on the survey data.

We could do this using events and multiple steps one waitForEvent per page, but that would tightly couple our dynamic survey system to the workflow steps. Therefore the approch of allowing direct data access seems to make sense.

Hopefuly this scenario makes sense nad you can see the use case forthis functionality.

Please let me know if this pull request needs any more information or any changes. 
