### PR TITLE
Enable override of RunAsync in StepBody

### DIFF
--- a/src/WorkflowCore/Models/StepBody.cs
+++ b/src/WorkflowCore/Models/StepBody.cs
@@ -6,9 +6,12 @@ namespace WorkflowCore.Models
 {
     public abstract class StepBody : IStepBody
     {
-        public abstract ExecutionResult Run(IStepExecutionContext context);
+        public virtual ExecutionResult Run(IStepExecutionContext context)
+        {
+            throw new NotImplementedException();
+        }
 
-        public Task<ExecutionResult> RunAsync(IStepExecutionContext context)
+        public virtual Task<ExecutionResult> RunAsync(IStepExecutionContext context)
         {
             return Task.FromResult(Run(context));
         }        


### PR DESCRIPTION
Allow implementations of StepBody to override the RunAsync method so asynchronous operations can be performed with the await keyword inside a StepBody.

Removed the abstract keyword from the Run method so implementors overriding RunAsync do not need to override both Run and RunAsync.
Implementors who choose not to override RunAsync do not need to make any changes as the default implementation of RunAsync makes a call to Run.
Implementors who forget to override either Run or RunAsync will receive a NotImplementedException instead of the compiler abstract method warning.