### PR TITLE
Add UtcNow to IDateTimeProvider, and use that throughout.

### DIFF
--- a/src/WorkflowCore/Interface/IDateTimeProvider.cs
+++ b/src/WorkflowCore/Interface/IDateTimeProvider.cs
@@ -5,5 +5,6 @@ namespace WorkflowCore.Interface
     public interface IDateTimeProvider
     {
         DateTime Now { get; }
+        DateTime UtcNow { get; }
     }
 }

--- a/src/WorkflowCore/Services/BackgroundTasks/EventConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/EventConsumer.cs
@@ -37,7 +37,7 @@ namespace WorkflowCore.Services.BackgroundTasks
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var evt = await _persistenceStore.GetEvent(itemId);
-                if (evt.EventTime <= _datetimeProvider.Now.ToUniversalTime())
+                if (evt.EventTime <= _datetimeProvider.UtcNow)
                 {
                     var subs = await _persistenceStore.GetSubcriptions(evt.EventName, evt.EventKey, evt.EventTime);
                     var toQueue = new List<string>();

--- a/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
@@ -71,7 +71,7 @@ namespace WorkflowCore.Services.BackgroundTasks
 
                         await persistenceStore.PersistErrors(result.Errors);
 
-                        var readAheadTicks = _datetimeProvider.Now.Add(Options.PollInterval).ToUniversalTime().Ticks;
+                        var readAheadTicks = _datetimeProvider.UtcNow.Add(Options.PollInterval).Ticks;
 
                         if ((workflow.Status == WorkflowStatus.Runnable) && workflow.NextExecution.HasValue && workflow.NextExecution.Value < readAheadTicks)
                         {
@@ -109,7 +109,7 @@ namespace WorkflowCore.Services.BackgroundTasks
                     return;
                 }
 
-                var target = (workflow.NextExecution.Value - _datetimeProvider.Now.ToUniversalTime().Ticks);
+                var target = (workflow.NextExecution.Value - _datetimeProvider.UtcNow.Ticks);
                 if (target > 0)
                 {
                     await Task.Delay(TimeSpan.FromTicks(target), cancellationToken);

--- a/src/WorkflowCore/Services/DateTimeProvider.cs
+++ b/src/WorkflowCore/Services/DateTimeProvider.cs
@@ -6,5 +6,6 @@ namespace WorkflowCore.Services
     public class DateTimeProvider : IDateTimeProvider
     {
         public DateTime Now => DateTime.Now;
+        public DateTime UtcNow => DateTime.UtcNow;
     }
 }

--- a/src/WorkflowCore/Services/ErrorHandlers/CompensateHandler.cs
+++ b/src/WorkflowCore/Services/ErrorHandlers/CompensateHandler.cs
@@ -60,7 +60,7 @@ namespace WorkflowCore.Services.ErrorHandlers
                 }
 
                 scopePointer.Active = false;
-                scopePointer.EndTime = _datetimeProvider.Now.ToUniversalTime();
+                scopePointer.EndTime = _datetimeProvider.UtcNow;
                 scopePointer.Status = PointerStatus.Failed;
 
                 if (scopeStep.CompensationStepId.HasValue)

--- a/src/WorkflowCore/Services/ErrorHandlers/RetryHandler.cs
+++ b/src/WorkflowCore/Services/ErrorHandlers/RetryHandler.cs
@@ -22,7 +22,7 @@ namespace WorkflowCore.Services.ErrorHandlers
         public void Handle(WorkflowInstance workflow, WorkflowDefinition def, ExecutionPointer pointer, WorkflowStep step, Exception exception, Queue<ExecutionPointer> bubbleUpQueue)
         {
             pointer.RetryCount++;
-            pointer.SleepUntil = _datetimeProvider.Now.ToUniversalTime().Add(step.RetryInterval ?? def.DefaultErrorRetryInterval ?? _options.ErrorRetryInterval);
+            pointer.SleepUntil = _datetimeProvider.UtcNow.Add(step.RetryInterval ?? def.DefaultErrorRetryInterval ?? _options.ErrorRetryInterval);
             step.PrimeForRetry(pointer);
         }
     }

--- a/src/WorkflowCore/Services/ErrorHandlers/SuspendHandler.cs
+++ b/src/WorkflowCore/Services/ErrorHandlers/SuspendHandler.cs
@@ -24,7 +24,7 @@ namespace WorkflowCore.Services.ErrorHandlers
             workflow.Status = WorkflowStatus.Suspended;
             _eventPublisher.PublishNotification(new WorkflowSuspended()
             {
-                EventTimeUtc = _datetimeProvider.Now,
+                EventTimeUtc = _datetimeProvider.UtcNow,
                 Reference = workflow.Reference,
                 WorkflowInstanceId = workflow.Id,
                 WorkflowDefinitionId = workflow.WorkflowDefinitionId,

--- a/src/WorkflowCore/Services/ErrorHandlers/TerminateHandler.cs
+++ b/src/WorkflowCore/Services/ErrorHandlers/TerminateHandler.cs
@@ -24,7 +24,7 @@ namespace WorkflowCore.Services.ErrorHandlers
             workflow.Status = WorkflowStatus.Terminated;
             _eventPublisher.PublishNotification(new WorkflowTerminated()
             {
-                EventTimeUtc = _datetimeProvider.Now,
+                EventTimeUtc = _datetimeProvider.UtcNow,
                 Reference = workflow.Reference,
                 WorkflowInstanceId = workflow.Id,
                 WorkflowDefinitionId = workflow.WorkflowDefinitionId,

--- a/src/WorkflowCore/Services/ExecutionResultProcessor.cs
+++ b/src/WorkflowCore/Services/ExecutionResultProcessor.cs
@@ -33,7 +33,7 @@ namespace WorkflowCore.Services
             pointer.Outcome = result.OutcomeValue;
             if (result.SleepFor.HasValue)
             {
-                pointer.SleepUntil = _datetimeProvider.Now.ToUniversalTime().Add(result.SleepFor.Value);
+                pointer.SleepUntil = _datetimeProvider.UtcNow.Add(result.SleepFor.Value);
                 pointer.Status = PointerStatus.Sleeping;
             }
 
@@ -57,7 +57,7 @@ namespace WorkflowCore.Services
             if (result.Proceed)
             {
                 pointer.Active = false;
-                pointer.EndTime = _datetimeProvider.Now.ToUniversalTime();
+                pointer.EndTime = _datetimeProvider.UtcNow;
                 pointer.Status = PointerStatus.Complete;
 
                 foreach (var outcomeTarget in step.Outcomes.Where(x => object.Equals(x.GetValue(workflow.Data), result.OutcomeValue) || x.GetValue(workflow.Data) == null))
@@ -67,7 +67,7 @@ namespace WorkflowCore.Services
 
                 _eventPublisher.PublishNotification(new StepCompleted()
                 {
-                    EventTimeUtc = _datetimeProvider.Now,
+                    EventTimeUtc = _datetimeProvider.UtcNow,
                     Reference = workflow.Reference,
                     ExecutionPointerId = pointer.Id,
                     StepId = step.Id,
@@ -92,7 +92,7 @@ namespace WorkflowCore.Services
         {
             _eventPublisher.PublishNotification(new WorkflowError()
             {
-                EventTimeUtc = _datetimeProvider.Now,
+                EventTimeUtc = _datetimeProvider.UtcNow,
                 Reference = workflow.Reference,
                 WorkflowInstanceId = workflow.Id,
                 WorkflowDefinitionId = workflow.WorkflowDefinitionId,

--- a/test/WorkflowCore.UnitTests/Services/ExecutionResultProcessorFixture.cs
+++ b/test/WorkflowCore.UnitTests/Services/ExecutionResultProcessorFixture.cs
@@ -34,6 +34,7 @@ namespace WorkflowCore.UnitTests.Services
             Options = new WorkflowOptions(A.Fake<IServiceCollection>());
 
             A.CallTo(() => DateTimeProvider.Now).Returns(DateTime.Now);
+            A.CallTo(() => DateTimeProvider.UtcNow).Returns(DateTime.UtcNow);
 
             //config logging
             var loggerFactory = new LoggerFactory();

--- a/test/WorkflowCore.UnitTests/Services/WorkflowExecutorFixture.cs
+++ b/test/WorkflowCore.UnitTests/Services/WorkflowExecutorFixture.cs
@@ -48,6 +48,7 @@ namespace WorkflowCore.UnitTests.Services
             A.CallTo(() => scope.ServiceProvider).Returns(ServiceProvider);
 
             A.CallTo(() => DateTimeProvider.Now).Returns(DateTime.Now);
+            A.CallTo(() => DateTimeProvider.UtcNow).Returns(DateTime.UtcNow);
 
             //config logging
             var loggerFactory = new LoggerFactory();


### PR DESCRIPTION
Fix some assignments to EventTimeUtc.

Old version with DateTime.Now.ToUniversalTime was less clear and above an order of magnitude slower.