### PR TITLE
sql context init action

### DIFF
--- a/src/providers/WorkflowCore.Persistence.SqlServer/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.SqlServer/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data.Common;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
 using WorkflowCore.Persistence.EntityFramework.Interfaces;
@@ -9,10 +10,10 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ServiceCollectionExtensions
     {
-        public static WorkflowOptions UseSqlServer(this WorkflowOptions options, string connectionString, bool canCreateDB, bool canMigrateDB)
+        public static WorkflowOptions UseSqlServer(this WorkflowOptions options, string connectionString, bool canCreateDB, bool canMigrateDB, Action<DbConnection> initAction = null)
         {
-            options.UsePersistence(sp => new EntityFrameworkPersistenceProvider(new SqlContextFactory(connectionString), canCreateDB, canMigrateDB));
-            options.Services.AddTransient<IWorkflowPurger>(sp => new WorkflowPurger(new SqlContextFactory(connectionString)));
+            options.UsePersistence(sp => new EntityFrameworkPersistenceProvider(new SqlContextFactory(connectionString, initAction), canCreateDB, canMigrateDB));
+            options.Services.AddTransient<IWorkflowPurger>(sp => new WorkflowPurger(new SqlContextFactory(connectionString, initAction)));
             return options;
         }
     }

--- a/src/providers/WorkflowCore.Persistence.SqlServer/SqlContextFactory.cs
+++ b/src/providers/WorkflowCore.Persistence.SqlServer/SqlContextFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
 using WorkflowCore.Persistence.EntityFramework.Interfaces;
 using WorkflowCore.Persistence.EntityFramework.Services;
 
@@ -9,15 +10,20 @@ namespace WorkflowCore.Persistence.SqlServer
     public class SqlContextFactory : IWorkflowDbContextFactory
     {
         private readonly string _connectionString;
+        private readonly Action<DbConnection> _initAction;
 
-        public SqlContextFactory(string connectionString)
+        public SqlContextFactory(string connectionString, Action<DbConnection> initAction = null)
         {
             _connectionString = connectionString;
+            _initAction = initAction;
         }
-
+        
         public WorkflowDbContext Build()
         {
-            return new SqlServerContext(_connectionString);
+            var result = new SqlServerContext(_connectionString);
+            _initAction?.Invoke(result.Database.GetDbConnection());
+
+            return result;
         }
     }
 }

--- a/src/providers/WorkflowCore.Persistence.SqlServer/SqlServerContext.cs
+++ b/src/providers/WorkflowCore.Persistence.SqlServer/SqlServerContext.cs
@@ -21,7 +21,7 @@ namespace WorkflowCore.Persistence.SqlServer
 
             _connectionString = connectionString;
         }
-
+        
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             base.OnConfiguring(optionsBuilder);

--- a/src/providers/WorkflowCore.Persistence.SqlServer/WorkflowCore.Persistence.SqlServer.csproj
+++ b/src/providers/WorkflowCore.Persistence.SqlServer/WorkflowCore.Persistence.SqlServer.csproj
@@ -15,11 +15,11 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <Description>Provides support to persist workflows running on Workflow Core to a SQL Server database.</Description>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.0.0</FileVersion>
-    <PackageVersion>3.0.0</PackageVersion>
+    <AssemblyVersion>3.0.1.0</AssemblyVersion>
+    <FileVersion>3.0.1.0</FileVersion>
+    <PackageVersion>3.0.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#495 @woutervs
Adds init action for Sql context... enabling setting the access token on the Sql connection.
https://docs.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-connect-msi

Something like this
```c#
services.AddWorkflow(wf => wf.UseSqlServer(@"Server=.;Database=WorkflowCore;Trusted_Connection=True;", true, true, 
                conn => (SqlConnection)conn.AccessToken = ...));
```