### PR TITLE
Overload the existing Setup() method in JsonWorkflowTest to wire up DI

### DIFF
--- a/test/WorkflowCore.Testing/JsonWorkflowTest.cs
+++ b/test/WorkflowCore.Testing/JsonWorkflowTest.cs
@@ -39,6 +39,25 @@ namespace WorkflowCore.Testing
             Host.Start();
         }
 
+        protected virtual void Setup(IServiceCollection services)
+        {
+            // setup dependency injection
+            services.AddLogging();
+            ConfigureServices(services);
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            //config logging
+            var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
+            //loggerFactory.AddConsole(LogLevel.Debug);
+
+            PersistenceProvider = serviceProvider.GetService<IPersistenceProvider>();
+            DefinitionLoader = serviceProvider.GetService<IDefinitionLoader>();
+            Host = serviceProvider.GetService<IWorkflowHost>();
+            Host.OnStepError += Host_OnStepError;
+            Host.Start();
+        }
+
         private void Host_OnStepError(WorkflowInstance workflow, WorkflowStep step, Exception exception)
         {
             UnhandledStepErrors.Add(new StepError()


### PR DESCRIPTION
Hi @danielgerlag 

While writing tests for my json based workflows, I noticed that there isn't any way of injecting mocks or any sort of dependency to the setup method. My workflow steps have multiple dependencies and while testing I want to wire up the mock objects.
To achieve that, I created a virtual overloaded method for the existing Setup() method, so users can pass IServiceCollection as input.
Please let me know if this change is correct or not.
Thanks