### PR TITLE
During BuildObjectInputAction for inputs graph object, we manage to c…

### DIFF
--- a/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
+++ b/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
@@ -303,8 +303,23 @@ namespace WorkflowCore.Services.DefinitionStorage
                     foreach (var child in subobj.Children<JObject>())
                         stack.Push(child);
                 }
-
-                stepProperty.SetValue(pStep, destObj);
+                
+                object existingStepPropertyValue = stepProperty.GetValue(pStep);
+                if (existingStepPropertyValue == null)
+                {
+                    // here we need to create a new object from the JObject and set it to property
+                    object inputPropertyValue = destObj.ToObject(stepProperty.PropertyType);
+                    stepProperty.SetValue(pStep, inputPropertyValue);
+                }
+                else
+                {
+                    // here the property value is already not null so we will simply populate this object
+                    using (var jsonReader = destObj.CreateReader())
+                    {
+                        JsonSerializer serializer = new JsonSerializer();
+                        serializer.Populate(jsonReader, existingStepPropertyValue);
+                    }
+                }
             }
             return acn;
         }


### PR DESCRIPTION
During BuildObjectInputAction for inputs graph object, we manage to convert the JObject into the step property type.
Currently the implementation supposed that the step property type if a assignable with a JObject, so directly a JObject or at least something like a IDictionary<string,object>.
I would like that the step property can be of any custom type, some model object of my project.
I think this should be the expected behavior no ?
For that I manage to convert the JObject into an object corresponding the the step property type.
I manage both cases :
 1. when the step property is null: so convert the JObject to step property type
 2. or if the step property is not null. For examlpe the step property could be instanciated in the step ctor to inject some dependency. In that case I keep the existing step property instance and simply populate this object from the JObject.