### PR TITLE
Allow dependency injection on Workflow

### DIFF
--- a/src/WorkflowCore/Interface/IWorkflowController.cs
+++ b/src/WorkflowCore/Interface/IWorkflowController.cs
@@ -13,8 +13,8 @@ namespace WorkflowCore.Interface
         Task<string> StartWorkflow<TData>(string workflowId, int? version, TData data = null, string reference=null) where TData : class, new();
 
         Task PublishEvent(string eventName, string eventKey, object eventData, DateTime? effectiveDate = null);
-        void RegisterWorkflow<TWorkflow>() where TWorkflow : IWorkflow, new();
-        void RegisterWorkflow<TWorkflow, TData>() where TWorkflow : IWorkflow<TData>, new() where TData : new();
+        void RegisterWorkflow<TWorkflow>() where TWorkflow : IWorkflow;
+        void RegisterWorkflow<TWorkflow, TData>() where TWorkflow : IWorkflow<TData> where TData : new();
 
         /// <summary>
         /// Suspend the execution of a given workflow until .ResumeWorkflow is called

--- a/src/WorkflowCore/Services/WorkflowController.cs
+++ b/src/WorkflowCore/Services/WorkflowController.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using WorkflowCore.Exceptions;
 using WorkflowCore.Interface;
@@ -19,9 +20,10 @@ namespace WorkflowCore.Services
         private readonly IQueueProvider _queueProvider;
         private readonly IExecutionPointerFactory _pointerFactory;
         private readonly ILifeCycleEventHub _eventHub;
+        private readonly IServiceProvider _serviceProvider;
         private readonly ILogger _logger;
 
-        public WorkflowController(IPersistenceProvider persistenceStore, IDistributedLockProvider lockProvider, IWorkflowRegistry registry, IQueueProvider queueProvider, IExecutionPointerFactory pointerFactory, ILifeCycleEventHub eventHub, ILoggerFactory loggerFactory)
+        public WorkflowController(IPersistenceProvider persistenceStore, IDistributedLockProvider lockProvider, IWorkflowRegistry registry, IQueueProvider queueProvider, IExecutionPointerFactory pointerFactory, ILifeCycleEventHub eventHub, ILoggerFactory loggerFactory, IServiceProvider serviceProvider)
         {
             _persistenceStore = persistenceStore;
             _lockProvider = lockProvider;
@@ -29,6 +31,7 @@ namespace WorkflowCore.Services
             _queueProvider = queueProvider;
             _pointerFactory = pointerFactory;
             _eventHub = eventHub;
+            _serviceProvider = serviceProvider;
             _logger = loggerFactory.CreateLogger<WorkflowController>();
         }
 
@@ -213,17 +216,17 @@ namespace WorkflowCore.Services
         }
 
         public void RegisterWorkflow<TWorkflow>()
-            where TWorkflow : IWorkflow, new()
+            where TWorkflow : IWorkflow
         {
-            TWorkflow wf = new TWorkflow();
+            TWorkflow wf = ActivatorUtilities.CreateInstance<TWorkflow>(_serviceProvider);
             _registry.RegisterWorkflow(wf);
         }
 
         public void RegisterWorkflow<TWorkflow, TData>()
-            where TWorkflow : IWorkflow<TData>, new()
+            where TWorkflow : IWorkflow<TData>
             where TData : new()
         {
-            TWorkflow wf = new TWorkflow();
+            TWorkflow wf = ActivatorUtilities.CreateInstance<TWorkflow>(_serviceProvider);
             _registry.RegisterWorkflow<TData>(wf);
         }
     }

--- a/src/WorkflowCore/Services/WorkflowHost.cs
+++ b/src/WorkflowCore/Services/WorkflowHost.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
 using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.Exceptions;
 using WorkflowCore.Models.LifeCycleEvents;
 
@@ -121,18 +122,16 @@ namespace WorkflowCore.Services
         }
 
         public void RegisterWorkflow<TWorkflow>()
-            where TWorkflow : IWorkflow, new()
+            where TWorkflow : IWorkflow
         {
-            TWorkflow wf = new TWorkflow();
-            Registry.RegisterWorkflow(wf);
+            _workflowController.RegisterWorkflow<TWorkflow>();
         }
 
         public void RegisterWorkflow<TWorkflow, TData>()
-            where TWorkflow : IWorkflow<TData>, new()
+            where TWorkflow : IWorkflow<TData>
             where TData : new()
         {
-            TWorkflow wf = new TWorkflow();
-            Registry.RegisterWorkflow<TData>(wf);
+            _workflowController.RegisterWorkflow<TWorkflow, TData>();
         }
 
         public Task<bool> SuspendWorkflow(string workflowId)

--- a/src/WorkflowCore/WorkflowCore.csproj
+++ b/src/WorkflowCore/WorkflowCore.csproj
@@ -15,9 +15,9 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Description>Workflow Core is a light weight workflow engine targeting .NET Standard.</Description>
-    <Version>3.1.5</Version>
-    <AssemblyVersion>3.1.5.0</AssemblyVersion>
-    <FileVersion>3.1.5.0</FileVersion>
+    <Version>3.1.6</Version>
+    <AssemblyVersion>3.1.6.0</AssemblyVersion>
+    <FileVersion>3.1.6.0</FileVersion>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageIconUrl>https://github.com/danielgerlag/workflow-core/raw/master/src/logo.png</PackageIconUrl>
     <PackageVersion>3.1.5</PackageVersion>


### PR DESCRIPTION
It will be very usefull to can inject services/configuration into Workflow directly.

Example:
```csharp
public class SampleWorkflow : IWorkflow<SampleRequest>
{
    private readonly IOptions<WorkflowOptions> _options;

    public SampleWorkflow(IOptions<WorkflowOptions> options)
    {
        _options = options;
    }

    public string Id => nameof(SampleWorkflow);

    public int Version => 1;

    public void Build(IWorkflowBuilder<SampleRequest> builder)
    {
        builder
            .StartWith(context => ExecutionResult.Next())
            .Then<SampleStep>()
                .Input(step => step.Request, data => data)
                .OnError(WorkflowErrorHandling.Retry, _options.Value.RetryInterval);
    }
}
```