### PR TITLE
Fix a little typo in mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ nav:
     - Getting started: getting-started.md
     - External events: external-events.md
     - Activity workers: activities.md
-    - Error handing: error-handling.md
+    - Error handling: error-handling.md
     - Control structures: control-structures.md
     - Saga transactions: sagas.md
     - JSON / YAML Definitions: json-yaml.md


### PR DESCRIPTION
`Error handing` => `Error handling`