### PR TITLE
Add possibility to not use `WorkflowBuilder.StartWith()` every time

### DIFF
--- a/src/WorkflowCore/Interface/IStepBuilder.cs
+++ b/src/WorkflowCore/Interface/IStepBuilder.cs
@@ -6,7 +6,7 @@ using WorkflowCore.Primitives;
 
 namespace WorkflowCore.Interface
 {
-    public interface IStepBuilder<TData, TStepBody>
+    public interface IStepBuilder<TData, TStepBody> : IWorkflowModifier<TData, TStepBody>
         where TStepBody : IStepBody
     {
 
@@ -27,36 +27,6 @@ namespace WorkflowCore.Interface
         /// <param name="id">A custom Id to reference this step</param>
         /// <returns></returns>
         IStepBuilder<TData, TStepBody> Id(string id);
-
-        /// <summary>
-        /// Specify the next step in the workflow
-        /// </summary>
-        /// <typeparam name="TStep">The type of the step to execute</typeparam>
-        /// <param name="stepSetup">Configure additional parameters for this step</param>
-        /// <returns></returns>
-        IStepBuilder<TData, TStep> Then<TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody;
-
-        /// <summary>
-        /// Specify the next step in the workflow
-        /// </summary>
-        /// <typeparam name="TStep"></typeparam>
-        /// <param name="newStep"></param>
-        /// <returns></returns>
-        IStepBuilder<TData, TStep> Then<TStep>(IStepBuilder<TData, TStep> newStep) where TStep : IStepBody;
-
-        /// <summary>
-        /// Specify an inline next step in the workflow
-        /// </summary>
-        /// <param name="body"></param>
-        /// <returns></returns>
-        IStepBuilder<TData, InlineStepBody> Then(Func<IStepExecutionContext, ExecutionResult> body);
-
-        /// <summary>
-        /// Specify an inline next step in the workflow
-        /// </summary>
-        /// <param name="body"></param>
-        /// <returns></returns>
-        IStepBuilder<TData, ActionStepBody> Then(Action<IStepExecutionContext> body);
 
         /// <summary>
         /// Specify the next step in the workflow by Id
@@ -129,26 +99,6 @@ namespace WorkflowCore.Interface
         /// <returns></returns>
         IStepBuilder<TData, TStepBody> Output(Action<TStepBody, TData> action);
 
-        /// <summary>
-        /// Wait here until to specified event is published
-        /// </summary>
-        /// <param name="eventName">The name used to identify the kind of event to wait for</param>
-        /// <param name="eventKey">A specific key value within the context of the event to wait for</param>
-        /// <param name="effectiveDate">Listen for events as of this effective date</param>
-        /// <param name="cancelCondition">A conditon that when true will cancel this WaitFor</param>
-        /// <returns></returns>
-        IStepBuilder<TData, WaitFor> WaitFor(string eventName, Expression<Func<TData, string>> eventKey, Expression<Func<TData, DateTime>> effectiveDate = null, Expression<Func<TData, bool>> cancelCondition = null);
-
-        /// <summary>
-        /// Wait here until to specified event is published
-        /// </summary>
-        /// <param name="eventName">The name used to identify the kind of event to wait for</param>
-        /// <param name="eventKey">A specific key value within the context of the event to wait for</param>
-        /// <param name="effectiveDate">Listen for events as of this effective date</param>
-        /// <param name="cancelCondition">A conditon that when true will cancel this WaitFor</param>
-        /// <returns></returns>
-        IStepBuilder<TData, WaitFor> WaitFor(string eventName, Expression<Func<TData, IStepExecutionContext, string>> eventKey, Expression<Func<TData, DateTime>> effectiveDate = null, Expression<Func<TData, bool>> cancelCondition = null);
-        
         IStepBuilder<TData, TStep> End<TStep>(string name) where TStep : IStepBody;
 
         /// <summary>
@@ -164,83 +114,6 @@ namespace WorkflowCore.Interface
         /// </summary>
         /// <returns></returns>
         IStepBuilder<TData, TStepBody> EndWorkflow();
-
-        /// <summary>
-        /// Wait for a specified period
-        /// </summary>
-        /// <param name="period"></param>
-        /// <returns></returns>
-        IStepBuilder<TData, Delay> Delay(Expression<Func<TData, TimeSpan>> period);
-
-        /// <summary>
-        /// Evaluate an expression and take a different path depending on the value
-        /// </summary>
-        /// <param name="expression">Expression to evaluate for decision</param>
-        /// <returns></returns>
-        IStepBuilder<TData, Decide> Decide(Expression<Func<TData, object>> expression);
-        
-        /// <summary>
-        /// Execute a block of steps, once for each item in a collection in a parallel foreach
-        /// </summary>
-        /// <param name="collection">Resolves a collection for iterate over</param>
-        /// <returns></returns>
-        IContainerStepBuilder<TData, Foreach, Foreach> ForEach(Expression<Func<TData, IEnumerable>> collection);
-
-        /// <summary>
-        /// Execute a block of steps, once for each item in a collection in a RunParallel foreach
-        /// </summary>
-        /// <param name="collection">Resolves a collection for iterate over</param>
-        /// <returns></returns>
-        IContainerStepBuilder<TData, Foreach, Foreach> ForEach(Expression<Func<TData, IEnumerable>> collection, Expression<Func<TData, bool>> runParallel);
-
-        /// <summary>
-        /// Repeat a block of steps until a condition becomes true
-        /// </summary>
-        /// <param name="condition">Resolves a condition to break out of the while loop</param>
-        /// <returns></returns>
-        IContainerStepBuilder<TData, While, While> While(Expression<Func<TData, bool>> condition);
-
-        /// <summary>
-        /// Execute a block of steps if a condition is true
-        /// </summary>
-        /// <param name="condition">Resolves a condition to evaluate</param>
-        /// <returns></returns>
-        IContainerStepBuilder<TData, If, If> If(Expression<Func<TData, bool>> condition);
-
-        /// <summary>
-        /// Configure an outcome for this step, then wire it to a sequence
-        /// </summary>
-        /// <param name="outcomeValue"></param>
-        /// <returns></returns>
-        IContainerStepBuilder<TData, When, OutcomeSwitch> When(Expression<Func<TData, object>> outcomeValue, string label = null);
-
-        /// <summary>
-        /// Execute multiple blocks of steps in parallel
-        /// </summary>
-        /// <returns></returns>
-        IParallelStepBuilder<TData, Sequence> Parallel();
-
-        /// <summary>
-        /// Execute a sequence of steps in a container
-        /// </summary>
-        /// <returns></returns>
-        IStepBuilder<TData, Sequence> Saga(Action<IWorkflowBuilder<TData>> builder);
-
-        /// <summary>
-        /// Schedule a block of steps to execute in parallel sometime in the future
-        /// </summary>
-        /// <param name="time">The time span to wait before executing the block</param>
-        /// <returns></returns>
-        IContainerStepBuilder<TData, Schedule, TStepBody> Schedule(Expression<Func<TData, TimeSpan>> time);
-
-        /// <summary>
-        /// Schedule a block of steps to execute in parallel sometime in the future at a recurring interval
-        /// </summary>
-        /// <param name="interval">The time span to wait between recurring executions</param>
-        /// <param name="until">Resolves a condition to stop the recurring task</param>
-        /// <returns></returns>
-        IContainerStepBuilder<TData, Recur, TStepBody> Recur(Expression<Func<TData, TimeSpan>> interval, Expression<Func<TData, bool>> until);
-
 
         /// <summary>
         /// Undo step if unhandled exception is thrown by this step
@@ -277,16 +150,5 @@ namespace WorkflowCore.Interface
         /// <param name="cancelCondition"></param>
         /// <returns></returns>
         IStepBuilder<TData, TStepBody> CancelCondition(Expression<Func<TData, bool>> cancelCondition, bool proceedAfterCancel = false);
-        
-        /// <summary>
-        /// Wait here until an external activity is complete
-        /// </summary>
-        /// <param name="activityName">The name used to identify the activity to wait for</param>
-        /// <param name="parameters">The data to pass the external activity worker</param>
-        /// <param name="effectiveDate">Listen for events as of this effective date</param>
-        /// <param name="cancelCondition">A conditon that when true will cancel this WaitFor</param>
-        /// <returns></returns>
-        IStepBuilder<TData, Activity> Activity(string activityName, Expression<Func<TData, object>> parameters = null, Expression<Func<TData, DateTime>> effectiveDate = null, Expression<Func<TData, bool>> cancelCondition = null);
-
     }
 }

--- a/src/WorkflowCore/Interface/IWorkflowBuilder.cs
+++ b/src/WorkflowCore/Interface/IWorkflowBuilder.cs
@@ -20,7 +20,7 @@ namespace WorkflowCore.Interface
         void AttachBranch(IWorkflowBuilder branch);
     }
 
-    public interface IWorkflowBuilder<TData> : IWorkflowBuilder
+    public interface IWorkflowBuilder<TData> : IWorkflowBuilder, IWorkflowModifier<TData, InlineStepBody>
     {        
         IStepBuilder<TData, TStep> StartWith<TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody;
 

--- a/src/WorkflowCore/Interface/IWorkflowModifier.cs
+++ b/src/WorkflowCore/Interface/IWorkflowModifier.cs
@@ -83,6 +83,13 @@ namespace WorkflowCore.Interface
     /// <param name="collection">Resolves a collection for iterate over</param>
     /// <returns></returns>
     IContainerStepBuilder<TData, Foreach, Foreach> ForEach(Expression<Func<TData, IEnumerable>> collection);
+    
+    /// <summary>
+    /// Execute a block of steps, once for each item in a collection in a RunParallel foreach
+    /// </summary>
+    /// <param name="collection">Resolves a collection for iterate over</param>
+    /// <returns></returns>
+    IContainerStepBuilder<TData, Foreach, Foreach> ForEach(Expression<Func<TData, IEnumerable>> collection, Expression<Func<TData, bool>> runParallel);
 
     /// <summary>
     /// Repeat a block of steps until a condition becomes true

--- a/src/WorkflowCore/Interface/IWorkflowModifier.cs
+++ b/src/WorkflowCore/Interface/IWorkflowModifier.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections;
+using System.Linq.Expressions;
+using WorkflowCore.Models;
+using WorkflowCore.Primitives;
+
+namespace WorkflowCore.Interface
+{
+    public interface IWorkflowModifier<TData, TStepBody>
+        where TStepBody : IStepBody
+
+    {
+    /// <summary>
+    /// Specify the next step in the workflow
+    /// </summary>
+    /// <typeparam name="TStep">The type of the step to execute</typeparam>
+    /// <param name="stepSetup">Configure additional parameters for this step</param>
+    /// <returns></returns>
+    IStepBuilder<TData, TStep> Then<TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody;
+
+    /// <summary>
+    /// Specify the next step in the workflow
+    /// </summary>
+    /// <typeparam name="TStep"></typeparam>
+    /// <param name="newStep"></param>
+    /// <returns></returns>
+    IStepBuilder<TData, TStep> Then<TStep>(IStepBuilder<TData, TStep> newStep) where TStep : IStepBody;
+
+    /// <summary>
+    /// Specify an inline next step in the workflow
+    /// </summary>
+    /// <param name="body"></param>
+    /// <returns></returns>
+    IStepBuilder<TData, InlineStepBody> Then(Func<IStepExecutionContext, ExecutionResult> body);
+
+    /// <summary>
+    /// Specify an inline next step in the workflow
+    /// </summary>
+    /// <param name="body"></param>
+    /// <returns></returns>
+    IStepBuilder<TData, ActionStepBody> Then(Action<IStepExecutionContext> body);
+
+    /// <summary>
+    /// Wait here until to specified event is published
+    /// </summary>
+    /// <param name="eventName">The name used to identify the kind of event to wait for</param>
+    /// <param name="eventKey">A specific key value within the context of the event to wait for</param>
+    /// <param name="effectiveDate">Listen for events as of this effective date</param>
+    /// <param name="cancelCondition">A conditon that when true will cancel this WaitFor</param>
+    /// <returns></returns>
+    IStepBuilder<TData, WaitFor> WaitFor(string eventName, Expression<Func<TData, string>> eventKey,
+        Expression<Func<TData, DateTime>> effectiveDate = null, Expression<Func<TData, bool>> cancelCondition = null);
+
+    /// <summary>
+    /// Wait here until to specified event is published
+    /// </summary>
+    /// <param name="eventName">The name used to identify the kind of event to wait for</param>
+    /// <param name="eventKey">A specific key value within the context of the event to wait for</param>
+    /// <param name="effectiveDate">Listen for events as of this effective date</param>
+    /// <param name="cancelCondition">A conditon that when true will cancel this WaitFor</param>
+    /// <returns></returns>
+    IStepBuilder<TData, WaitFor> WaitFor(string eventName,
+        Expression<Func<TData, IStepExecutionContext, string>> eventKey,
+        Expression<Func<TData, DateTime>> effectiveDate = null, Expression<Func<TData, bool>> cancelCondition = null);
+
+    /// <summary>
+    /// Wait for a specified period
+    /// </summary>
+    /// <param name="period"></param>
+    /// <returns></returns>
+    IStepBuilder<TData, Delay> Delay(Expression<Func<TData, TimeSpan>> period);
+
+    /// <summary>
+    /// Evaluate an expression and take a different path depending on the value
+    /// </summary>
+    /// <param name="expression">Expression to evaluate for decision</param>
+    /// <returns></returns>
+    IStepBuilder<TData, Decide> Decide(Expression<Func<TData, object>> expression);
+
+    /// <summary>
+    /// Execute a block of steps, once for each item in a collection in a parallel foreach
+    /// </summary>
+    /// <param name="collection">Resolves a collection for iterate over</param>
+    /// <returns></returns>
+    IContainerStepBuilder<TData, Foreach, Foreach> ForEach(Expression<Func<TData, IEnumerable>> collection);
+
+    /// <summary>
+    /// Repeat a block of steps until a condition becomes true
+    /// </summary>
+    /// <param name="condition">Resolves a condition to break out of the while loop</param>
+    /// <returns></returns>
+    IContainerStepBuilder<TData, While, While> While(Expression<Func<TData, bool>> condition);
+
+    /// <summary>
+    /// Execute a block of steps if a condition is true
+    /// </summary>
+    /// <param name="condition">Resolves a condition to evaluate</param>
+    /// <returns></returns>
+    IContainerStepBuilder<TData, If, If> If(Expression<Func<TData, bool>> condition);
+
+    /// <summary>
+    /// Configure an outcome for this step, then wire it to a sequence
+    /// </summary>
+    /// <param name="outcomeValue"></param>
+    /// <returns></returns>
+    IContainerStepBuilder<TData, When, OutcomeSwitch> When(Expression<Func<TData, object>> outcomeValue,
+        string label = null);
+
+    /// <summary>
+    /// Execute multiple blocks of steps in parallel
+    /// </summary>
+    /// <returns></returns>
+    IParallelStepBuilder<TData, Sequence> Parallel();
+
+    /// <summary>
+    /// Execute a sequence of steps in a container
+    /// </summary>
+    /// <returns></returns>
+    IStepBuilder<TData, Sequence> Saga(Action<IWorkflowBuilder<TData>> builder);
+
+    /// <summary>
+    /// Schedule a block of steps to execute in parallel sometime in the future
+    /// </summary>
+    /// <param name="time">The time span to wait before executing the block</param>
+    /// <returns></returns>
+    IContainerStepBuilder<TData, Schedule, TStepBody> Schedule(Expression<Func<TData, TimeSpan>> time);
+
+    /// <summary>
+    /// Schedule a block of steps to execute in parallel sometime in the future at a recurring interval
+    /// </summary>
+    /// <param name="interval">The time span to wait between recurring executions</param>
+    /// <param name="until">Resolves a condition to stop the recurring task</param>
+    /// <returns></returns>
+    IContainerStepBuilder<TData, Recur, TStepBody> Recur(Expression<Func<TData, TimeSpan>> interval,
+        Expression<Func<TData, bool>> until);
+
+    /// <summary>
+    /// Wait here until an external activity is complete
+    /// </summary>
+    /// <param name="activityName">The name used to identify the activity to wait for</param>
+    /// <param name="parameters">The data to pass the external activity worker</param>
+    /// <param name="effectiveDate">Listen for events as of this effective date</param>
+    /// <param name="cancelCondition">A conditon that when true will cancel this WaitFor</param>
+    /// <returns></returns>
+    IStepBuilder<TData, Activity> Activity(string activityName, Expression<Func<TData, object>> parameters = null,
+        Expression<Func<TData, DateTime>> effectiveDate = null, Expression<Func<TData, bool>> cancelCondition = null);
+
+    }
+}

--- a/src/WorkflowCore/Services/FluentBuilders/WorkflowBuilder.cs
+++ b/src/WorkflowCore/Services/FluentBuilders/WorkflowBuilder.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
 using WorkflowCore.Primitives;
@@ -148,7 +150,98 @@ namespace WorkflowCore.Services
             var result = new WorkflowBuilder<TData>(new List<WorkflowStep>());
             return result;
         }
-                
+
+        public IStepBuilder<TData, TStep> Then<TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody
+        {
+            return Start().Then(stepSetup);
+        }
+
+        public IStepBuilder<TData, TStep> Then<TStep>(IStepBuilder<TData, TStep> newStep) where TStep : IStepBody
+        {
+            return Start().Then(newStep);
+        }
+
+        public IStepBuilder<TData, InlineStepBody> Then(Func<IStepExecutionContext, ExecutionResult> body)
+        {
+            return Start().Then(body);
+        }
+
+        public IStepBuilder<TData, ActionStepBody> Then(Action<IStepExecutionContext> body)
+        {
+            return Start().Then(body);
+        }
+
+        public IStepBuilder<TData, WaitFor> WaitFor(string eventName, Expression<Func<TData, string>> eventKey, Expression<Func<TData, DateTime>> effectiveDate = null,
+            Expression<Func<TData, bool>> cancelCondition = null)
+        {
+            return Start().WaitFor(eventName, eventKey, effectiveDate, cancelCondition);
+        }
+
+        public IStepBuilder<TData, WaitFor> WaitFor(string eventName, Expression<Func<TData, IStepExecutionContext, string>> eventKey, Expression<Func<TData, DateTime>> effectiveDate = null,
+            Expression<Func<TData, bool>> cancelCondition = null)
+        {
+            return Start().WaitFor(eventName, eventKey, effectiveDate, cancelCondition);
+        }
+
+        public IStepBuilder<TData, Delay> Delay(Expression<Func<TData, TimeSpan>> period)
+        {
+            return Start().Delay(period);
+        }
+
+        public IStepBuilder<TData, Decide> Decide(Expression<Func<TData, object>> expression)
+        {
+            return Start().Decide(expression);
+        }
+
+        public IContainerStepBuilder<TData, Foreach, Foreach> ForEach(Expression<Func<TData, IEnumerable>> collection)
+        {
+            return Start().ForEach(collection);
+        }
+
+        public IContainerStepBuilder<TData, While, While> While(Expression<Func<TData, bool>> condition)
+        {
+            return Start().While(condition);
+        }
+
+        public IContainerStepBuilder<TData, If, If> If(Expression<Func<TData, bool>> condition)
+        {
+            return Start().If(condition);
+        }
+
+        public IContainerStepBuilder<TData, When, OutcomeSwitch> When(Expression<Func<TData, object>> outcomeValue, string label = null)
+        {
+            return ((IWorkflowModifier<TData, InlineStepBody>) Start()).When(outcomeValue, label);
+        }
+
+        public IParallelStepBuilder<TData, Sequence> Parallel()
+        {
+            return Start().Parallel();
+        }
+
+        public IStepBuilder<TData, Sequence> Saga(Action<IWorkflowBuilder<TData>> builder)
+        {
+            return Start().Saga(builder);
+        }
+
+        public IContainerStepBuilder<TData, Schedule, InlineStepBody> Schedule(Expression<Func<TData, TimeSpan>> time)
+        {
+            return Start().Schedule(time);
+        }
+
+        public IContainerStepBuilder<TData, Recur, InlineStepBody> Recur(Expression<Func<TData, TimeSpan>> interval, Expression<Func<TData, bool>> until)
+        {
+            return Start().Recur(interval, until);
+        }
+
+        public IStepBuilder<TData, Activity> Activity(string activityName, Expression<Func<TData, object>> parameters = null, Expression<Func<TData, DateTime>> effectiveDate = null,
+            Expression<Func<TData, bool>> cancelCondition = null)
+        {
+            return Start().Activity(activityName, parameters, effectiveDate, cancelCondition);
+        }
+
+        private IStepBuilder<TData, InlineStepBody> Start()
+        {
+            return StartWith(_ => ExecutionResult.Next());
+        }
     }
-        
 }

--- a/src/WorkflowCore/Services/FluentBuilders/WorkflowBuilder.cs
+++ b/src/WorkflowCore/Services/FluentBuilders/WorkflowBuilder.cs
@@ -197,6 +197,11 @@ namespace WorkflowCore.Services
         {
             return Start().ForEach(collection);
         }
+        
+        public IContainerStepBuilder<TData, Foreach, Foreach> ForEach(Expression<Func<TData, IEnumerable>> collection, Expression<Func<TData, bool>> runParallel)
+        {
+            return Start().ForEach(collection, runParallel);
+        }
 
         public IContainerStepBuilder<TData, While, While> While(Expression<Func<TData, bool>> condition)
         {


### PR DESCRIPTION
This pull request enables users to not start a workflow with `StartWith()` every time, which results in code that's much less boilerplate and that reads smoothier.