### PR TITLE
Feature: Context-aware scope for StepBody construction

### DIFF
--- a/src/WorkflowCore/Interface/IScopeProvider.cs
+++ b/src/WorkflowCore/Interface/IScopeProvider.cs
@@ -12,6 +12,6 @@ namespace WorkflowCore.Interface
         /// Create a new service scope
         /// </summary>
         /// <returns></returns>
-        IServiceScope CreateScope();
+        IServiceScope CreateScope(IStepExecutionContext context);
     }
 }

--- a/src/WorkflowCore/Services/ScopeProvider.cs
+++ b/src/WorkflowCore/Services/ScopeProvider.cs
@@ -6,20 +6,20 @@ namespace WorkflowCore.Services
 {
     /// <summary>
     /// A concrete implementation for the IScopeProvider interface
-    /// Largely to get around the problems of unit testing an extension method (CreateScope())
+    /// Could be used for context-aware scope creation customization
     /// </summary>
     public class ScopeProvider : IScopeProvider
     {
-        private readonly IServiceProvider provider;
+        private readonly IServiceScopeFactory _serviceScopeFactory;
 
-        public ScopeProvider(IServiceProvider provider)
+        public ScopeProvider(IServiceScopeFactory serviceScopeFactory)
         {
-            this.provider = provider;
+            _serviceScopeFactory = serviceScopeFactory;
         }
 
-        public IServiceScope CreateScope()
+        public IServiceScope CreateScope(IStepExecutionContext context)
         {
-            return provider.CreateScope();
+            return _serviceScopeFactory.CreateScope();
         }
     }
 }

--- a/src/WorkflowCore/Services/WorkflowExecutor.cs
+++ b/src/WorkflowCore/Services/WorkflowExecutor.cs
@@ -137,7 +137,16 @@ namespace WorkflowCore.Services
 
         private async Task ExecuteStep(WorkflowInstance workflow, WorkflowStep step, ExecutionPointer pointer, WorkflowExecutorResult wfResult, WorkflowDefinition def)
         {
-            using (var scope = _scopeProvider.CreateScope())
+            IStepExecutionContext context = new StepExecutionContext()
+            {
+                Workflow = workflow,
+                Step = step,
+                PersistenceData = pointer.PersistenceData,
+                ExecutionPointer = pointer,
+                Item = pointer.ContextItem
+            };
+            
+            using (var scope = _scopeProvider.CreateScope(context))
             {
                 _logger.LogDebug("Starting step {0} on workflow {1}", step.Name, workflow.Id);
 
@@ -156,15 +165,6 @@ namespace WorkflowCore.Services
                     });
                     return;
                 }
-
-                IStepExecutionContext context = new StepExecutionContext()
-                {
-                    Workflow = workflow,
-                    Step = step,
-                    PersistenceData = pointer.PersistenceData,
-                    ExecutionPointer = pointer,
-                    Item = pointer.ContextItem
-                };
 
                 foreach (var input in step.Inputs)
                     input.AssignInput(workflow.Data, body, context);

--- a/test/WorkflowCore.TestAssets/WorkflowCore.TestAssets.csproj
+++ b/test/WorkflowCore.TestAssets/WorkflowCore.TestAssets.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="NUnit" Version="3.6.1" />
   </ItemGroup>

--- a/test/WorkflowCore.TestAssets/WorkflowCore.TestAssets.csproj
+++ b/test/WorkflowCore.TestAssets/WorkflowCore.TestAssets.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="NUnit" Version="3.6.1" />
   </ItemGroup>

--- a/test/WorkflowCore.UnitTests/Services/ScopeProviderTests.cs
+++ b/test/WorkflowCore.UnitTests/Services/ScopeProviderTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using WorkflowCore.Interface;
+using WorkflowCore.Services;
+using Xunit;
+
+namespace WorkflowCore.UnitTests.Services
+{
+    public class ScopeProviderTests
+    {
+        private readonly ScopeProvider _sut;
+        private readonly Mock<IServiceScopeFactory> _scopeFactoryMock;
+
+        public ScopeProviderTests()
+        {
+            _scopeFactoryMock = new Mock<IServiceScopeFactory>();
+
+            _sut = new ScopeProvider(_scopeFactoryMock.Object);
+        }
+
+        [Fact(DisplayName = "Should return IServiceScope")]
+        public void ReturnsServiceScope_CreateScopeCalled()
+        {
+            var scope = new Mock<IServiceScope>().Object;
+            _scopeFactoryMock.Setup(x => x.CreateScope())
+                .Returns(scope);
+            
+            var result = _sut.CreateScope(new Mock<IStepExecutionContext>().Object);
+
+            result.Should().NotBeNull().And.BeSameAs(scope);
+            _scopeFactoryMock.Verify(x => x.CreateScope(), Times.Once);
+        }
+    }
+}

--- a/test/WorkflowCore.UnitTests/Services/WorkflowExecutorFixture.cs
+++ b/test/WorkflowCore.UnitTests/Services/WorkflowExecutorFixture.cs
@@ -3,15 +3,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
 using WorkflowCore.Services;
-using FluentAssertions;
 using Xunit;
-using WorkflowCore.Primitives;
-using System.Linq.Expressions;
-using System.Threading.Tasks;
 
 namespace WorkflowCore.UnitTests.Services
 {
@@ -44,7 +39,7 @@ namespace WorkflowCore.UnitTests.Services
             Options = new WorkflowOptions(A.Fake<IServiceCollection>());
 
             var scope = A.Fake<IServiceScope>();
-            A.CallTo(() => ScopeProvider.CreateScope()).Returns(scope);
+            A.CallTo(() => ScopeProvider.CreateScope(A<IStepExecutionContext>._)).Returns(scope);
             A.CallTo(() => scope.ServiceProvider).Returns(ServiceProvider);
 
             A.CallTo(() => DateTimeProvider.Now).Returns(DateTime.Now);


### PR DESCRIPTION
There's use case when you need to take control on how you create a lifetimescope. E.g. if you use Autofac with ServiceProviderFactory, you can override specific dependencies for child scope based on the current context.
#628 