### PR TITLE
Pass the CancellationToken into IStepExecutionContext for async steps.

### DIFF
--- a/src/WorkflowCore/Interface/IStepExecutionContext.cs
+++ b/src/WorkflowCore/Interface/IStepExecutionContext.cs
@@ -1,4 +1,5 @@
-﻿using WorkflowCore.Models;
+﻿using System.Threading;
+using WorkflowCore.Models;
 
 namespace WorkflowCore.Interface
 {
@@ -12,6 +13,8 @@ namespace WorkflowCore.Interface
 
         WorkflowStep Step { get; set; }
 
-        WorkflowInstance Workflow { get; set; }        
+        WorkflowInstance Workflow { get; set; }
+
+        CancellationToken CancellationToken { get; set; }
     }
 }

--- a/src/WorkflowCore/Interface/IWorkflowExecutor.cs
+++ b/src/WorkflowCore/Interface/IWorkflowExecutor.cs
@@ -1,10 +1,11 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using WorkflowCore.Models;
 
 namespace WorkflowCore.Interface
 {
     public interface IWorkflowExecutor
     {
-        Task<WorkflowExecutorResult> Execute(WorkflowInstance workflow);
+        Task<WorkflowExecutorResult> Execute(WorkflowInstance workflow, CancellationToken cancellationToken = default);
     }
 }

--- a/src/WorkflowCore/Models/StepExecutionContext.cs
+++ b/src/WorkflowCore/Models/StepExecutionContext.cs
@@ -1,4 +1,5 @@
 ﻿using WorkflowCore.Interface;
+using System.Threading;
 
 namespace WorkflowCore.Models
 {
@@ -13,5 +14,7 @@ namespace WorkflowCore.Models
         public object PersistenceData { get; set; }
 
         public object Item { get; set; }
+
+        public CancellationToken CancellationToken { get; set; } = CancellationToken.None;
     }
 }

--- a/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
@@ -48,7 +48,7 @@ namespace WorkflowCore.Services.BackgroundTasks
                 {
                     try
                     {
-                        result = await _executor.Execute(workflow);
+                        result = await _executor.Execute(workflow, cancellationToken);
                     }
                     finally
                     {


### PR DESCRIPTION
Here is small changes to pass primary CancellationToken from the background tasks into any StepBodyAsync classes. It is necessary to make microservices more responsible when stopping IWorkflowHost on long running operations: queries, network requests and etc.