### PR TITLE
Feature/rabbit mq multinode connection

### DIFF
--- a/WorkflowCore.sln
+++ b/WorkflowCore.sln
@@ -145,6 +145,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Sample09s", "s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScratchPad", "test\ScratchPad\ScratchPad.csproj", "{51BB7DCD-01DD-453D-A1E7-17E5E3DBB14C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkflowCore.Tests.QueueProviders.RabbitMQ", "test\WorkflowCore.Tests.QueueProviders.RabbitMQ\WorkflowCore.Tests.QueueProviders.RabbitMQ.csproj", "{54DE20BA-EBA7-4BF0-9BD9-F03766849716}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -355,6 +357,10 @@ Global
 		{51BB7DCD-01DD-453D-A1E7-17E5E3DBB14C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{51BB7DCD-01DD-453D-A1E7-17E5E3DBB14C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{51BB7DCD-01DD-453D-A1E7-17E5E3DBB14C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54DE20BA-EBA7-4BF0-9BD9-F03766849716}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54DE20BA-EBA7-4BF0-9BD9-F03766849716}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54DE20BA-EBA7-4BF0-9BD9-F03766849716}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54DE20BA-EBA7-4BF0-9BD9-F03766849716}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -414,6 +420,7 @@ Global
 		{5BE6D628-B9DB-4C76-AAEB-8F3800509A84} = {5080DB09-CBE8-4C45-9957-C3BB7651755E}
 		{E32CF21A-29CC-46D1-8044-FCC327F2B281} = {5080DB09-CBE8-4C45-9957-C3BB7651755E}
 		{51BB7DCD-01DD-453D-A1E7-17E5E3DBB14C} = {E6CEAD8D-F565-471E-A0DC-676F54EAEDEB}
+		{54DE20BA-EBA7-4BF0-9BD9-F03766849716} = {E6CEAD8D-F565-471E-A0DC-676F54EAEDEB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DC0FA8D3-6449-4FDA-BB46-ECF58FAD23B4}

--- a/src/providers/WorkflowCore.QueueProviders.RabbitMQ/Interfaces/IRabbitMqQueueNameProvider.cs
+++ b/src/providers/WorkflowCore.QueueProviders.RabbitMQ/Interfaces/IRabbitMqQueueNameProvider.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Linq;
+using WorkflowCore.Interface;
+
+namespace WorkflowCore.QueueProviders.RabbitMQ.Interfaces
+{
+    public interface IRabbitMqQueueNameProvider
+    {
+        string GetQueueName(QueueType queue);
+    }
+}

--- a/src/providers/WorkflowCore.QueueProviders.RabbitMQ/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.QueueProviders.RabbitMQ/ServiceCollectionExtensions.cs
@@ -41,13 +41,15 @@ namespace Microsoft.Extensions.DependencyInjection
             if (rabbitMqConnectionFactory == null) throw new ArgumentNullException(nameof(rabbitMqConnectionFactory));
 
             options.Services.AddSingleton(rabbitMqConnectionFactory);
-            options.Services.TryAddTransient<IRabbitMqQueueNameProvider, DefaultRabbitMqQueueNameProvider>();
+            options.Services.TryAddSingleton<IRabbitMqQueueNameProvider, DefaultRabbitMqQueueNameProvider>();
             options.UseQueueProvider(RabbitMqQueueProviderFactory);
             
             return options;
         }
 
         private static IQueueProvider RabbitMqQueueProviderFactory(IServiceProvider sp)
-            => new RabbitMQProvider(sp);
+            => new RabbitMQProvider(sp,
+                sp.GetRequiredService<IRabbitMqQueueNameProvider>(),
+                sp.GetRequiredService<RabbitMqConnectionFactory>());
     }
 }

--- a/src/providers/WorkflowCore.QueueProviders.RabbitMQ/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.QueueProviders.RabbitMQ/ServiceCollectionExtensions.cs
@@ -2,18 +2,52 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using WorkflowCore.Interface;
 using WorkflowCore.Models;
+using WorkflowCore.QueueProviders.RabbitMQ.Interfaces;
 using WorkflowCore.QueueProviders.RabbitMQ.Services;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
+    public delegate IConnection RabbitMqConnectionFactory(IServiceProvider sp, string clientProvidedName);
+    
     public static class ServiceCollectionExtensions
     {
         public static WorkflowOptions UseRabbitMQ(this WorkflowOptions options, IConnectionFactory connectionFactory)
         {
-            options.UseQueueProvider(sp => new RabbitMQProvider(connectionFactory));
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            if (connectionFactory == null) throw new ArgumentNullException(nameof(connectionFactory));
+
+            return options
+                .UseRabbitMQ((sp, name) => connectionFactory.CreateConnection(name));
+        }
+        
+        public static WorkflowOptions UseRabbitMQ(this WorkflowOptions options,
+            IConnectionFactory connectionFactory,
+            IEnumerable<string> hostnames)
+        {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            if (connectionFactory == null) throw new ArgumentNullException(nameof(connectionFactory));
+            if (hostnames == null) throw new ArgumentNullException(nameof(hostnames));
+
+            return options
+                .UseRabbitMQ((sp, name) => connectionFactory.CreateConnection(hostnames.ToList(), name));
+        }
+        
+        public static WorkflowOptions UseRabbitMQ(this WorkflowOptions options, RabbitMqConnectionFactory rabbitMqConnectionFactory)
+        {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            if (rabbitMqConnectionFactory == null) throw new ArgumentNullException(nameof(rabbitMqConnectionFactory));
+
+            options.Services.AddSingleton(rabbitMqConnectionFactory);
+            options.Services.TryAddTransient<IRabbitMqQueueNameProvider, DefaultRabbitMqQueueNameProvider>();
+            options.UseQueueProvider(RabbitMqQueueProviderFactory);
+            
             return options;
         }
+
+        private static IQueueProvider RabbitMqQueueProviderFactory(IServiceProvider sp)
+            => new RabbitMQProvider(sp);
     }
 }

--- a/src/providers/WorkflowCore.QueueProviders.RabbitMQ/Services/DefaultRabbitMqQueueNameProvider.cs
+++ b/src/providers/WorkflowCore.QueueProviders.RabbitMQ/Services/DefaultRabbitMqQueueNameProvider.cs
@@ -1,0 +1,23 @@
+﻿using WorkflowCore.Interface;
+using WorkflowCore.QueueProviders.RabbitMQ.Interfaces;
+
+namespace WorkflowCore.QueueProviders.RabbitMQ.Services
+{
+    public class DefaultRabbitMqQueueNameProvider : IRabbitMqQueueNameProvider
+    {
+        public string GetQueueName(QueueType queue)
+        {
+            switch (queue)
+            {
+                case QueueType.Workflow:
+                    return "wfc.workflow_queue";
+                case QueueType.Event:
+                    return "wfc.event_queue";
+                case QueueType.Index:
+                    return "wfc.index_queue";
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/src/providers/WorkflowCore.QueueProviders.RabbitMQ/Services/RabbitMQProvider.cs
+++ b/src/providers/WorkflowCore.QueueProviders.RabbitMQ/Services/RabbitMQProvider.cs
@@ -7,23 +7,30 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
+using WorkflowCore.QueueProviders.RabbitMQ.Interfaces;
 
 namespace WorkflowCore.QueueProviders.RabbitMQ.Services
 {
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
     public class RabbitMQProvider : IQueueProvider
     {
-        private readonly IConnectionFactory _connectionFactory;
+        private readonly IRabbitMqQueueNameProvider _queueNameProvider;
+        private readonly RabbitMqConnectionFactory _rabbitMqConnectionFactory;
+        private readonly IServiceProvider _serviceProvider;
+        
         private IConnection _connection = null;
         private static JsonSerializerSettings SerializerSettings = new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.All };
 
         public bool IsDequeueBlocking => false;
 
-        public RabbitMQProvider(IConnectionFactory connectionFactory)
+        public RabbitMQProvider(IServiceProvider serviceProvider)
         {
-            _connectionFactory = connectionFactory;
+            _serviceProvider = serviceProvider;
+            _queueNameProvider = _serviceProvider.GetRequiredService<IRabbitMqQueueNameProvider>();
+            _rabbitMqConnectionFactory = _serviceProvider.GetRequiredService<RabbitMqConnectionFactory>();
         }
 
         public async Task QueueWork(string id, QueueType queue)
@@ -33,9 +40,9 @@ namespace WorkflowCore.QueueProviders.RabbitMQ.Services
 
             using (var channel = _connection.CreateModel())
             {
-                channel.QueueDeclare(queue: GetQueueName(queue), durable: true, exclusive: false, autoDelete: false, arguments: null);
+                channel.QueueDeclare(queue: _queueNameProvider.GetQueueName(queue), durable: true, exclusive: false, autoDelete: false, arguments: null);
                 var body = Encoding.UTF8.GetBytes(id);
-                channel.BasicPublish(exchange: "", routingKey: GetQueueName(queue), basicProperties: null, body: body);
+                channel.BasicPublish(exchange: "", routingKey: _queueNameProvider.GetQueueName(queue), basicProperties: null, body: body);
             }
         }
 
@@ -46,7 +53,7 @@ namespace WorkflowCore.QueueProviders.RabbitMQ.Services
 
             using (var channel = _connection.CreateModel())
             {
-                channel.QueueDeclare(queue: GetQueueName(queue),
+                channel.QueueDeclare(queue: _queueNameProvider.GetQueueName(queue),
                                      durable: true,
                                      exclusive: false,
                                      autoDelete: false,
@@ -54,7 +61,7 @@ namespace WorkflowCore.QueueProviders.RabbitMQ.Services
 
                 channel.BasicQos(prefetchSize: 0, prefetchCount: 1, global: false);
 
-                var msg = channel.BasicGet(GetQueueName(queue), false);
+                var msg = channel.BasicGet(_queueNameProvider.GetQueueName(queue), false);
                 if (msg != null)
                 {
                     var data = Encoding.UTF8.GetString(msg.Body);
@@ -76,7 +83,7 @@ namespace WorkflowCore.QueueProviders.RabbitMQ.Services
 
         public async Task Start()
         {
-            _connection = _connectionFactory.CreateConnection("Workflow-Core");
+            _connection = _rabbitMqConnectionFactory(_serviceProvider, "Workflow-Core");
         }
 
         public async Task Stop()
@@ -88,20 +95,6 @@ namespace WorkflowCore.QueueProviders.RabbitMQ.Services
             }
         }
 
-        private string GetQueueName(QueueType queue)
-        {
-            switch (queue)
-            {
-                case QueueType.Workflow:
-                    return "wfc.workflow_queue";
-                case QueueType.Event:
-                    return "wfc.event_queue";
-                case QueueType.Index:
-                    return "wfc.index_queue";
-            }
-            return null;
-        }
-                
     }
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
 }

--- a/src/providers/WorkflowCore.QueueProviders.RabbitMQ/Services/RabbitMQProvider.cs
+++ b/src/providers/WorkflowCore.QueueProviders.RabbitMQ/Services/RabbitMQProvider.cs
@@ -26,11 +26,13 @@ namespace WorkflowCore.QueueProviders.RabbitMQ.Services
 
         public bool IsDequeueBlocking => false;
 
-        public RabbitMQProvider(IServiceProvider serviceProvider)
+        public RabbitMQProvider(IServiceProvider serviceProvider,
+            IRabbitMqQueueNameProvider queueNameProvider,
+            RabbitMqConnectionFactory connectionFactory)
         {
             _serviceProvider = serviceProvider;
-            _queueNameProvider = _serviceProvider.GetRequiredService<IRabbitMqQueueNameProvider>();
-            _rabbitMqConnectionFactory = _serviceProvider.GetRequiredService<RabbitMqConnectionFactory>();
+            _queueNameProvider = queueNameProvider;
+            _rabbitMqConnectionFactory = connectionFactory;
         }
 
         public async Task QueueWork(string id, QueueType queue)

--- a/src/providers/WorkflowCore.QueueProviders.RabbitMQ/WorkflowCore.QueueProviders.RabbitMQ.csproj
+++ b/src/providers/WorkflowCore.QueueProviders.RabbitMQ/WorkflowCore.QueueProviders.RabbitMQ.csproj
@@ -19,6 +19,7 @@
     <Description>Queue provider for Workflow-core using RabbitMQ</Description>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
+    <PackageVersion>2.1.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WorkflowCore.Tests.QueueProviders.RabbitMQ/Tests/DefaultRabbitMqQueueNameProviderTests.cs
+++ b/test/WorkflowCore.Tests.QueueProviders.RabbitMQ/Tests/DefaultRabbitMqQueueNameProviderTests.cs
@@ -1,0 +1,28 @@
+﻿using FluentAssertions;
+using WorkflowCore.Interface;
+using WorkflowCore.QueueProviders.RabbitMQ.Services;
+using Xunit;
+
+namespace WorkflowCore.Tests.QueueProviders.RabbitMQ.Tests
+{
+    public class DefaultRabbitMqQueueNameProviderTests
+    {
+        private readonly DefaultRabbitMqQueueNameProvider _sut;
+
+        public DefaultRabbitMqQueueNameProviderTests()
+        {
+            _sut = new DefaultRabbitMqQueueNameProvider();
+        }
+
+        [Theory]
+        [InlineData(QueueType.Event, "wfc.event_queue")]
+        [InlineData(QueueType.Index, "wfc.index_queue")]
+        [InlineData(QueueType.Workflow, "wfc.workflow_queue")]
+        public void GetQueueName_ValidInput_ReturnsValidQueueName(QueueType queueType, string queueName)
+        {
+            var result = _sut.GetQueueName(queueType);
+
+            result.Should().Be(queueName);
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.QueueProviders.RabbitMQ/WorkflowCore.Tests.QueueProviders.RabbitMQ.csproj
+++ b/test/WorkflowCore.Tests.QueueProviders.RabbitMQ/WorkflowCore.Tests.QueueProviders.RabbitMQ.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="5.10.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\providers\WorkflowCore.QueueProviders.RabbitMQ\WorkflowCore.QueueProviders.RabbitMQ.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
My team has encountered with problems of multi-node RabbitMq connection due to RabbitMq.Client specific connection API.
These changes just extend RabbitMqQueueProvider configuration

Also there's a dedicated IRabbitMqQueueNameProvider allowing to hook into queueNaming from outside