### PR TITLE
#659 Handle enum in When-steps

### DIFF
--- a/src/WorkflowCore/Primitives/When.cs
+++ b/src/WorkflowCore/Primitives/When.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Dynamic.Core;
+using System.Collections.Generic;
 using WorkflowCore.Exceptions;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;

--- a/src/WorkflowCore/Primitives/When.cs
+++ b/src/WorkflowCore/Primitives/When.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Dynamic.Core;
 using WorkflowCore.Exceptions;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
-using System.Linq.Dynamic.Core;
-using System.ComponentModel;
 
 namespace WorkflowCore.Primitives
 {

--- a/src/WorkflowCore/Primitives/When.cs
+++ b/src/WorkflowCore/Primitives/When.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using WorkflowCore.Exceptions;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
+using System.Linq.Dynamic.Core;
+using System.ComponentModel;
 
 namespace WorkflowCore.Primitives
 {
@@ -17,10 +19,18 @@ namespace WorkflowCore.Primitives
 
             if (ExpectedOutcome != switchOutcome)
             {
-                if (Convert.ToString(ExpectedOutcome) != Convert.ToString(switchOutcome))
+                var expectedType = ExpectedOutcome?.GetType();
+                var hasMatch = false;
+                if (expectedType?.IsEnum == true)
+                {
+                    try { hasMatch = Enum.Parse(expectedType, Convert.ToString(switchOutcome)).Equals(ExpectedOutcome); }
+                    catch { }
+                }
+                if (!hasMatch && Convert.ToString(ExpectedOutcome) != Convert.ToString(switchOutcome))
                 {
                     return ExecutionResult.Next();
                 }
+             
             }
 
             if (context.PersistenceData == null)


### PR DESCRIPTION
Added check for IsEnum and checks parsed persisted switchOutcome against the expected value to fix #659.

Tried to do it more gracefully with IsDefined, TryParse (generics only, with Type only available in Core) but decided this was the easiest path.