### PR TITLE
#660 Don't lose context in When(_ => 0).Do(

### DIFF
--- a/src/WorkflowCore/Services/WorkflowExecutor.cs
+++ b/src/WorkflowCore/Services/WorkflowExecutor.cs
@@ -138,6 +138,7 @@ namespace WorkflowCore.Services
 
         private async Task ExecuteStep(WorkflowInstance workflow, WorkflowStep step, ExecutionPointer pointer, WorkflowExecutorResult wfResult, WorkflowDefinition def, CancellationToken cancellationToken = default)
         {
+            pointer.ContextItem = pointer.ContextItem ?? workflow?.ExecutionPointers?.FirstOrDefault(x => x.Children.Contains(pointer.Id))?.ContextItem;
             IStepExecutionContext context = new StepExecutionContext()
             {
                 Workflow = workflow,
@@ -147,7 +148,7 @@ namespace WorkflowCore.Services
                 Item = pointer.ContextItem,
                 CancellationToken = cancellationToken
             };
-            
+
             using (var scope = _scopeProvider.CreateScope(context))
             {
                 _logger.LogDebug("Starting step {0} on workflow {1}", step.Name, workflow.Id);


### PR DESCRIPTION
A possible solution. Not sure this is good but you do a similar solution for outcome in the When-primitive.

And the pointer on the top level should be able to extract it's context from the children as well.

The outcome in at least becomes, which would fix #660:
> When(true/false): Approver = User 2 (1 executions) context.Item = 1
> When(true/false): Approver = User 1 (1 executions) context.Item = 0
> When(true/false): Approver = User 2 (2 executions) context.Item = 1
> When(true/false): Approver = User 1 (2 executions) context.Item = 0
> When(true): Approver = User 2 (3 executions) context.Item = 1
> When(true): Approver = User 1 (3 executions) context.Item = 0
> When(_ > true/false): Approver = User 2 (1 executions) context.Item = 1
> When(_ > true/false): Approver = User 1 (1 executions) context.Item = 0
> When(_ > true/false): Approver = User 2 (2 executions) context.Item = 1
> When(_ > true/false): Approver = User 1 (2 executions) context.Item = 0
> When(_ > true): Approver = User 2 (3 executions) context.Item = 1
> When(_ > true): Approver = User 1 (3 executions) context.Item = 0