### PR TITLE
add support for WorkflowStep

### DIFF
--- a/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
+++ b/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
@@ -68,8 +68,22 @@ namespace WorkflowCore.Services.DefinitionStorage
                 var nextStep = stack.Pop();
 
                 var stepType = FindType(nextStep.StepType);
-                var containerType = typeof(WorkflowStep<>).MakeGenericType(stepType);
-                var targetStep = (containerType.GetConstructor(new Type[] { }).Invoke(null) as WorkflowStep);
+
+                WorkflowStep targetStep;
+
+                Type containerType;
+                if (stepType.IsSubclassOf(typeof(StepBody)))
+                {
+                    containerType = typeof(WorkflowStep<>).MakeGenericType(stepType);
+
+                    targetStep = (containerType.GetConstructor(new Type[] { }).Invoke(null) as WorkflowStep);
+                }
+                else
+                {
+                    targetStep = stepType.GetConstructor(new Type[] { }).Invoke(null) as WorkflowStep;
+                    if (targetStep != null)
+                        stepType = targetStep.BodyType;
+                }
 
                 if (nextStep.Saga)
                 {

--- a/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
+++ b/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
@@ -72,7 +72,7 @@ namespace WorkflowCore.Services.DefinitionStorage
                 WorkflowStep targetStep;
 
                 Type containerType;
-                if (stepType.IsSubclassOf(typeof(StepBody)))
+                if (stepType.GetInterfaces().Contains(typeof(IStepBody)))
                 {
                     containerType = typeof(WorkflowStep<>).MakeGenericType(stepType);
 


### PR DESCRIPTION
Before, the `StepType` field  must be subclass of `StepBody`
Now,It support for `WorkflowStep`
Old:
```c#
public class HelloWorld : StepBody
```
new:(Add)
```c#
public class EndStep : WorkflowStep
```
It means , In the `YourUserTaskStep`
you can set `ValueOutcome.Value` and control step create in [ProcessExecutionResult](https://github.com/danielgerlag/workflow-core/blob/32fedfd528e9d8f8eeae7a3b9500d84c5c411c39/src/WorkflowCore/Services/ExecutionResultProcessor.cs#L65)