### PR TITLE
Feature - Scoped Middleware

### DIFF
--- a/src/WorkflowCore/ServiceCollectionExtensions.cs
+++ b/src/WorkflowCore/ServiceCollectionExtensions.cs
@@ -51,10 +51,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IGreyList, GreyList>();
             services.AddSingleton<IWorkflowController, WorkflowController>();
             services.AddSingleton<IActivityController, ActivityController>();
-            services.AddSingleton<IStepExecutor, StepExecutor>();
-            services.AddSingleton<IWorkflowMiddlewareRunner, WorkflowMiddlewareRunner>();
-            services.AddSingleton<IWorkflowMiddlewareErrorHandler, DefaultWorkflowMiddlewareErrorHandler>();
             services.AddSingleton<IWorkflowHost, WorkflowHost>();
+            services.AddTransient<IStepExecutor, StepExecutor>();
+            services.AddTransient<IWorkflowMiddlewareErrorHandler, DefaultWorkflowMiddlewareErrorHandler>();
+            services.AddTransient<IWorkflowMiddlewareRunner, WorkflowMiddlewareRunner>();
             services.AddTransient<IScopeProvider, ScopeProvider>();
             services.AddTransient<IWorkflowExecutor, WorkflowExecutor>();
             services.AddTransient<ICancellationProcessor, CancellationProcessor>();

--- a/src/WorkflowCore/Services/WorkflowExecutor.cs
+++ b/src/WorkflowCore/Services/WorkflowExecutor.cs
@@ -22,12 +22,10 @@ namespace WorkflowCore.Services
         private readonly ICancellationProcessor _cancellationProcessor;
         private readonly ILifeCycleEventPublisher _publisher;
         private readonly WorkflowOptions _options;
-        private readonly IStepExecutor _stepExecutor;
-        private readonly IWorkflowMiddlewareRunner _middlewareRunner;
 
         private IWorkflowHost Host => _serviceProvider.GetService<IWorkflowHost>();
 
-        public WorkflowExecutor(IWorkflowRegistry registry, IServiceProvider serviceProvider, IScopeProvider scopeProvider, IDateTimeProvider datetimeProvider, IExecutionResultProcessor executionResultProcessor, ILifeCycleEventPublisher publisher, ICancellationProcessor cancellationProcessor, WorkflowOptions options, IWorkflowMiddlewareRunner middlewareRunner, IStepExecutor stepExecutor, ILoggerFactory loggerFactory)
+        public WorkflowExecutor(IWorkflowRegistry registry, IServiceProvider serviceProvider, IScopeProvider scopeProvider, IDateTimeProvider datetimeProvider, IExecutionResultProcessor executionResultProcessor, ILifeCycleEventPublisher publisher, ICancellationProcessor cancellationProcessor, WorkflowOptions options, ILoggerFactory loggerFactory)
         {
             _serviceProvider = serviceProvider;
             _scopeProvider = scopeProvider;
@@ -38,8 +36,6 @@ namespace WorkflowCore.Services
             _options = options;
             _logger = loggerFactory.CreateLogger<WorkflowExecutor>();
             _executionResultProcessor = executionResultProcessor;
-            _middlewareRunner = middlewareRunner;
-            _stepExecutor = stepExecutor;
         }
 
         public async Task<WorkflowExecutorResult> Execute(WorkflowInstance workflow, CancellationToken cancellationToken = default)
@@ -157,6 +153,7 @@ namespace WorkflowCore.Services
                 _logger.LogDebug("Starting step {0} on workflow {1}", step.Name, workflow.Id);
 
                 IStepBody body = step.ConstructBody(scope.ServiceProvider);
+                var stepExecutor = scope.ServiceProvider.GetRequiredService<IStepExecutor>();
 
                 if (body == null)
                 {
@@ -185,7 +182,7 @@ namespace WorkflowCore.Services
                         return;
                 }
 
-                var result = await _stepExecutor.ExecuteStep(context, body);
+                var result = await stepExecutor.ExecuteStep(context, body);
 
                 if (result.Proceed)
                 {
@@ -250,7 +247,11 @@ namespace WorkflowCore.Services
             workflow.Status = WorkflowStatus.Complete;
             workflow.CompleteTime = _datetimeProvider.UtcNow;
 
-            await _middlewareRunner.RunPostMiddleware(workflow, def);
+            using (var scope = _serviceProvider.CreateScope())
+            {
+                var middlewareRunner = scope.ServiceProvider.GetRequiredService<IWorkflowMiddlewareRunner>();
+                await middlewareRunner.RunPostMiddleware(workflow, def);
+            }
 
             _publisher.PublishNotification(new WorkflowCompleted()
             {

--- a/src/WorkflowCore/WorkflowCore.csproj
+++ b/src/WorkflowCore/WorkflowCore.csproj
@@ -15,12 +15,12 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Description>Workflow Core is a light weight workflow engine targeting .NET Standard.</Description>
-    <Version>3.3.2</Version>
-    <AssemblyVersion>3.3.2.0</AssemblyVersion>
-    <FileVersion>3.3.2.0</FileVersion>
+    <Version>3.3.3</Version>
+    <AssemblyVersion>3.3.3.0</AssemblyVersion>
+    <FileVersion>3.3.3.0</FileVersion>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageIconUrl>https://github.com/danielgerlag/workflow-core/raw/master/src/logo.png</PackageIconUrl>
-    <PackageVersion>3.3.2</PackageVersion>
+    <PackageVersion>3.3.3</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WorkflowCore.UnitTests/Services/WorkflowExecutorFixture.cs
+++ b/test/WorkflowCore.UnitTests/Services/WorkflowExecutorFixture.cs
@@ -51,6 +51,14 @@ namespace WorkflowCore.UnitTests.Services
             A.CallTo(() => DateTimeProvider.Now).Returns(DateTime.Now);
             A.CallTo(() => DateTimeProvider.UtcNow).Returns(DateTime.UtcNow);
 
+            A
+                .CallTo(() => ServiceProvider.GetService(typeof(IWorkflowMiddlewareRunner)))
+                .Returns(MiddlewareRunner);
+
+            A
+                .CallTo(() => ServiceProvider.GetService(typeof(IStepExecutor)))
+                .Returns(StepExecutor);
+
             A.CallTo(() => MiddlewareRunner
                     .RunPostMiddleware(A<WorkflowInstance>._, A<WorkflowDefinition>._))
                 .Returns(Task.CompletedTask);
@@ -64,7 +72,7 @@ namespace WorkflowCore.UnitTests.Services
             var loggerFactory = new LoggerFactory();
             //loggerFactory.AddConsole(LogLevel.Debug);
 
-            Subject = new WorkflowExecutor(Registry, ServiceProvider, ScopeProvider, DateTimeProvider, ResultProcesser, EventHub, CancellationProcessor, Options, MiddlewareRunner, StepExecutor, loggerFactory);
+            Subject = new WorkflowExecutor(Registry, ServiceProvider, ScopeProvider, DateTimeProvider, ResultProcesser, EventHub, CancellationProcessor, Options, loggerFactory);
         }
 
         [Fact(DisplayName = "Should execute active step")]


### PR DESCRIPTION
Move WorkflowMiddlewareRunner and StepExecutor to be instantiated in a scope specific to the step to avoid potential threading issues when used with EFCore and DbContext.

Fixes bug introduced in #678 and closes issue #709.