### PR TITLE
Tackle consumer starvation

### DIFF
--- a/src/WorkflowCore/Models/WorkflowOptions.cs
+++ b/src/WorkflowCore/Models/WorkflowOptions.cs
@@ -34,6 +34,11 @@ namespace WorkflowCore.Models
             EventHubFactory = new Func<IServiceProvider, ILifeCycleEventHub>(sp => new SingleNodeEventHub(sp.GetService<ILoggerFactory>()));
         }
 
+        public bool DisableWorkflowConsumer { get; set; } = false;
+        public bool DisableEventConsumer { get; set; } = false;
+        public bool DisableIndexConsumer { get; set; } = false;
+        public bool DisableRunnablePoller { get; set; } = false;
+
         public void UsePersistence(Func<IServiceProvider, IPersistenceProvider> factory)
         {
             PersistanceFactory = factory;

--- a/src/WorkflowCore/Models/WorkflowOptions.cs
+++ b/src/WorkflowCore/Models/WorkflowOptions.cs
@@ -34,10 +34,10 @@ namespace WorkflowCore.Models
             EventHubFactory = new Func<IServiceProvider, ILifeCycleEventHub>(sp => new SingleNodeEventHub(sp.GetService<ILoggerFactory>()));
         }
 
-        public bool DisableWorkflowConsumer { get; set; } = false;
-        public bool DisableEventConsumer { get; set; } = false;
-        public bool DisableIndexConsumer { get; set; } = false;
-        public bool DisableRunnablePoller { get; set; } = false;
+        public bool EnableWorkflows { get; set; } = true;
+        public bool EnableEvents { get; set; } = true;
+        public bool EnableIndexes { get; set; } = true;
+        public bool EnablePolling { get; set; } = true;
 
         public void UsePersistence(Func<IServiceProvider, IPersistenceProvider> factory)
         {

--- a/src/WorkflowCore/ServiceCollectionExtensions.cs
+++ b/src/WorkflowCore/ServiceCollectionExtensions.cs
@@ -37,22 +37,22 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<WorkflowOptions>(options);
             services.AddSingleton<ILifeCycleEventPublisher, LifeCycleEventPublisher>();
 
-            if (!options.DisableWorkflowConsumer)
+            if (!options.EnableWorkflows)
             {
                 services.AddTransient<IBackgroundTask, WorkflowConsumer>();
             }
 
-            if (!options.DisableEventConsumer)
+            if (!options.EnableEvents)
             {
                 services.AddTransient<IBackgroundTask, EventConsumer>();
             }
 
-            if (!options.DisableIndexConsumer)
+            if (!options.EnableIndexes)
             {
                 services.AddTransient<IBackgroundTask, IndexConsumer>();
             }
 
-            if (!options.DisableRunnablePoller)
+            if (!options.EnablePolling)
             {
                 services.AddTransient<IBackgroundTask, RunnablePoller>();
             }

--- a/src/WorkflowCore/ServiceCollectionExtensions.cs
+++ b/src/WorkflowCore/ServiceCollectionExtensions.cs
@@ -37,22 +37,22 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<WorkflowOptions>(options);
             services.AddSingleton<ILifeCycleEventPublisher, LifeCycleEventPublisher>();
 
-            if (!options.EnableWorkflows)
+            if (options.EnableWorkflows)
             {
                 services.AddTransient<IBackgroundTask, WorkflowConsumer>();
             }
 
-            if (!options.EnableEvents)
+            if (options.EnableEvents)
             {
                 services.AddTransient<IBackgroundTask, EventConsumer>();
             }
 
-            if (!options.EnableIndexes)
+            if (options.EnableIndexes)
             {
                 services.AddTransient<IBackgroundTask, IndexConsumer>();
             }
 
-            if (!options.EnablePolling)
+            if (options.EnablePolling)
             {
                 services.AddTransient<IBackgroundTask, RunnablePoller>();
             }

--- a/src/WorkflowCore/ServiceCollectionExtensions.cs
+++ b/src/WorkflowCore/ServiceCollectionExtensions.cs
@@ -37,10 +37,26 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<WorkflowOptions>(options);
             services.AddSingleton<ILifeCycleEventPublisher, LifeCycleEventPublisher>();
 
-            services.AddTransient<IBackgroundTask, WorkflowConsumer>();
-            services.AddTransient<IBackgroundTask, EventConsumer>();
-            services.AddTransient<IBackgroundTask, IndexConsumer>();
-            services.AddTransient<IBackgroundTask, RunnablePoller>();
+            if (!options.DisableWorkflowConsumer)
+            {
+                services.AddTransient<IBackgroundTask, WorkflowConsumer>();
+            }
+
+            if (!options.DisableEventConsumer)
+            {
+                services.AddTransient<IBackgroundTask, EventConsumer>();
+            }
+
+            if (!options.DisableIndexConsumer)
+            {
+                services.AddTransient<IBackgroundTask, IndexConsumer>();
+            }
+
+            if (!options.DisableRunnablePoller)
+            {
+                services.AddTransient<IBackgroundTask, RunnablePoller>();
+            }
+
             services.AddTransient<IBackgroundTask>(sp => sp.GetService<ILifeCycleEventPublisher>());
 
             services.AddTransient<IWorkflowErrorHandler, CompensateHandler>();


### PR DESCRIPTION
It will be nice to control which background task is starting. In my case i want to separate the workflow poller from workflow consumer.

Setup:
- n x Workflow Producers (this can be achieved by not starting the host and just register the workflow)
- 1 x Workflow Poller (i want to be able to start the host without to have the consumer enabled)
- n x Workflow Consumers (i want to be able to start the host without to have the poller enabled)

The simple way is to add option for each background worker to can disable them and don't register it in DI container.

If you have another idea or thought about this please let me know.

Thanks

**Update:**
Short description of the problem: We are running the workflow host inside the application host and this is deployed in multiple instances. With  enough amount of runnable workflows and keeping the polling interval to 10s you bring consumers to starvations. That is why we wanted to have an option to deactivat the poller.

But know i found another solution that we can replace the `IGreyList` with a async ready variant and implement this in `MongoDB` or `Redis`

Let me know what you think.