### PR TITLE
Adding RavenDB persistence provider

### DIFF
--- a/WorkflowCore.sln
+++ b/WorkflowCore.sln
@@ -150,6 +150,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Tests.QueuePro
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Sample19", "src\samples\WorkflowCore.Sample19\WorkflowCore.Sample19.csproj", "{1223ED47-3E5E-4960-B70D-DFAF550F6666}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkflowCore.Persistence.RavenDB", "src\providers\WorkflowCore.Persistence.RavenDB\WorkflowCore.Persistence.RavenDB.csproj", "{AF205715-C8B7-42EF-BF14-AFC9E7F27242}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -368,6 +370,10 @@ Global
 		{1223ED47-3E5E-4960-B70D-DFAF550F6666}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1223ED47-3E5E-4960-B70D-DFAF550F6666}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1223ED47-3E5E-4960-B70D-DFAF550F6666}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AF205715-C8B7-42EF-BF14-AFC9E7F27242}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF205715-C8B7-42EF-BF14-AFC9E7F27242}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF205715-C8B7-42EF-BF14-AFC9E7F27242}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF205715-C8B7-42EF-BF14-AFC9E7F27242}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -429,6 +435,7 @@ Global
 		{51BB7DCD-01DD-453D-A1E7-17E5E3DBB14C} = {E6CEAD8D-F565-471E-A0DC-676F54EAEDEB}
 		{54DE20BA-EBA7-4BF0-9BD9-F03766849716} = {E6CEAD8D-F565-471E-A0DC-676F54EAEDEB}
 		{1223ED47-3E5E-4960-B70D-DFAF550F6666} = {5080DB09-CBE8-4C45-9957-C3BB7651755E}
+		{AF205715-C8B7-42EF-BF14-AFC9E7F27242} = {2EEE6ABD-EE9B-473F-AF2D-6DABB85D7BA2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DC0FA8D3-6449-4FDA-BB46-ECF58FAD23B4}

--- a/src/providers/WorkflowCore.Persistence.RavenDB/README.md
+++ b/src/providers/WorkflowCore.Persistence.RavenDB/README.md
@@ -1,0 +1,31 @@
+﻿
+# RavenDB Persistence provider for Workflow Core
+
+Provides support to persist workflows running on [Workflow Core](../../README.md) to a RavenDB database.
+
+## Installing
+
+Install the NuGet package "WorkflowCore.Persistence.RavenDB"
+
+```
+PM> Install-Package WorkflowCore.Persistence.RavenDB
+```
+
+## Usage
+
+Compose your RavenStoreOptions using the model provided by the library. 
+
+```C#
+var options = new RavenStoreOptions {
+	ServerUrl = "https://ravendbserver.domain.com:8080",
+	DatabaseName = "TestDatabase",
+	CertificatePath = System.IO.Path.Combine(AppContext.BaseDirectory, "Resources/servercert.pfx"),
+	CertificatePassword = "CertificatePassword"
+}
+```
+
+Use the `.UseRavenDB` extension method when building your service provider, passing in the options you configured for the RavenDB store. 
+
+```C#
+services.AddWorkflow(x => x.UseRavenDB(options));
+```

--- a/src/providers/WorkflowCore.Persistence.RavenDB/RavenStoreOptions.cs
+++ b/src/providers/WorkflowCore.Persistence.RavenDB/RavenStoreOptions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WorkflowCore.Persistence.RavenDB
+{
+	public class RavenStoreOptions
+	{
+		public string ServerUrl { get; set; }
+		public string DatabaseName { get; set; }
+		public string CertificatePath { get; set; }
+		public string CertificatePassword { get; set; }
+	}
+}

--- a/src/providers/WorkflowCore.Persistence.RavenDB/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.RavenDB/ServiceCollectionExtensions.cs
@@ -1,0 +1,39 @@
+﻿using Raven.Client.Documents.Operations;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using WorkflowCore.Models;
+using Raven.Client;
+using Raven.Client.Documents;
+using System.Security.Cryptography.X509Certificates;
+using WorkflowCore.Persistence.RavenDB.Services;
+using WorkflowCore.Interface;
+using WorkflowCore.Persistence.RavenDB;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+	public static class ServiceCollectionExtensions
+	{
+		public static WorkflowOptions UseRavenDB(this WorkflowOptions options, RavenStoreOptions configOptions)
+		{
+			IDocumentStore store = new DocumentStore
+			{
+				Urls = new[] { configOptions.ServerUrl },
+				Database = configOptions.DatabaseName,
+				Certificate = new X509Certificate2(configOptions.CertificatePath, configOptions.CertificatePassword)
+			}.Initialize();
+
+			options.UsePersistence(sp =>
+			{
+				return new RavendbPersistenceProvider(store);
+			});
+
+			options.Services.AddTransient<IWorkflowPurger>(sp =>
+			{
+				return new WorkflowPurger(store);
+			});
+
+			return options;
+		}
+	}
+}

--- a/src/providers/WorkflowCore.Persistence.RavenDB/Services/RavenDbIndexes.cs
+++ b/src/providers/WorkflowCore.Persistence.RavenDB/Services/RavenDbIndexes.cs
@@ -1,0 +1,14 @@
+﻿using Raven.Client.Documents.Indexes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using WorkflowCore.Models;
+
+namespace WorkflowCore.Persistence.RavenDB.Services
+{
+	// TODO:  Implement Map for result bind of Index
+	public class WorkflowInstances_Id : AbstractIndexCreationTask<WorkflowInstance> { }
+	public class EventSubscriptions_Id : AbstractIndexCreationTask<EventSubscription> { }
+	public class Events_Id : AbstractIndexCreationTask<Event> { }
+	public class ExecutionErrors_Id : AbstractIndexCreationTask<ExecutionError> { }
+}

--- a/src/providers/WorkflowCore.Persistence.RavenDB/Services/RavendbPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.RavenDB/Services/RavendbPersistenceProvider.cs
@@ -1,0 +1,320 @@
+﻿using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Operations;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+
+namespace WorkflowCore.Persistence.RavenDB.Services
+{
+	public class RavendbPersistenceProvider : IPersistenceProvider
+	{
+		internal const string WorkflowCollectionName = "wfc.workflows";
+		private readonly IDocumentStore _database;
+		static bool indexesCreated = false;
+
+		public RavendbPersistenceProvider(IDocumentStore database)
+		{
+			_database = database;
+			CreateIndexes(this);
+		}
+
+		static void CreateIndexes(RavendbPersistenceProvider instance)
+		{
+			if (!indexesCreated)
+			{
+				/*
+				// create the indexes here based on assemby of classes in the file 'RavenDbIndexes.cs'
+				IndexCreation.CreateIndexes(typeof(WorkflowInstances_Id).Assembly, instance._database);
+				IndexCreation.CreateIndexes(typeof(EventSubscriptions_Id).Assembly, instance._database);
+				IndexCreation.CreateIndexes(typeof(Events_Id).Assembly, instance._database);
+				IndexCreation.CreateIndexes(typeof(ExecutionErrors_Id).Assembly, instance._database);
+				*/
+				indexesCreated = true;
+			}
+		}
+
+		public async Task<string> CreateNewWorkflow(WorkflowInstance workflow)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				await session.StoreAsync(workflow);
+				var id = workflow.Id;
+				await session.SaveChangesAsync();
+				return id;
+			}
+		}
+
+		public async Task PersistWorkflow(WorkflowInstance workflow)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				session.Advanced.Patch<WorkflowInstance, string>(workflow.Id, x => x.WorkflowDefinitionId, workflow.WorkflowDefinitionId);
+				session.Advanced.Patch<WorkflowInstance, int>(workflow.Id, x => x.Version, workflow.Version);
+				session.Advanced.Patch<WorkflowInstance, string>(workflow.Id, x => x.Description, workflow.Description);
+				session.Advanced.Patch<WorkflowInstance, string>(workflow.Id, x => x.Reference, workflow.Reference);
+				session.Advanced.Patch<WorkflowInstance, ExecutionPointerCollection>(workflow.Id, x => x.ExecutionPointers, workflow.ExecutionPointers);
+				session.Advanced.Patch<WorkflowInstance, long?>(workflow.Id, x => x.NextExecution, workflow.NextExecution);
+				session.Advanced.Patch<WorkflowInstance, WorkflowStatus>(workflow.Id, x => x.Status, workflow.Status);
+				session.Advanced.Patch<WorkflowInstance, object>(workflow.Id, x => x.Data, workflow.Data);
+				session.Advanced.Patch<WorkflowInstance, DateTime>(workflow.Id, x => x.CreateTime, workflow.CreateTime);
+				session.Advanced.Patch<WorkflowInstance, DateTime?>(workflow.Id, x => x.CompleteTime, workflow.CompleteTime);
+
+				await session.SaveChangesAsync();
+			}
+		}
+
+		public async Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt)
+		{
+			var now = asAt.ToUniversalTime().Ticks;
+			using (var session = _database.OpenAsyncSession())
+			{
+				var l = session.Query<WorkflowInstance>().Where(w => w.NextExecution.HasValue
+					&& (w.NextExecution <= now)
+					&& (w.Status == WorkflowStatus.Runnable)
+				).Select(x => x.Id);
+
+				return await l.ToListAsync();
+			}
+		}
+
+		public async Task<WorkflowInstance> GetWorkflowInstance(string Id)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				var result = await session.Query<WorkflowInstance>().FirstOrDefaultAsync(x => x.Id == Id);
+				return result;
+			}
+		}
+
+		public async Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(IEnumerable<string> ids)
+		{
+			if (ids == null)
+			{
+				return new List<WorkflowInstance>();
+			}
+
+			using (var session = _database.OpenAsyncSession())
+			{
+				var list = session.Query<WorkflowInstance>().Where(x => x.Id.In(ids));
+				return await list.ToListAsync<WorkflowInstance>();
+			}
+		}
+
+		public async Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(WorkflowStatus? status, string type, DateTime? createdFrom, DateTime? createdTo, int skip, int take)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				var result = session.Query<WorkflowInstance>();
+
+				if (status.HasValue)
+					result = result.Where(x => x.Status == status.Value);
+
+				if (!String.IsNullOrEmpty(type))
+					result = result.Where(x => x.WorkflowDefinitionId == type);
+
+				if (createdFrom.HasValue)
+					result = result.Where(x => x.CreateTime >= createdFrom.Value);
+
+				if (createdTo.HasValue)
+					result = result.Where(x => x.CreateTime <= createdTo.Value);
+
+				return await result.Skip(skip).Take(take).ToListAsync();
+			}
+		}
+
+		public async Task<string> CreateEventSubscription(EventSubscription subscription)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				await session.StoreAsync(subscription);
+				var id = subscription.Id;
+				await session.SaveChangesAsync();
+				return id;
+			}
+		}
+
+		public async Task TerminateSubscription(string eventSubscriptionId)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				session.Delete(eventSubscriptionId);
+				await Task.CompletedTask;
+			}
+		}
+
+		public async Task<EventSubscription> GetSubscription(string eventSubscriptionId)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				var result = session.Query<EventSubscription>().Where(x => x.Id == eventSubscriptionId);
+				return await result.FirstOrDefaultAsync();
+			}
+		}
+
+		public async Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				var q = session.Query<EventSubscription>().Where(x =>
+					x.EventName == eventKey
+					&& x.EventKey == eventKey
+					&& x.SubscribeAsOf <= asOf
+					&& x.ExternalToken == null
+				);
+
+				return await q.FirstOrDefaultAsync();
+			}
+		}
+
+		public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry)
+		{
+			try
+			{
+				// The query string
+				var strbuilder = new StringBuilder();
+				strbuilder.Append("from EventSubscriptions as e ");
+				strbuilder.Append($"where e.Id = {eventSubscriptionId} and ExternalToken = null");
+				strbuilder.Append("update");
+				strbuilder.Append("{");
+				strbuilder.Append($"e.ExternalToken = '{token}'");
+				strbuilder.Append($"e.ExternalTokenExpiry = '{expiry}'");
+				strbuilder.Append($"e.ExternalWorkerId = 'workerId'");
+				strbuilder.Append("}");
+
+				var operation = await _database.Operations.SendAsync(new PatchByQueryOperation(strbuilder.ToString()));
+				operation.WaitForCompletion();
+				return true;
+			}
+			catch (Exception e)
+			{
+				return false;
+			}
+		}
+
+		public async Task ClearSubscriptionToken(string eventSubscriptionId, string token)
+		{
+			try
+			{
+				// The query string
+				var strbuilder = new StringBuilder();
+				strbuilder.Append("from EventSubscriptions as e ");
+				strbuilder.Append($"where e.Id = {eventSubscriptionId} and ExternalToken = '{token}'");
+				strbuilder.Append("update");
+				strbuilder.Append("{");
+				strbuilder.Append($"e.ExternalToken = null");
+				strbuilder.Append($"e.ExternalTokenExpiry = null");
+				strbuilder.Append($"e.ExternalWorkerId = null");
+				strbuilder.Append("}");
+
+				var operation = await _database.Operations.SendAsync(new PatchByQueryOperation(strbuilder.ToString()));
+				operation.WaitForCompletion();
+			}
+			catch (Exception e)
+			{
+				throw e;
+			}
+		}
+
+		public void EnsureStoreExists() { }
+
+		public async Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				var q = session.Query<EventSubscription>().Where(x =>
+					x.EventName == eventName
+					&& x.EventKey == eventKey
+					&& x.SubscribeAsOf <= asOf
+				);
+
+				return await q.ToListAsync();
+			}
+		}
+
+		public async Task<string> CreateEvent(Event newEvent)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				await session.StoreAsync(newEvent);
+				var id = newEvent.Id;
+				await session.SaveChangesAsync();
+				return id;
+			}
+		}
+
+		public async Task<Event> GetEvent(string id)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				var result = session.Query<Event>().Where(x => x.Id == id);
+				return await result.FirstAsync();
+			}
+		}
+
+		public async Task<IEnumerable<string>> GetRunnableEvents(DateTime asAt)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				var now = asAt.ToUniversalTime();
+				var result = session.Query<Event>()
+									.Where(x => !x.IsProcessed && x.EventTime < now)
+									.Select(x => x.Id);
+
+				return await result.ToListAsync();
+			}
+		}
+
+		public async Task MarkEventProcessed(string id)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				session.Advanced.Patch<Event, bool>(id, x => x.IsProcessed, true);
+
+				await session.SaveChangesAsync();
+			}
+		}
+
+		public async Task<IEnumerable<string>> GetEvents(string eventName, string eventKey, DateTime asOf)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				var q = session.Query<Event>()
+								.Where(x =>
+									x.EventName == eventName
+									&& x.EventKey == eventKey
+									&& x.EventTime >= asOf)
+								.Select(x => x.Id);
+
+				return await q.ToListAsync();
+			}
+		}
+
+		public async Task MarkEventUnprocessed(string id)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				session.Advanced.Patch<Event, bool>(id, x => x.IsProcessed, false);
+
+				await session.SaveChangesAsync();
+			}
+		}
+
+		public async Task PersistErrors(IEnumerable<ExecutionError> errors)
+		{
+			if (errors.Any())
+			{
+				var blk = _database.BulkInsert();
+				foreach (var error in errors)
+					await blk.StoreAsync(error);
+
+			}
+		}
+
+	}
+}

--- a/src/providers/WorkflowCore.Persistence.RavenDB/Services/WorkflowPurger.cs
+++ b/src/providers/WorkflowCore.Persistence.RavenDB/Services/WorkflowPurger.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using Raven.Client;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using System.Linq;
+using Raven.Client.Extensions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Queries;
+
+namespace WorkflowCore.Persistence.RavenDB.Services
+{
+	public class WorkflowPurger : IWorkflowPurger
+	{
+		private readonly IDocumentStore _database;
+
+		public WorkflowPurger(IDocumentStore database)
+		{
+			_database = database;
+		}
+
+		public async Task PurgeWorkflows(WorkflowStatus status, DateTime olderThan)
+		{
+			await DeleteWorkflowInstances(status, olderThan);
+		}
+
+
+		/// <summary>
+		/// Delete all Workflow Documents
+		/// </summary>
+		/// <returns></returns>
+		private Task<Operation> DeleteWorkflowInstances(WorkflowStatus status, DateTime olderThan)
+		{
+			var utcTime = olderThan.ToUniversalTime();
+			var queryToDelete = new IndexQuery { Query = $"FROM {nameof(WorkflowInstance)} where status = '{status}' and CompleteTime < '{olderThan}'" };
+			return _database.Operations.SendAsync(new DeleteByQueryOperation(queryToDelete, new QueryOperationOptions { AllowStale = false }));
+		}
+	}
+}

--- a/src/providers/WorkflowCore.Persistence.RavenDB/WorkflowCore.Persistence.RavenDB.csproj
+++ b/src/providers/WorkflowCore.Persistence.RavenDB/WorkflowCore.Persistence.RavenDB.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyTitle>Workflow Core RavenDB Persistence Provider</AssemblyTitle>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>WorkflowCore.Persistence.RavenDB</AssemblyName>
+    <PackageId>WorkflowCore.Persistence.RavenDB</PackageId>
+    <PackageTags>workflow;.NET;Core;state machine;WorkflowCore;RavenDB</PackageTags>
+    <PackageProjectUrl>https://github.com/danielgerlag/workflow-core</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/danielgerlag/workflow-core/blob/master/LICENSE.md</PackageLicenseUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/danielgerlag/workflow-core.git</RepositoryUrl>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <Description>Provides support to persist workflows running on Workflow Core to a RavenDB database.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="RavenDB.Client" Version="5.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\WorkflowCore\WorkflowCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+  </ItemGroup>
+
+
+</Project>


### PR DESCRIPTION
I use RavenDB as a database store. So in order to use conductor, I needed a RavenDB persistent store. I created a netstandard2.0 project modeled after the MongoDB provider store, but adapted to work with RavenDB.