### PR TITLE
SqlServer Provider: replace UseSqlServerIdentityColumn with UseIdentityColumn

### DIFF
--- a/src/providers/WorkflowCore.Persistence.SqlServer/SqlServerContext.cs
+++ b/src/providers/WorkflowCore.Persistence.SqlServer/SqlServerContext.cs
@@ -28,37 +28,37 @@ namespace WorkflowCore.Persistence.SqlServer
         protected override void ConfigureSubscriptionStorage(EntityTypeBuilder<PersistedSubscription> builder)
         {
             builder.ToTable("Subscription", "wfc");
-            builder.Property(x => x.PersistenceId).UseSqlServerIdentityColumn();
+            builder.Property(x => x.PersistenceId).UseIdentityColumn();
         }
 
         protected override void ConfigureWorkflowStorage(EntityTypeBuilder<PersistedWorkflow> builder)
         {
             builder.ToTable("Workflow", "wfc");
-            builder.Property(x => x.PersistenceId).UseSqlServerIdentityColumn();
+            builder.Property(x => x.PersistenceId).UseIdentityColumn();
         }
         
         protected override void ConfigureExecutionPointerStorage(EntityTypeBuilder<PersistedExecutionPointer> builder)
         {
             builder.ToTable("ExecutionPointer", "wfc");
-            builder.Property(x => x.PersistenceId).UseSqlServerIdentityColumn();
+            builder.Property(x => x.PersistenceId).UseIdentityColumn();
         }
 
         protected override void ConfigureExecutionErrorStorage(EntityTypeBuilder<PersistedExecutionError> builder)
         {
             builder.ToTable("ExecutionError", "wfc");
-            builder.Property(x => x.PersistenceId).UseSqlServerIdentityColumn();
+            builder.Property(x => x.PersistenceId).UseIdentityColumn();
         }
 
         protected override void ConfigureExetensionAttributeStorage(EntityTypeBuilder<PersistedExtensionAttribute> builder)
         {
             builder.ToTable("ExtensionAttribute", "wfc");
-            builder.Property(x => x.PersistenceId).UseSqlServerIdentityColumn();
+            builder.Property(x => x.PersistenceId).UseIdentityColumn();
         }
 
         protected override void ConfigureEventStorage(EntityTypeBuilder<PersistedEvent> builder)
         {
             builder.ToTable("Event", "wfc");
-            builder.Property(x => x.PersistenceId).UseSqlServerIdentityColumn();
+            builder.Property(x => x.PersistenceId).UseIdentityColumn();
         }
     }
 }


### PR DESCRIPTION
fix #694
SqlServer Provider: replace UseSqlServerIdentityColumn with UseIdentityColumn
as per [doc](https://docs.microsoft.com/en-us/ef/core/what-is-new/ef-core-3.x/breaking-changes#provider-specific-metadata-api-changes)