### PR TITLE
Service Bus LifeCycle listener to use message handler instead of session handler

### DIFF
--- a/src/providers/WorkflowCore.Providers.Azure/WorkflowCore.Providers.Azure.csproj
+++ b/src/providers/WorkflowCore.Providers.Azure/WorkflowCore.Providers.Azure.csproj
@@ -7,15 +7,15 @@
 - Provides distributed lock management  on Workflow Core
 - Provides Queueing support  on Workflow Core</Description>
     <PackageTags>workflow workflowcore dlm</PackageTags>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <PackageProjectUrl>https://github.com/danielgerlag/workflow-core</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/danielgerlag/workflow-core/blob/master/LICENSE.md</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/danielgerlag/workflow-core.git</RepositoryUrl>
     <Authors>Daniel Gerlag</Authors>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.0.0</FileVersion>
+    <AssemblyVersion>3.1.0.0</AssemblyVersion>
+    <FileVersion>3.1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We publish messages without a session ID but receive them with a session handler.
This PR changes the Service Bus LifeCycle listener to use message handler instead of session handler.
@glucaci 
@jiripoledna
