### PR TITLE
Fix testing with DI in Workflow

### DIFF
--- a/test/WorkflowCore.IntegrationTests/Scenarios/DiScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/DiScenario.cs
@@ -87,6 +87,8 @@ namespace WorkflowCore.IntegrationTests.Scenarios
     {
         protected void ConfigureHost(IServiceProvider serviceProvider)
         {
+            Workflow = serviceProvider.GetService<DiWorkflow>();
+
             PersistenceProvider = serviceProvider.GetService<IPersistenceProvider>();
             Host = serviceProvider.GetService<IWorkflowHost>();
             Host.RegisterWorkflow<DiWorkflow, DiData>();

--- a/test/WorkflowCore.IntegrationTests/Scenarios/DiScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/DiScenario.cs
@@ -113,6 +113,7 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             services.AddTransient<Dependency1>();
             services.AddTransient<Dependency2>();
             services.AddTransient<DiStep1>();
+            services.AddTransient<DiWorkflow>();
             services.AddLogging();
             ConfigureServices(services);
 
@@ -151,6 +152,7 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             services.AddScoped<Dependency2>();
             services.AddTransient<DiStep1>();
             services.AddLogging();
+            services.AddTransient<DiWorkflow>();
             ConfigureServices(services);
 
             var serviceProvider = services.BuildServiceProvider();
@@ -193,6 +195,7 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             builder.RegisterType<Dependency1>().InstancePerDependency();
             builder.RegisterType<Dependency2>().InstancePerDependency();
             builder.RegisterType<DiStep1>().InstancePerDependency();
+            builder.RegisterType<DiWorkflow>().InstancePerDependency();
             var container = builder.Build();
 
             var serviceProvider = new AutofacServiceProvider(container);
@@ -235,6 +238,7 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             builder.RegisterType<Dependency1>().InstancePerLifetimeScope();
             builder.RegisterType<Dependency2>().InstancePerLifetimeScope();
             builder.RegisterType<DiStep1>().InstancePerLifetimeScope();
+            builder.RegisterType<DiWorkflow>().InstancePerLifetimeScope();
             var container = builder.Build();
 
             var serviceProvider = new AutofacServiceProvider(container);

--- a/test/WorkflowCore.Testing/WorkflowCore.Testing.csproj
+++ b/test/WorkflowCore.Testing/WorkflowCore.Testing.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.3.0</Version>
-    <AssemblyVersion>2.3.0.0</AssemblyVersion>
-    <FileVersion>2.3.0.0</FileVersion>
+    <Version>2.3.1</Version>
+    <AssemblyVersion>2.3.1.0</AssemblyVersion>
+    <FileVersion>2.3.1.0</FileVersion>
     <Description>Facilitates testing of workflows built on Workflow-Core</Description>
   </PropertyGroup>
 

--- a/test/WorkflowCore.Testing/WorkflowTest.cs
+++ b/test/WorkflowCore.Testing/WorkflowTest.cs
@@ -24,6 +24,8 @@ namespace WorkflowCore.Testing
             //setup dependency injection
             IServiceCollection services = new ServiceCollection();
             services.AddLogging();
+            services.AddTransient<TWorkflow>();
+            
             ConfigureServices(services);
 
             var serviceProvider = services.BuildServiceProvider();
@@ -54,7 +56,6 @@ namespace WorkflowCore.Testing
         protected virtual void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow();
-            services.AddTransient<TWorkflow>();
         }
 
         public string StartWorkflow(TData data)


### PR DESCRIPTION
Dependency injection is supported in Workflow but cannot be tested (fix)
It is related to changes made in PR: Allow dependency injection on Workflow #576
The new() constraint on TWokflow is still present on WorkflowTest while it has been removed elsewhere