### PR TITLE
Extend RunWorkflowSync

### DIFF
--- a/src/WorkflowCore/Interface/ISyncWorkflowRunner.cs
+++ b/src/WorkflowCore/Interface/ISyncWorkflowRunner.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using WorkflowCore.Models;
 
@@ -7,6 +8,9 @@ namespace WorkflowCore.Interface
     public interface ISyncWorkflowRunner
     {
         Task<WorkflowInstance> RunWorkflowSync<TData>(string workflowId, int version, TData data, string reference, TimeSpan timeOut, bool persistSate = true)
+            where TData : new();
+
+        Task<WorkflowInstance> RunWorkflowSync<TData>(string workflowId, int version, TData data, string reference, CancellationToken token, bool persistSate = true)
             where TData : new();
     }
 }


### PR DESCRIPTION
Extend RunWorkflowSync using a CancelationToken.
When used in a controller, it lets you pass the token from the current context and apply its timeout settings