### PR TITLE
Refactored DataObjectSerializer to be able to use decimal value types and BsonRepresentation attributes

### DIFF
--- a/src/WorkflowCore/WorkflowCore.csproj
+++ b/src/WorkflowCore/WorkflowCore.csproj
@@ -15,12 +15,12 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Description>Workflow Core is a light weight workflow engine targeting .NET Standard.</Description>
-    <Version>3.3.5</Version>
-    <AssemblyVersion>3.3.5.0</AssemblyVersion>
-    <FileVersion>3.3.5.0</FileVersion>
+    <Version>3.3.6</Version>
+    <AssemblyVersion>3.3.6.0</AssemblyVersion>
+    <FileVersion>3.3.6.0</FileVersion>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageIconUrl>https://github.com/danielgerlag/workflow-core/raw/master/src/logo.png</PackageIconUrl>
-    <PackageVersion>3.3.5</PackageVersion>
+    <PackageVersion>3.3.6</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WorkflowCore/WorkflowCore.csproj
+++ b/src/WorkflowCore/WorkflowCore.csproj
@@ -15,12 +15,12 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Description>Workflow Core is a light weight workflow engine targeting .NET Standard.</Description>
-    <Version>3.3.6</Version>
-    <AssemblyVersion>3.3.6.0</AssemblyVersion>
-    <FileVersion>3.3.6.0</FileVersion>
+    <Version>3.3.5</Version>
+    <AssemblyVersion>3.3.5.0</AssemblyVersion>
+    <FileVersion>3.3.5.0</FileVersion>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageIconUrl>https://github.com/danielgerlag/workflow-core/raw/master/src/logo.png</PackageIconUrl>
-    <PackageVersion>3.3.6</PackageVersion>
+    <PackageVersion>3.3.5</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/providers/WorkflowCore.Persistence.MongoDB/README.md
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/README.md
@@ -17,3 +17,35 @@ Use the .UseMongoDB extension method when building your service provider.
 ```C#
 services.AddWorkflow(x => x.UseMongoDB(@"mongodb://localhost:27017", "workflow"));
 ```
+
+### State object serialization
+
+By default (to maintain backwards compatibility), the state object is serialized using a two step serialization process using object -> JSON -> BSON serialization.
+This approach has some limitations, for example you cannot control which types will be used in MongoDB for particular fields and you cannot use basic types that are not present in JSON (decimal, timestamp, etc).
+
+To eliminate these limitations, you can use a direct object -> BSON serialization and utilize all serialization possibilities that MongoDb driver provides. You can read more in the [MongoDb CSharp documentation](https://mongodb.github.io/mongo-csharp-driver/1.11/serialization/).
+To enable direct serilization you need to register a class map for you state class somewhere in your startup process before you run `WorkflowHost`.
+
+```C#
+private void RunWorkflow()
+{
+    var host = this._serviceProvider.GetService<IWorkflowHost>();
+    if (host == null)
+    {
+        return;
+    }
+
+    if (!BsonClassMap.IsClassMapRegistered(typeof(MyWorkflowState)))
+    {
+        BsonClassMap.RegisterClassMap<MyWorkflowState>(cm =>
+        {
+            cm.AutoMap();
+        });
+    }
+
+    host.RegisterWorkflow<MyWorkflow, MyWorkflowState>();
+
+    host.Start();
+}
+
+```

--- a/src/providers/WorkflowCore.Persistence.MongoDB/Services/DataObjectSerializer.cs
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/Services/DataObjectSerializer.cs
@@ -77,7 +77,7 @@ namespace WorkflowCore.Persistence.MongoDB.Services
                 if (subPath[0] == '[')
                 {
                     var index = Int32.Parse(subPath.Trim('[', ']'));
-                    if (value.GetType().IsSubclassOf(typeof(IList)) || value.GetType().IsArray)
+                    if ((value is IList) || value.GetType().IsArray)
                     {
                         IList list = (IList) value;
                         value = list[index];

--- a/src/providers/WorkflowCore.Persistence.MongoDB/Services/DataObjectSerializer.cs
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/Services/DataObjectSerializer.cs
@@ -2,11 +2,9 @@
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Bson;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Threading.Tasks;
-using WorkflowCore.Models;
 using Newtonsoft.Json;
 
 namespace WorkflowCore.Persistence.MongoDB.Services
@@ -17,7 +15,7 @@ namespace WorkflowCore.Persistence.MongoDB.Services
         {
             TypeNameHandling = TypeNameHandling.Objects,
         };
-        
+
         public override object Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
         {
             if (context.Reader.CurrentBsonType == BsonType.String)
@@ -26,16 +24,101 @@ namespace WorkflowCore.Persistence.MongoDB.Services
                 return JsonConvert.DeserializeObject(raw, SerializerSettings);
             }
 
-            return BsonSerializer.Deserialize(context.Reader, typeof(object));
+            var obj = BsonSerializer.Deserialize(context.Reader, typeof(object));
+            return obj;
         }
 
         public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, object value)
         {
-            var str = JsonConvert.SerializeObject(value, SerializerSettings);
-            var doc = BsonDocument.Parse(str);
-            ConvertMetaFormat(doc);
+            BsonDocument doc;
+            if (BsonClassMap.IsClassMapRegistered(value.GetType()))
+            {
+                doc = value.ToBsonDocument();
+                doc.Remove("_t");
+                doc.InsertAt(0, new BsonElement("_t", value.GetType().AssemblyQualifiedName));
+                AddTypeInformation(doc.Elements, value, string.Empty);
+            }
+            else
+            {
+                var str = JsonConvert.SerializeObject(value, SerializerSettings);
+                doc = BsonDocument.Parse(str);
+                ConvertMetaFormat(doc);
+            }
             
             BsonSerializer.Serialize(context.Writer, doc);
+        }
+
+        private void AddTypeInformation(IEnumerable<BsonElement> elements, object value, string xPath)
+        {
+            foreach (var element in elements)
+            {
+                var elementXPath = string.IsNullOrEmpty(xPath) ? element.Name : xPath + "." + element.Name;
+                if (element.Value.IsBsonDocument)
+                {
+                    var doc = element.Value.AsBsonDocument;
+                    doc.Remove("_t");
+                    doc.InsertAt(0, new BsonElement("_t", GetTypeNameFromXPath(value, elementXPath)));
+                    AddTypeInformation(doc.Elements, value, elementXPath);
+                }
+                if (element.Value.IsBsonArray)
+                {
+                    AddTypeInformation(element.Value.AsBsonArray, value, elementXPath);
+                }
+            }
+        }
+
+        private string GetTypeNameFromXPath(object root, string xPath)
+        {
+            var parts = xPath.Split('.').ToList();
+            object value = root;
+            while (parts.Count > 0)
+            {
+                var subPath = parts[0];
+                if (subPath[0] == '[')
+                {
+                    var index = Int32.Parse(subPath.Trim('[', ']'));
+                    if (value.GetType().IsSubclassOf(typeof(IList)) || value.GetType().IsArray)
+                    {
+                        IList list = (IList) value;
+                        value = list[index];
+                    }
+                    else
+                    {
+                        throw new NotSupportedException();
+                    }
+                }
+                else
+                {
+                    var propInfo = value.GetType().GetProperty(subPath);
+                    value = propInfo.GetValue(value);
+                }
+
+                parts.RemoveAt(0);
+            }
+
+            return value.GetType().AssemblyQualifiedName;
+        }
+
+        private void AddTypeInformation(IEnumerable<BsonValue> elements, object value, string xPath)
+        {
+            //foreach (var element in elements) 
+            for (int i = 0; i < elements.Count(); i++)
+            {
+                var element = elements.ElementAt(i);
+                if (element.IsBsonDocument)
+                {
+                    var doc = element.AsBsonDocument;
+                    var elementXPath = xPath + $".[{i}]";
+                    doc.Remove("_t");
+                    doc.InsertAt(0, new BsonElement("_t", GetTypeNameFromXPath(value, elementXPath)));
+                    AddTypeInformation(doc.Elements, value, elementXPath);
+                }
+
+                if (element.IsBsonArray)
+                {
+                    AddTypeInformation(element.AsBsonArray, value, xPath);
+                }
+            }
         }
 
         private static void ConvertMetaFormat(BsonDocument root)

--- a/src/providers/WorkflowCore.Persistence.MongoDB/WorkflowCore.Persistence.MongoDB.csproj
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/WorkflowCore.Persistence.MongoDB.csproj
@@ -14,11 +14,11 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.3</Version>
+    <Version>3.0.4</Version>
     <Description>Provides support to persist workflows running on Workflow Core to a MongoDB database.</Description>
-    <AssemblyVersion>3.0.3.0</AssemblyVersion>
-    <FileVersion>3.0.3.0</FileVersion>
-    <PackageVersion>3.0.3</PackageVersion>
+    <AssemblyVersion>3.0.4.0</AssemblyVersion>
+    <FileVersion>3.0.4.0</FileVersion>
+    <PackageVersion>3.0.4</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/samples/WorkflowCore.TestSample01/NUnitTest.cs
+++ b/src/samples/WorkflowCore.TestSample01/NUnitTest.cs
@@ -13,9 +13,9 @@ namespace WorkflowCore.TestSample01
     public class NUnitTest : WorkflowTest<MyWorkflow, MyDataClass>
     {
         [SetUp]
-        protected override void Setup()
+        protected override void Setup(bool registerClassMap = false)
         {
-            base.Setup();
+            base.Setup(registerClassMap);
         }
 
         [Test]

--- a/test/WorkflowCore.IntegrationTests/Scenarios/DataIOScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/DataIOScenario.cs
@@ -29,6 +29,14 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             public int Value1 { get; set; }
             public int Value2 { get; set; }
             public int Value3 { get; set; }
+            public decimal Value4 { get; set; }
+            
+            public DataSubclass SubValue { get; set; }
+        }
+
+        public class DataSubclass
+        {
+            public decimal Value5 { get; set; }
         }
 
         public class DataIOWorkflow : IWorkflow<MyDataClass>
@@ -47,18 +55,20 @@ namespace WorkflowCore.IntegrationTests.Scenarios
 
         public DataIOScenario()
         {
-            Setup();
+            Setup(true);
         }
 
         [Fact]
         public void Scenario()
         {
-            var workflowId = StartWorkflow(new MyDataClass() { Value1 = 2, Value2 = 3 });
+            decimal v4 = 1.235465673450897890m;
+            var workflowId = StartWorkflow(new MyDataClass() {Value1 = 2, Value2 = 3, Value4 = v4, SubValue = new DataSubclass() {Value5 = v4}});
             WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(30));
 
             GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
             UnhandledStepErrors.Count.Should().Be(0);
             GetData(workflowId).Value3.Should().Be(5);
+            GetData(workflowId).Value4.Should().Be(v4);
         }
     }
 }

--- a/test/WorkflowCore.Testing/WorkflowCore.Testing.csproj
+++ b/test/WorkflowCore.Testing/WorkflowCore.Testing.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="MongoDB.Bson" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WorkflowCore.Testing/WorkflowTest.cs
+++ b/test/WorkflowCore.Testing/WorkflowTest.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using MongoDB.Bson.Serialization;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
 
@@ -20,7 +21,7 @@ namespace WorkflowCore.Testing
         protected IPersistenceProvider PersistenceProvider;
         protected List<StepError> UnhandledStepErrors = new List<StepError>();
 
-        protected virtual void Setup()
+        protected virtual void Setup(bool registerClassMap = false)
         {
             //setup dependency injection
             IServiceCollection services = new ServiceCollection();
@@ -32,6 +33,11 @@ namespace WorkflowCore.Testing
             //config logging
             var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
             //loggerFactory.AddConsole(LogLevel.Debug);
+
+            if (registerClassMap && !BsonClassMap.IsClassMapRegistered(typeof(TData)))
+            {
+                BsonClassMap.RegisterClassMap<TData>(map => map.AutoMap());
+            }
 
             PersistenceProvider = serviceProvider.GetService<IPersistenceProvider>();
             Host = serviceProvider.GetService<IWorkflowHost>();


### PR DESCRIPTION
See #761. Previous DataObjectSerializer class has many problems listed in the issue. I've fixed this problem by introducing the ability to use class maps for data classes and enriching serialized BSON with type information by using reflection. This is purely optional and old method is used by default.