### PR TITLE
Error middleware enhancement

### DIFF
--- a/src/WorkflowCore/Interface/IWorkflowMiddlewareErrorHandler.cs
+++ b/src/WorkflowCore/Interface/IWorkflowMiddlewareErrorHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using WorkflowCore.Models;
 
 namespace WorkflowCore.Interface
 {
@@ -11,8 +12,9 @@ namespace WorkflowCore.Interface
         /// <summary>
         /// Asynchronously handle the given exception.
         /// </summary>
+        /// <param name="workflowInstance">Workflow instance where error happened</param>
         /// <param name="ex">The exception to handle</param>
         /// <returns>A task that completes when handling is done.</returns>
-        Task HandleAsync(Exception ex);
+        Task HandleAsync(WorkflowInstance workflowInstance, Exception ex);
     }
 }

--- a/src/WorkflowCore/Services/DefaultWorkflowMiddlewareErrorHandler.cs
+++ b/src/WorkflowCore/Services/DefaultWorkflowMiddlewareErrorHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using WorkflowCore.Interface;
+using WorkflowCore.Models;
 
 namespace WorkflowCore.Services
 {
@@ -21,11 +22,12 @@ namespace WorkflowCore.Services
         /// <summary>
         /// Asynchronously handle the given exception.
         /// </summary>
+        /// <param name="workflowInstance">Workflow instance where error happened</param>
         /// <param name="ex">The exception to handle</param>
         /// <returns>A task that completes when handling is done.</returns>
-        public Task HandleAsync(Exception ex)
+        public Task HandleAsync(WorkflowInstance workflowInstance, Exception ex)
         {
-            _log.LogError(ex, "An error occurred running workflow middleware: {Message}", ex.Message);
+            _log.LogError(ex, "An error occurred running workflow '{workflow}' middleware: {Message}", workflowInstance.Id, ex.Message);
             return Task.CompletedTask;
         }
     }

--- a/src/WorkflowCore/Services/WorkflowMiddlewareRunner.cs
+++ b/src/WorkflowCore/Services/WorkflowMiddlewareRunner.cs
@@ -71,7 +71,7 @@ namespace WorkflowCore.Services
                     var typeInstance = scope.ServiceProvider.GetService(errorHandlerType);
                     if (typeInstance != null && typeInstance is IWorkflowMiddlewareErrorHandler handler)
                     {
-                        await handler.HandleAsync(exception);
+                        await handler.HandleAsync(workflow, exception);
                     }
                 }
             }

--- a/test/WorkflowCore.UnitTests/Services/WorkflowMiddlewareRunnerTests.cs
+++ b/test/WorkflowCore.UnitTests/Services/WorkflowMiddlewareRunnerTests.cs
@@ -265,7 +265,7 @@ namespace WorkflowCore.UnitTests.Services
                 A<WorkflowDelegate>._);
 
         private static Expression<Func<Task>> HandleMethodFor(IWorkflowMiddlewareErrorHandler errorHandler) =>
-            () => errorHandler.HandleAsync(A<Exception>._);
+            () => errorHandler.HandleAsync(A<WorkflowInstance>._, A<Exception>._);
 
         public interface IDefLevelErrorHandler : IWorkflowMiddlewareErrorHandler
         {


### PR DESCRIPTION
This PR is adding a WorkflowInstance parameter to `IWorkflowMiddlewareErrorHandler` interface so that it's possible to log only exception, but also related workflow information like ID:

```
_log.LogError(ex, "An error occurred running workflow '{workflow}' middleware: {Message}", workflowInstance.Id, ex.Message);
```

WARNING: this is a breaking change in terms that any 3rd party implementations of IWorkflowMiddlewareErrorHandler won't work without changes.
