### PR TITLE
CancellationToken passed to PersistantStorage providers

### DIFF
--- a/src/WorkflowCore/Interface/Persistence/IEventRepository.cs
+++ b/src/WorkflowCore/Interface/Persistence/IEventRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using WorkflowCore.Models;
 
@@ -7,17 +8,17 @@ namespace WorkflowCore.Interface
 {
     public interface IEventRepository
     {
-        Task<string> CreateEvent(Event newEvent);
+        Task<string> CreateEvent(Event newEvent, CancellationToken cancellationToken = default);
 
-        Task<Event> GetEvent(string id);
+        Task<Event> GetEvent(string id, CancellationToken cancellationToken = default);
 
-        Task<IEnumerable<string>> GetRunnableEvents(DateTime asAt);
+        Task<IEnumerable<string>> GetRunnableEvents(DateTime asAt, CancellationToken cancellationToken = default);
 
-        Task<IEnumerable<string>> GetEvents(string eventName, string eventKey, DateTime asOf);
+        Task<IEnumerable<string>> GetEvents(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken = default);
 
-        Task MarkEventProcessed(string id);
+        Task MarkEventProcessed(string id, CancellationToken cancellationToken = default);
 
-        Task MarkEventUnprocessed(string id);
+        Task MarkEventUnprocessed(string id, CancellationToken cancellationToken = default);
 
     }
 }

--- a/src/WorkflowCore/Interface/Persistence/IPersistenceProvider.cs
+++ b/src/WorkflowCore/Interface/Persistence/IPersistenceProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using WorkflowCore.Models;
 
@@ -8,7 +9,7 @@ namespace WorkflowCore.Interface
     public interface IPersistenceProvider : IWorkflowRepository, ISubscriptionRepository, IEventRepository
     {        
 
-        Task PersistErrors(IEnumerable<ExecutionError> errors);
+        Task PersistErrors(IEnumerable<ExecutionError> errors, CancellationToken cancellationToken = default);
 
         void EnsureStoreExists();
 

--- a/src/WorkflowCore/Interface/Persistence/ISubscriptionRepository.cs
+++ b/src/WorkflowCore/Interface/Persistence/ISubscriptionRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using WorkflowCore.Models;
 
@@ -7,19 +8,19 @@ namespace WorkflowCore.Interface
 {
     public interface ISubscriptionRepository
     {        
-        Task<string> CreateEventSubscription(EventSubscription subscription);
+        Task<string> CreateEventSubscription(EventSubscription subscription, CancellationToken cancellationToken = default);
 
-        Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf);
+        Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken = default);
 
-        Task TerminateSubscription(string eventSubscriptionId);
+        Task TerminateSubscription(string eventSubscriptionId, CancellationToken cancellationToken = default);
 
-        Task<EventSubscription> GetSubscription(string eventSubscriptionId);
+        Task<EventSubscription> GetSubscription(string eventSubscriptionId, CancellationToken cancellationToken = default);
 
-        Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf);
+        Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken = default);
         
-        Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry);
+        Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken cancellationToken = default);
         
-        Task ClearSubscriptionToken(string eventSubscriptionId, string token);
+        Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken cancellationToken = default);
 
     }
 }

--- a/src/WorkflowCore/Interface/Persistence/IWorkflowRepository.cs
+++ b/src/WorkflowCore/Interface/Persistence/IWorkflowRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using WorkflowCore.Models;
 
@@ -7,18 +8,18 @@ namespace WorkflowCore.Interface
 {
     public interface IWorkflowRepository
     {
-        Task<string> CreateNewWorkflow(WorkflowInstance workflow);
+        Task<string> CreateNewWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken = default);
 
-        Task PersistWorkflow(WorkflowInstance workflow);
+        Task PersistWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken = default);
 
-        Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt);
+        Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt, CancellationToken cancellationToken = default);
 
         [Obsolete]
         Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(WorkflowStatus? status, string type, DateTime? createdFrom, DateTime? createdTo, int skip, int take);
 
-        Task<WorkflowInstance> GetWorkflowInstance(string Id);
+        Task<WorkflowInstance> GetWorkflowInstance(string Id, CancellationToken cancellationToken = default);
 
-        Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(IEnumerable<string> ids);
+        Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(IEnumerable<string> ids, CancellationToken cancellationToken = default);
 
     }
 }

--- a/src/WorkflowCore/Services/BackgroundTasks/EventConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/EventConsumer.cs
@@ -42,7 +42,7 @@ namespace WorkflowCore.Services.BackgroundTasks
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var evt = await _eventRepository.GetEvent(itemId);
+                var evt = await _eventRepository.GetEvent(itemId, cancellationToken);
                 if (evt.IsProcessed)
                 {
                     _greylist.Add($"evt:{evt.Id}");
@@ -53,18 +53,18 @@ namespace WorkflowCore.Services.BackgroundTasks
                     IEnumerable<EventSubscription> subs = null;
                     if (evt.EventData is ActivityResult)
                     {
-                        var activity = await _subscriptionRepository.GetSubscription((evt.EventData as ActivityResult).SubscriptionId);
+                        var activity = await _subscriptionRepository.GetSubscription((evt.EventData as ActivityResult).SubscriptionId, cancellationToken);
                         if (activity == null)
                         {
                             Logger.LogWarning($"Activity already processed - {(evt.EventData as ActivityResult).SubscriptionId}");
-                            await _eventRepository.MarkEventProcessed(itemId);
+                            await _eventRepository.MarkEventProcessed(itemId, cancellationToken);
                             return;
                         }
                         subs = new List<EventSubscription>() { activity };
                     }
                     else
                     {
-                        subs = await _subscriptionRepository.GetSubscriptions(evt.EventName, evt.EventKey, evt.EventTime);
+                        subs = await _subscriptionRepository.GetSubscriptions(evt.EventName, evt.EventKey, evt.EventTime, cancellationToken);
                     }
 
                     var toQueue = new HashSet<string>();
@@ -74,7 +74,7 @@ namespace WorkflowCore.Services.BackgroundTasks
                         complete = complete && await SeedSubscription(evt, sub, toQueue, cancellationToken);
 
                     if (complete)
-                        await _eventRepository.MarkEventProcessed(itemId);
+                        await _eventRepository.MarkEventProcessed(itemId, cancellationToken);
 
                     foreach (var eventId in toQueue)
                         await QueueProvider.QueueWork(eventId, QueueType.Event);
@@ -88,12 +88,12 @@ namespace WorkflowCore.Services.BackgroundTasks
         
         private async Task<bool> SeedSubscription(Event evt, EventSubscription sub, HashSet<string> toQueue, CancellationToken cancellationToken)
         {            
-            foreach (var eventId in await _eventRepository.GetEvents(sub.EventName, sub.EventKey, sub.SubscribeAsOf))
+            foreach (var eventId in await _eventRepository.GetEvents(sub.EventName, sub.EventKey, sub.SubscribeAsOf, cancellationToken))
             {
                 if (eventId == evt.Id)
                     continue;
 
-                var siblingEvent = await _eventRepository.GetEvent(eventId);
+                var siblingEvent = await _eventRepository.GetEvent(eventId, cancellationToken);
                 if ((!siblingEvent.IsProcessed) && (siblingEvent.EventTime < evt.EventTime))
                 {
                     await QueueProvider.QueueWork(eventId, QueueType.Event);
@@ -112,7 +112,7 @@ namespace WorkflowCore.Services.BackgroundTasks
             
             try
             {
-                var workflow = await _workflowRepository.GetWorkflowInstance(sub.WorkflowId);
+                var workflow = await _workflowRepository.GetWorkflowInstance(sub.WorkflowId, cancellationToken);
                 IEnumerable<ExecutionPointer> pointers = null;
                 
                 if (!string.IsNullOrEmpty(sub.ExecutionPointerId))
@@ -127,8 +127,8 @@ namespace WorkflowCore.Services.BackgroundTasks
                     p.Active = true;
                 }
                 workflow.NextExecution = 0;
-                await _workflowRepository.PersistWorkflow(workflow);
-                await _subscriptionRepository.TerminateSubscription(sub.Id);
+                await _workflowRepository.PersistWorkflow(workflow, cancellationToken);
+                await _subscriptionRepository.TerminateSubscription(sub.Id, cancellationToken);
                 return true;
             }
             catch (Exception ex)

--- a/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
@@ -43,7 +43,7 @@ namespace WorkflowCore.Services.BackgroundTasks
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                workflow = await _persistenceStore.GetWorkflowInstance(itemId);
+                workflow = await _persistenceStore.GetWorkflowInstance(itemId, cancellationToken);
                 if (workflow.Status == WorkflowStatus.Runnable)
                 {
                     try
@@ -52,7 +52,7 @@ namespace WorkflowCore.Services.BackgroundTasks
                     }
                     finally
                     {
-                        await _persistenceStore.PersistWorkflow(workflow);
+                        await _persistenceStore.PersistWorkflow(workflow, cancellationToken);
                         await QueueProvider.QueueWork(itemId, QueueType.Index);
                         _greylist.Remove($"wf:{itemId}");
                     }
@@ -65,10 +65,10 @@ namespace WorkflowCore.Services.BackgroundTasks
                 {
                     foreach (var sub in result.Subscriptions)
                     {
-                        await SubscribeEvent(sub, _persistenceStore);
+                        await SubscribeEvent(sub, _persistenceStore, cancellationToken);
                     }
 
-                    await _persistenceStore.PersistErrors(result.Errors);
+                    await _persistenceStore.PersistErrors(result.Errors, cancellationToken);
 
                     var readAheadTicks = _datetimeProvider.UtcNow.Add(Options.PollInterval).Ticks;
 
@@ -81,18 +81,18 @@ namespace WorkflowCore.Services.BackgroundTasks
             
         }
         
-        private async Task SubscribeEvent(EventSubscription subscription, IPersistenceProvider persistenceStore)
+        private async Task SubscribeEvent(EventSubscription subscription, IPersistenceProvider persistenceStore, CancellationToken cancellationToken)
         {
             //TODO: move to own class
             Logger.LogDebug("Subscribing to event {0} {1} for workflow {2} step {3}", subscription.EventName, subscription.EventKey, subscription.WorkflowId, subscription.StepId);
             
-            await persistenceStore.CreateEventSubscription(subscription);
+            await persistenceStore.CreateEventSubscription(subscription, cancellationToken);
             if (subscription.EventName != Event.EventTypeActivity)
             {
-                var events = await persistenceStore.GetEvents(subscription.EventName, subscription.EventKey, subscription.SubscribeAsOf);
+                var events = await persistenceStore.GetEvents(subscription.EventName, subscription.EventKey, subscription.SubscribeAsOf, cancellationToken);
                 foreach (var evt in events)
                 {
-                    await persistenceStore.MarkEventUnprocessed(evt);
+                    await persistenceStore.MarkEventUnprocessed(evt, cancellationToken);
                     await QueueProvider.QueueWork(evt, QueueType.Event);
                 }
             }

--- a/src/WorkflowCore/Services/DefaultProviders/MemoryPersistenceProvider.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/MemoryPersistenceProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
@@ -24,7 +25,7 @@ namespace WorkflowCore.Services
         private readonly List<Event> _events = new List<Event>();
         private readonly List<ExecutionError> _errors = new List<ExecutionError>();
 
-        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow)
+        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow, CancellationToken _ = default)
         {
             lock (_instances)
             {
@@ -34,7 +35,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task PersistWorkflow(WorkflowInstance workflow)
+        public async Task PersistWorkflow(WorkflowInstance workflow, CancellationToken _ = default)
         {
             lock (_instances)
             {
@@ -44,7 +45,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt)
+        public async Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt, CancellationToken _ = default)
         {
             lock (_instances)
             {
@@ -53,7 +54,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task<WorkflowInstance> GetWorkflowInstance(string Id)
+        public async Task<WorkflowInstance> GetWorkflowInstance(string Id, CancellationToken _ = default)
         {
             lock (_instances)
             {
@@ -61,7 +62,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(IEnumerable<string> ids)
+        public async Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(IEnumerable<string> ids, CancellationToken _ = default)
         {
             if (ids == null)
             {
@@ -105,7 +106,7 @@ namespace WorkflowCore.Services
         }
 
 
-        public async Task<string> CreateEventSubscription(EventSubscription subscription)
+        public async Task<string> CreateEventSubscription(EventSubscription subscription, CancellationToken _ = default)
         {
             lock (_subscriptions)
             {
@@ -115,7 +116,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf)
+        public async Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf, CancellationToken _ = default)
         {
             lock (_subscriptions)
             {
@@ -124,7 +125,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task TerminateSubscription(string eventSubscriptionId)
+        public async Task TerminateSubscription(string eventSubscriptionId, CancellationToken _ = default)
         {
             lock (_subscriptions)
             {
@@ -133,7 +134,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public Task<EventSubscription> GetSubscription(string eventSubscriptionId)
+        public Task<EventSubscription> GetSubscription(string eventSubscriptionId, CancellationToken _ = default)
         {
             lock (_subscriptions)
             {
@@ -142,7 +143,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf)
+        public Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf, CancellationToken _ = default)
         {
             lock (_subscriptions)
             {
@@ -152,7 +153,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry)
+        public Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken _ = default)
         {
             lock (_subscriptions)
             {
@@ -165,7 +166,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public Task ClearSubscriptionToken(string eventSubscriptionId, string token)
+        public Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken _ = default)
         {
             lock (_subscriptions)
             {
@@ -184,7 +185,7 @@ namespace WorkflowCore.Services
         {
         }
 
-        public async Task<string> CreateEvent(Event newEvent)
+        public async Task<string> CreateEvent(Event newEvent, CancellationToken _ = default)
         {
             lock (_events)
             {
@@ -194,7 +195,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task MarkEventProcessed(string id)
+        public async Task MarkEventProcessed(string id, CancellationToken _ = default)
         {
             lock (_events)
             {
@@ -204,7 +205,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task<IEnumerable<string>> GetRunnableEvents(DateTime asAt)
+        public async Task<IEnumerable<string>> GetRunnableEvents(DateTime asAt, CancellationToken _ = default)
         {
             lock (_events)
             {
@@ -216,7 +217,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task<Event> GetEvent(string id)
+        public async Task<Event> GetEvent(string id, CancellationToken _ = default)
         {
             lock (_events)
             {
@@ -224,7 +225,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task<IEnumerable<string>> GetEvents(string eventName, string eventKey, DateTime asOf)
+        public async Task<IEnumerable<string>> GetEvents(string eventName, string eventKey, DateTime asOf, CancellationToken _ = default)
         {
             lock (_events)
             {
@@ -236,7 +237,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task MarkEventUnprocessed(string id)
+        public async Task MarkEventUnprocessed(string id, CancellationToken _ = default)
         {
             lock (_events)
             {
@@ -248,7 +249,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task PersistErrors(IEnumerable<ExecutionError> errors)
+        public async Task PersistErrors(IEnumerable<ExecutionError> errors, CancellationToken _ = default)
         {
             lock (errors)
             {

--- a/src/WorkflowCore/Services/DefaultProviders/TransientMemoryPersistenceProvider.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/TransientMemoryPersistenceProvider.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
@@ -16,45 +16,45 @@ namespace WorkflowCore.Services
             _innerService = innerService;
         }
 
-        public Task<string> CreateEvent(Event newEvent) => _innerService.CreateEvent(newEvent);
+        public Task<string> CreateEvent(Event newEvent, CancellationToken _ = default) => _innerService.CreateEvent(newEvent);
 
-        public Task<string> CreateEventSubscription(EventSubscription subscription) => _innerService.CreateEventSubscription(subscription);
+        public Task<string> CreateEventSubscription(EventSubscription subscription, CancellationToken _ = default) => _innerService.CreateEventSubscription(subscription);
 
-        public Task<string> CreateNewWorkflow(WorkflowInstance workflow) => _innerService.CreateNewWorkflow(workflow);
+        public Task<string> CreateNewWorkflow(WorkflowInstance workflow, CancellationToken _ = default) => _innerService.CreateNewWorkflow(workflow);
 
         public void EnsureStoreExists() => _innerService.EnsureStoreExists();
 
-        public Task<Event> GetEvent(string id) => _innerService.GetEvent(id);
+        public Task<Event> GetEvent(string id, CancellationToken _ = default) => _innerService.GetEvent(id);
 
-        public Task<IEnumerable<string>> GetEvents(string eventName, string eventKey, DateTime asOf) => _innerService.GetEvents(eventName, eventKey, asOf);
+        public Task<IEnumerable<string>> GetEvents(string eventName, string eventKey, DateTime asOf, CancellationToken _ = default) => _innerService.GetEvents(eventName, eventKey, asOf);
 
-        public Task<IEnumerable<string>> GetRunnableEvents(DateTime asAt) => _innerService.GetRunnableEvents(asAt);
+        public Task<IEnumerable<string>> GetRunnableEvents(DateTime asAt, CancellationToken _ = default) => _innerService.GetRunnableEvents(asAt);
 
-        public Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt) => _innerService.GetRunnableInstances(asAt);
+        public Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt, CancellationToken _ = default) => _innerService.GetRunnableInstances(asAt);
 
-        public Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf) => _innerService.GetSubscriptions(eventName, eventKey, asOf);
+        public Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf, CancellationToken _ = default) => _innerService.GetSubscriptions(eventName, eventKey, asOf);
 
-        public Task<WorkflowInstance> GetWorkflowInstance(string Id) => _innerService.GetWorkflowInstance(Id);
+        public Task<WorkflowInstance> GetWorkflowInstance(string Id, CancellationToken _ = default) => _innerService.GetWorkflowInstance(Id);
 
-        public Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(IEnumerable<string> ids) => _innerService.GetWorkflowInstances(ids);
+        public Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(IEnumerable<string> ids, CancellationToken _ = default) => _innerService.GetWorkflowInstances(ids);
 
         public Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(WorkflowStatus? status, string type, DateTime? createdFrom, DateTime? createdTo, int skip, int take) => _innerService.GetWorkflowInstances(status, type, createdFrom, createdTo, skip, take);
 
-        public Task MarkEventProcessed(string id) => _innerService.MarkEventProcessed(id);
+        public Task MarkEventProcessed(string id, CancellationToken _ = default) => _innerService.MarkEventProcessed(id);
 
-        public Task MarkEventUnprocessed(string id) => _innerService.MarkEventUnprocessed(id);
+        public Task MarkEventUnprocessed(string id, CancellationToken _ = default) => _innerService.MarkEventUnprocessed(id);
 
-        public Task PersistErrors(IEnumerable<ExecutionError> errors) => _innerService.PersistErrors(errors);
+        public Task PersistErrors(IEnumerable<ExecutionError> errors, CancellationToken _ = default) => _innerService.PersistErrors(errors);
 
-        public Task PersistWorkflow(WorkflowInstance workflow) => _innerService.PersistWorkflow(workflow);
+        public Task PersistWorkflow(WorkflowInstance workflow, CancellationToken _ = default) => _innerService.PersistWorkflow(workflow);
 
-        public Task TerminateSubscription(string eventSubscriptionId) => _innerService.TerminateSubscription(eventSubscriptionId);
-        public Task<EventSubscription> GetSubscription(string eventSubscriptionId) => _innerService.GetSubscription(eventSubscriptionId);
+        public Task TerminateSubscription(string eventSubscriptionId, CancellationToken _ = default) => _innerService.TerminateSubscription(eventSubscriptionId);
+        public Task<EventSubscription> GetSubscription(string eventSubscriptionId, CancellationToken _ = default) => _innerService.GetSubscription(eventSubscriptionId);
 
-        public Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf) => _innerService.GetFirstOpenSubscription(eventName, eventKey, asOf);
+        public Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf, CancellationToken _ = default) => _innerService.GetFirstOpenSubscription(eventName, eventKey, asOf);
 
-        public Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry) => _innerService.SetSubscriptionToken(eventSubscriptionId, token, workerId, expiry);
+        public Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken _ = default) => _innerService.SetSubscriptionToken(eventSubscriptionId, token, workerId, expiry);
 
-        public Task ClearSubscriptionToken(string eventSubscriptionId, string token) => _innerService.ClearSubscriptionToken(eventSubscriptionId, token);
+        public Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken _ = default) => _innerService.ClearSubscriptionToken(eventSubscriptionId, token);
     }
 }

--- a/src/WorkflowCore/Services/SyncWorkflowRunner.cs
+++ b/src/WorkflowCore/Services/SyncWorkflowRunner.cs
@@ -74,7 +74,7 @@ namespace WorkflowCore.Services
             var id = Guid.NewGuid().ToString();
 
             if (persistSate)
-                id = await _persistenceStore.CreateNewWorkflow(wf);
+                id = await _persistenceStore.CreateNewWorkflow(wf, token);
             else
                 wf.Id = id;
 
@@ -91,7 +91,7 @@ namespace WorkflowCore.Services
                 {
                     await _executor.Execute(wf);
                     if (persistSate)
-                        await _persistenceStore.PersistWorkflow(wf);
+                        await _persistenceStore.PersistWorkflow(wf, token);
                 }
             }
             finally

--- a/src/providers/WorkflowCore.Persistence.RavenDB/Services/RavendbPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.RavenDB/Services/RavendbPersistenceProvider.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
@@ -39,18 +40,18 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 			}
 		}
 
-		public async Task<string> CreateNewWorkflow(WorkflowInstance workflow)
+		public async Task<string> CreateNewWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken = default)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
-				await session.StoreAsync(workflow);
+				await session.StoreAsync(workflow, cancellationToken);
 				var id = workflow.Id;
-				await session.SaveChangesAsync();
+				await session.SaveChangesAsync(cancellationToken);
 				return id;
 			}
 		}
 
-		public async Task PersistWorkflow(WorkflowInstance workflow)
+		public async Task PersistWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken = default)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
@@ -65,11 +66,11 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 				session.Advanced.Patch<WorkflowInstance, DateTime>(workflow.Id, x => x.CreateTime, workflow.CreateTime);
 				session.Advanced.Patch<WorkflowInstance, DateTime?>(workflow.Id, x => x.CompleteTime, workflow.CompleteTime);
 
-				await session.SaveChangesAsync();
+				await session.SaveChangesAsync(cancellationToken);
 			}
 		}
 
-		public async Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt)
+		public async Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt, CancellationToken cancellationToken = default)
 		{
 			var now = asAt.ToUniversalTime().Ticks;
 			using (var session = _database.OpenAsyncSession())
@@ -79,20 +80,20 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 					&& (w.Status == WorkflowStatus.Runnable)
 				).Select(x => x.Id);
 
-				return await l.ToListAsync();
+				return await l.ToListAsync(cancellationToken);
 			}
 		}
 
-		public async Task<WorkflowInstance> GetWorkflowInstance(string Id)
+		public async Task<WorkflowInstance> GetWorkflowInstance(string Id, CancellationToken cancellationToken = default)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
-				var result = await session.Query<WorkflowInstance>().FirstOrDefaultAsync(x => x.Id == Id);
+				var result = await session.Query<WorkflowInstance>().FirstOrDefaultAsync(x => x.Id == Id, cancellationToken);
 				return result;
 			}
 		}
 
-		public async Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(IEnumerable<string> ids)
+		public async Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(IEnumerable<string> ids, CancellationToken cancellationToken = default)
 		{
 			if (ids == null)
 			{
@@ -102,7 +103,7 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 			using (var session = _database.OpenAsyncSession())
 			{
 				var list = session.Query<WorkflowInstance>().Where(x => x.Id.In(ids));
-				return await list.ToListAsync<WorkflowInstance>();
+				return await list.ToListAsync<WorkflowInstance>(cancellationToken);
 			}
 		}
 
@@ -128,18 +129,18 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 			}
 		}
 
-		public async Task<string> CreateEventSubscription(EventSubscription subscription)
+		public async Task<string> CreateEventSubscription(EventSubscription subscription, CancellationToken cancellationToken = default)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
-				await session.StoreAsync(subscription);
+				await session.StoreAsync(subscription, cancellationToken);
 				var id = subscription.Id;
-				await session.SaveChangesAsync();
+				await session.SaveChangesAsync(cancellationToken);
 				return id;
 			}
 		}
 
-		public async Task TerminateSubscription(string eventSubscriptionId)
+		public async Task TerminateSubscription(string eventSubscriptionId, CancellationToken _ = default)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
@@ -148,16 +149,16 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 			}
 		}
 
-		public async Task<EventSubscription> GetSubscription(string eventSubscriptionId)
+		public async Task<EventSubscription> GetSubscription(string eventSubscriptionId, CancellationToken cancellationToken = default)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
 				var result = session.Query<EventSubscription>().Where(x => x.Id == eventSubscriptionId);
-				return await result.FirstOrDefaultAsync();
+				return await result.FirstOrDefaultAsync(cancellationToken);
 			}
 		}
 
-		public async Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf)
+		public async Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken = default)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
@@ -168,11 +169,11 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 					&& x.ExternalToken == null
 				);
 
-				return await q.FirstOrDefaultAsync();
+				return await q.FirstOrDefaultAsync(cancellationToken);
 			}
 		}
 
-		public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry)
+		public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken cancellationToken = default)
 		{
 			try
 			{
@@ -187,7 +188,7 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 				strbuilder.Append($"e.ExternalWorkerId = 'workerId'");
 				strbuilder.Append("}");
 
-				var operation = await _database.Operations.SendAsync(new PatchByQueryOperation(strbuilder.ToString()));
+				var operation = await _database.Operations.SendAsync(new PatchByQueryOperation(strbuilder.ToString()), token: cancellationToken);
 				operation.WaitForCompletion();
 				return true;
 			}
@@ -197,7 +198,7 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 			}
 		}
 
-		public async Task ClearSubscriptionToken(string eventSubscriptionId, string token)
+		public async Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken cancellationToken = default)
 		{
 			try
 			{
@@ -212,7 +213,7 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 				strbuilder.Append($"e.ExternalWorkerId = null");
 				strbuilder.Append("}");
 
-				var operation = await _database.Operations.SendAsync(new PatchByQueryOperation(strbuilder.ToString()));
+				var operation = await _database.Operations.SendAsync(new PatchByQueryOperation(strbuilder.ToString()), token: cancellationToken);
 				operation.WaitForCompletion();
 			}
 			catch (Exception e)
@@ -223,7 +224,7 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 
 		public void EnsureStoreExists() { }
 
-		public async Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf)
+		public async Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken = default)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
@@ -233,31 +234,31 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 					&& x.SubscribeAsOf <= asOf
 				);
 
-				return await q.ToListAsync();
+				return await q.ToListAsync(cancellationToken);
 			}
 		}
 
-		public async Task<string> CreateEvent(Event newEvent)
+		public async Task<string> CreateEvent(Event newEvent, CancellationToken cancellationToken = default)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
-				await session.StoreAsync(newEvent);
+				await session.StoreAsync(newEvent, cancellationToken);
 				var id = newEvent.Id;
-				await session.SaveChangesAsync();
+				await session.SaveChangesAsync(cancellationToken);
 				return id;
 			}
 		}
 
-		public async Task<Event> GetEvent(string id)
+		public async Task<Event> GetEvent(string id, CancellationToken cancellationToken = default)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
 				var result = session.Query<Event>().Where(x => x.Id == id);
-				return await result.FirstAsync();
+				return await result.FirstAsync(cancellationToken);
 			}
 		}
 
-		public async Task<IEnumerable<string>> GetRunnableEvents(DateTime asAt)
+		public async Task<IEnumerable<string>> GetRunnableEvents(DateTime asAt, CancellationToken cancellationToken = default)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
@@ -266,21 +267,21 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 									.Where(x => !x.IsProcessed && x.EventTime < now)
 									.Select(x => x.Id);
 
-				return await result.ToListAsync();
+				return await result.ToListAsync(cancellationToken);
 			}
 		}
 
-		public async Task MarkEventProcessed(string id)
+		public async Task MarkEventProcessed(string id, CancellationToken cancellationToken = default)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
 				session.Advanced.Patch<Event, bool>(id, x => x.IsProcessed, true);
 
-				await session.SaveChangesAsync();
+				await session.SaveChangesAsync(cancellationToken);
 			}
 		}
 
-		public async Task<IEnumerable<string>> GetEvents(string eventName, string eventKey, DateTime asOf)
+		public async Task<IEnumerable<string>> GetEvents(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
@@ -291,25 +292,25 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 									&& x.EventTime >= asOf)
 								.Select(x => x.Id);
 
-				return await q.ToListAsync();
+				return await q.ToListAsync(cancellationToken);
 			}
 		}
 
-		public async Task MarkEventUnprocessed(string id)
+		public async Task MarkEventUnprocessed(string id, CancellationToken cancellationToken = default)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
 				session.Advanced.Patch<Event, bool>(id, x => x.IsProcessed, false);
 
-				await session.SaveChangesAsync();
+				await session.SaveChangesAsync(cancellationToken);
 			}
 		}
 
-		public async Task PersistErrors(IEnumerable<ExecutionError> errors)
+		public async Task PersistErrors(IEnumerable<ExecutionError> errors, CancellationToken cancellationToken = default)
 		{
 			if (errors.Any())
 			{
-				var blk = _database.BulkInsert();
+				var blk = _database.BulkInsert(token: cancellationToken);
 				foreach (var error in errors)
 					await blk.StoreAsync(error);
 

--- a/src/providers/WorkflowCore.Providers.Azure/Services/CosmosDbPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Providers.Azure/Services/CosmosDbPersistenceProvider.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Linq;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
 using WorkflowCore.Providers.Azure.Interface;
@@ -13,7 +14,6 @@ namespace WorkflowCore.Providers.Azure.Services
 {
     public class CosmosDbPersistenceProvider : IPersistenceProvider
     {
-
         public const string WorkflowContainerName = "workflows";
         public const string EventContainerName = "events";
         public const string SubscriptionContainerName = "subscriptions";
@@ -35,7 +35,7 @@ namespace WorkflowCore.Providers.Azure.Services
             _subscriptionContainer = new Lazy<Container>(() => _client.GetDatabase(_dbId).GetContainer(SubscriptionContainerName));
         }
 
-        public async Task ClearSubscriptionToken(string eventSubscriptionId, string token)
+        public async Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken cancellationToken = default)
         {
             var existing = await _subscriptionContainer.Value.ReadItemAsync<PersistedSubscription>(eventSubscriptionId, new PartitionKey(eventSubscriptionId));
             
@@ -45,27 +45,27 @@ namespace WorkflowCore.Providers.Azure.Services
             existing.Resource.ExternalWorkerId = null;
             existing.Resource.ExternalTokenExpiry = null;
 
-            await _subscriptionContainer.Value.ReplaceItemAsync(existing.Resource, eventSubscriptionId);
+            await _subscriptionContainer.Value.ReplaceItemAsync(existing.Resource, eventSubscriptionId, cancellationToken: cancellationToken);
         }
 
-        public async Task<string> CreateEvent(Event newEvent)
+        public async Task<string> CreateEvent(Event newEvent, CancellationToken cancellationToken)
         {
             newEvent.Id = Guid.NewGuid().ToString();
-            var result = await _eventContainer.Value.CreateItemAsync(PersistedEvent.FromInstance(newEvent));
+            var result = await _eventContainer.Value.CreateItemAsync(PersistedEvent.FromInstance(newEvent), cancellationToken: cancellationToken);
             return result.Resource.id;
         }
 
-        public async Task<string> CreateEventSubscription(EventSubscription subscription)
+        public async Task<string> CreateEventSubscription(EventSubscription subscription, CancellationToken cancellationToken)
         {
             subscription.Id = Guid.NewGuid().ToString();
-            var result = await _subscriptionContainer.Value.CreateItemAsync(PersistedSubscription.FromInstance(subscription));
+            var result = await _subscriptionContainer.Value.CreateItemAsync(PersistedSubscription.FromInstance(subscription), cancellationToken: cancellationToken);
             return result.Resource.id;
         }
 
-        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow)
+        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken)
         {
             workflow.Id = Guid.NewGuid().ToString();
-            var result = await _workflowContainer.Value.CreateItemAsync(PersistedWorkflow.FromInstance(workflow));
+            var result = await _workflowContainer.Value.CreateItemAsync(PersistedWorkflow.FromInstance(workflow), cancellationToken: cancellationToken);
             return result.Resource.id;
         }
 
@@ -74,69 +74,120 @@ namespace WorkflowCore.Providers.Azure.Services
             _provisioner.Provision(_dbId).Wait();
         }
 
-        public async Task<Event> GetEvent(string id)
+        public async Task<Event> GetEvent(string id, CancellationToken cancellationToken)
         {
-            var resp = await _eventContainer.Value.ReadItemAsync<PersistedEvent>(id, new PartitionKey(id));
+            var resp = await _eventContainer.Value.ReadItemAsync<PersistedEvent>(id, new PartitionKey(id), cancellationToken: cancellationToken);
             return PersistedEvent.ToInstance(resp.Resource);
         }
 
-        public Task<IEnumerable<string>> GetEvents(string eventName, string eventKey, DateTime asOf)
+        public async Task<IEnumerable<string>> GetEvents(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken)
         {
-            var data = _eventContainer.Value.GetItemLinqQueryable<PersistedEvent>(true)
-                .Where(x => x.EventName == eventName && x.EventKey == eventKey)
-                .Where(x => x.EventTime >= asOf)
-                .Select(x => x.id);
-            
-            return Task.FromResult(data.AsEnumerable());
+            var events = new List<string>();
+            using (FeedIterator<PersistedEvent> feedIterator = _eventContainer.Value.GetItemLinqQueryable<PersistedEvent>()
+                    .Where(x => x.EventName == eventName && x.EventKey == eventKey)
+                    .Where(x => x.EventTime >= asOf)
+                    .ToFeedIterator())
+            {
+                while (feedIterator.HasMoreResults)
+                {
+                    foreach (var item in await feedIterator.ReadNextAsync(cancellationToken))
+                    {
+                        events.Add(item.id);
+                    }
+                }
+            }
+
+            return events;
         }
 
-        public Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf)
+        public async Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken)
         {
-            var data = _subscriptionContainer.Value.GetItemLinqQueryable<PersistedSubscription>(true)
-                .FirstOrDefault(x => x.ExternalToken == null &&  x.EventName == eventName && x.EventKey == eventKey && x.SubscribeAsOf <= asOf);
-            
-            return Task.FromResult(PersistedSubscription.ToInstance(data));
+            EventSubscription eventSubscription = null;
+            using (FeedIterator<PersistedSubscription> feedIterator = _subscriptionContainer.Value.GetItemLinqQueryable<PersistedSubscription>()
+                    .Where(x => x.ExternalToken == null && x.EventName == eventName && x.EventKey == eventKey && x.SubscribeAsOf <= asOf)
+                    .ToFeedIterator())
+            {
+                while (feedIterator.HasMoreResults && eventSubscription == null)
+                {
+                    foreach (var item in await feedIterator.ReadNextAsync(cancellationToken))
+                    {
+                        eventSubscription = PersistedSubscription.ToInstance(item);
+                    }
+                }
+            }
+
+            return eventSubscription;
         }
 
-        public Task<IEnumerable<string>> GetRunnableEvents(DateTime asAt)
+        public async Task<IEnumerable<string>> GetRunnableEvents(DateTime asAt, CancellationToken cancellationToken)
         {
-            var data = _eventContainer.Value.GetItemLinqQueryable<PersistedEvent>(true)
-                .Where(x => !x.IsProcessed)
-                .Where(x => x.EventTime <= asAt.ToUniversalTime())
-                .Select(x => x.id);
-            
-            return Task.FromResult(data.AsEnumerable());
+            var events = new List<string>();
+            using (FeedIterator<PersistedEvent> feedIterator = _eventContainer.Value.GetItemLinqQueryable<PersistedEvent>()
+                    .Where(x => !x.IsProcessed)
+                    .Where(x => x.EventTime <= asAt.ToUniversalTime())
+                    .ToFeedIterator())
+            {
+                while (feedIterator.HasMoreResults)
+                {
+                    foreach (var item in await feedIterator.ReadNextAsync(cancellationToken))
+                    {
+                        events.Add(item.id);
+                    }
+                }
+            }
+
+            return events;
         }
 
-        public Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt)
+        public async Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt, CancellationToken cancellationToken)
         {
             var now = asAt.ToUniversalTime().Ticks;
 
-            var data = _workflowContainer.Value.GetItemLinqQueryable<PersistedWorkflow>(true)
-                .Where(x => x.NextExecution.HasValue && (x.NextExecution <= now) && (x.Status == WorkflowStatus.Runnable))
-                .Select(x => x.id);
+            var instances = new List<string>();
+            using (FeedIterator<PersistedWorkflow> feedIterator = _workflowContainer.Value.GetItemLinqQueryable<PersistedWorkflow>()
+                    .Where(x => x.NextExecution.HasValue && (x.NextExecution <= now) && (x.Status == WorkflowStatus.Runnable))
+                    .ToFeedIterator())
+            {
+                while (feedIterator.HasMoreResults)
+                {
+                    foreach (var item in await feedIterator.ReadNextAsync(cancellationToken))
+                    {
+                        instances.Add(item.id);
+                    }
+                }
+            }
 
-            return Task.FromResult(data.AsEnumerable());
+            return instances;
         }
 
-        public async Task<EventSubscription> GetSubscription(string eventSubscriptionId)
+        public async Task<EventSubscription> GetSubscription(string eventSubscriptionId, CancellationToken cancellationToken)
         {
-            var resp = await _subscriptionContainer.Value.ReadItemAsync<PersistedSubscription>(eventSubscriptionId, new PartitionKey(eventSubscriptionId));
+            var resp = await _subscriptionContainer.Value.ReadItemAsync<PersistedSubscription>(eventSubscriptionId, new PartitionKey(eventSubscriptionId), cancellationToken: cancellationToken);
             return PersistedSubscription.ToInstance(resp.Resource);
         }
 
-        public Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf)
+        public async Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken)
         {
-            var data = _subscriptionContainer.Value.GetItemLinqQueryable<PersistedSubscription>(true)
+            var subscriptions = new List<EventSubscription>();
+            using (FeedIterator<PersistedSubscription> feedIterator = _subscriptionContainer.Value.GetItemLinqQueryable<PersistedSubscription>()
                 .Where(x => x.EventName == eventName && x.EventKey == eventKey && x.SubscribeAsOf <= asOf)
-                .ToList()
-                .Select(x => PersistedSubscription.ToInstance(x));
-            return Task.FromResult(data.AsEnumerable());
+                    .ToFeedIterator())
+            {
+                while (feedIterator.HasMoreResults)
+                {
+                    foreach (var item in await feedIterator.ReadNextAsync(cancellationToken))
+                    {
+                        subscriptions.Add(PersistedSubscription.ToInstance(item));
+                    }
+                }
+            }
+
+            return subscriptions;
         }
 
-        public async Task<WorkflowInstance> GetWorkflowInstance(string Id)
+        public async Task<WorkflowInstance> GetWorkflowInstance(string Id, CancellationToken cancellationToken)
         {
-            var result = await _workflowContainer.Value.ReadItemAsync<PersistedWorkflow>(Id, new PartitionKey(Id));
+            var result = await _workflowContainer.Value.ReadItemAsync<PersistedWorkflow>(Id, new PartitionKey(Id), cancellationToken: cancellationToken);
             return PersistedWorkflow.ToInstance(result.Resource);
         }
 
@@ -145,51 +196,51 @@ namespace WorkflowCore.Providers.Azure.Services
             throw new NotImplementedException();
         }
 
-        public Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(IEnumerable<string> ids)
+        public Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(IEnumerable<string> ids, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
-        public async Task MarkEventProcessed(string id)
+        public async Task MarkEventProcessed(string id, CancellationToken cancellationToken)
         {
-            var evt = await _eventContainer.Value.ReadItemAsync<PersistedEvent>(id, new PartitionKey(id));
+            var evt = await _eventContainer.Value.ReadItemAsync<PersistedEvent>(id, new PartitionKey(id), cancellationToken: cancellationToken);
             evt.Resource.IsProcessed = true;
-            await _eventContainer.Value.ReplaceItemAsync(evt.Resource, id);
+            await _eventContainer.Value.ReplaceItemAsync(evt.Resource, id, cancellationToken: cancellationToken);
         }
 
-        public async Task MarkEventUnprocessed(string id)
+        public async Task MarkEventUnprocessed(string id, CancellationToken cancellationToken)
         {
-            var evt = await _eventContainer.Value.ReadItemAsync<PersistedEvent>(id, new PartitionKey(id));
+            var evt = await _eventContainer.Value.ReadItemAsync<PersistedEvent>(id, new PartitionKey(id), cancellationToken: cancellationToken);
             evt.Resource.IsProcessed = false;
-            await _eventContainer.Value.ReplaceItemAsync(evt.Resource, id);
+            await _eventContainer.Value.ReplaceItemAsync(evt.Resource, id, cancellationToken: cancellationToken);
         }
 
-        public Task PersistErrors(IEnumerable<ExecutionError> errors)
+        public Task PersistErrors(IEnumerable<ExecutionError> errors, CancellationToken _ = default)
         {
             return Task.CompletedTask;
         }
 
-        public async Task PersistWorkflow(WorkflowInstance workflow)
+        public async Task PersistWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken)
         {
-            await _workflowContainer.Value.UpsertItemAsync(PersistedWorkflow.FromInstance(workflow));
+            await _workflowContainer.Value.UpsertItemAsync(PersistedWorkflow.FromInstance(workflow), cancellationToken: cancellationToken);
         }
 
-        public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry)
+        public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken cancellationToken)
         {
-            var sub = await _subscriptionContainer.Value.ReadItemAsync<PersistedSubscription>(eventSubscriptionId, new PartitionKey(eventSubscriptionId));
+            var sub = await _subscriptionContainer.Value.ReadItemAsync<PersistedSubscription>(eventSubscriptionId, new PartitionKey(eventSubscriptionId), cancellationToken: cancellationToken);
             var existingEntity = sub.Resource;
             existingEntity.ExternalToken = token;
             existingEntity.ExternalWorkerId = workerId;
             existingEntity.ExternalTokenExpiry = expiry;
             
-            await _subscriptionContainer.Value.ReplaceItemAsync(existingEntity, eventSubscriptionId);
+            await _subscriptionContainer.Value.ReplaceItemAsync(existingEntity, eventSubscriptionId, cancellationToken: cancellationToken);
 
             return true;
         }
 
-        public async Task TerminateSubscription(string eventSubscriptionId)
+        public async Task TerminateSubscription(string eventSubscriptionId, CancellationToken cancellationToken)
         {
-            await _subscriptionContainer.Value.DeleteItemAsync<PersistedSubscription>(eventSubscriptionId, new PartitionKey(eventSubscriptionId));
+            await _subscriptionContainer.Value.DeleteItemAsync<PersistedSubscription>(eventSubscriptionId, new PartitionKey(eventSubscriptionId), cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/providers/WorkflowCore.Providers.Redis/Services/RedisPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Providers.Redis/Services/RedisPersistenceProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -37,14 +38,14 @@ namespace WorkflowCore.Providers.Redis.Services
             _removeComplete = removeComplete;
         }
 
-        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow)
+        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow, CancellationToken _ = default)
         {
             workflow.Id = Guid.NewGuid().ToString();
             await PersistWorkflow(workflow);
             return workflow.Id;
         }
 
-        public async Task PersistWorkflow(WorkflowInstance workflow)
+        public async Task PersistWorkflow(WorkflowInstance workflow, CancellationToken _ = default)
         {
             var str = JsonConvert.SerializeObject(workflow, _serializerSettings);
             await _redis.HashSetAsync($"{_prefix}.{WORKFLOW_SET}", workflow.Id, str);
@@ -59,7 +60,7 @@ namespace WorkflowCore.Providers.Redis.Services
             }
         }
 
-        public async Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt)
+        public async Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt, CancellationToken _ = default)
         {
             var result = new List<string>();
             var data = await _redis.SortedSetRangeByScoreAsync($"{_prefix}.{WORKFLOW_SET}.{RUNNABLE_INDEX}", -1, asAt.ToUniversalTime().Ticks);
@@ -76,13 +77,13 @@ namespace WorkflowCore.Providers.Redis.Services
             throw new NotImplementedException();
         }
 
-        public async Task<WorkflowInstance> GetWorkflowInstance(string Id)
+        public async Task<WorkflowInstance> GetWorkflowInstance(string Id, CancellationToken _ = default)
         {
             var raw = await _redis.HashGetAsync($"{_prefix}.{WORKFLOW_SET}", Id);
             return JsonConvert.DeserializeObject<WorkflowInstance>(raw, _serializerSettings);
         }
 
-        public async Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(IEnumerable<string> ids)
+        public async Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(IEnumerable<string> ids, CancellationToken _ = default)
         {
             if (ids == null)
             {
@@ -93,7 +94,7 @@ namespace WorkflowCore.Providers.Redis.Services
             return raw.Select(r => JsonConvert.DeserializeObject<WorkflowInstance>(r, _serializerSettings));
         }
 
-        public async Task<string> CreateEventSubscription(EventSubscription subscription)
+        public async Task<string> CreateEventSubscription(EventSubscription subscription, CancellationToken _ = default)
         {
             subscription.Id = Guid.NewGuid().ToString();
             var str = JsonConvert.SerializeObject(subscription, _serializerSettings);
@@ -103,7 +104,7 @@ namespace WorkflowCore.Providers.Redis.Services
             return subscription.Id;
         }
 
-        public async Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf)
+        public async Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf, CancellationToken _ = default)
         {
             var result = new List<EventSubscription>();
             var data = await _redis.SortedSetRangeByScoreAsync($"{_prefix}.{SUBSCRIPTION_SET}.{EVENTSLUG_INDEX}.{eventName}-{eventKey}", -1, asOf.Ticks);
@@ -118,7 +119,7 @@ namespace WorkflowCore.Providers.Redis.Services
             return result;
         }
 
-        public async Task TerminateSubscription(string eventSubscriptionId)
+        public async Task TerminateSubscription(string eventSubscriptionId, CancellationToken _ = default)
         {
             var existingRaw = await _redis.HashGetAsync($"{_prefix}.{SUBSCRIPTION_SET}", eventSubscriptionId);
             var existing = JsonConvert.DeserializeObject<EventSubscription>(existingRaw, _serializerSettings);
@@ -126,18 +127,18 @@ namespace WorkflowCore.Providers.Redis.Services
             await _redis.SortedSetRemoveAsync($"{_prefix}.{SUBSCRIPTION_SET}.{EVENTSLUG_INDEX}.{existing.EventName}-{existing.EventKey}", eventSubscriptionId);
         }
 
-        public async Task<EventSubscription> GetSubscription(string eventSubscriptionId)
+        public async Task<EventSubscription> GetSubscription(string eventSubscriptionId, CancellationToken _ = default)
         {
             var raw = await _redis.HashGetAsync($"{_prefix}.{SUBSCRIPTION_SET}", eventSubscriptionId);
             return JsonConvert.DeserializeObject<EventSubscription>(raw, _serializerSettings);
         }
 
-        public async Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf)
+        public async Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken = default)
         {
-            return (await GetSubscriptions(eventName, eventKey, asOf)).FirstOrDefault(sub => string.IsNullOrEmpty(sub.ExternalToken));
+            return (await GetSubscriptions(eventName, eventKey, asOf, cancellationToken)).FirstOrDefault(sub => string.IsNullOrEmpty(sub.ExternalToken));
         }
 
-        public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry)
+        public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken _ = default)
         {
             var item = JsonConvert.DeserializeObject<EventSubscription>(await _redis.HashGetAsync($"{_prefix}.{SUBSCRIPTION_SET}", eventSubscriptionId), _serializerSettings);
             if (item.ExternalToken != null)
@@ -150,7 +151,7 @@ namespace WorkflowCore.Providers.Redis.Services
             return true;
         }
 
-        public async Task ClearSubscriptionToken(string eventSubscriptionId, string token)
+        public async Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken _ = default)
         {
             var item = JsonConvert.DeserializeObject<EventSubscription>(await _redis.HashGetAsync($"{_prefix}.{SUBSCRIPTION_SET}", eventSubscriptionId), _serializerSettings);
             if (item.ExternalToken != token)
@@ -162,7 +163,7 @@ namespace WorkflowCore.Providers.Redis.Services
             await _redis.HashSetAsync($"{_prefix}.{SUBSCRIPTION_SET}", eventSubscriptionId, str);
         }
 
-        public async Task<string> CreateEvent(Event newEvent)
+        public async Task<string> CreateEvent(Event newEvent, CancellationToken _ = default)
         {
             newEvent.Id = Guid.NewGuid().ToString();
             var str = JsonConvert.SerializeObject(newEvent, _serializerSettings);
@@ -177,13 +178,13 @@ namespace WorkflowCore.Providers.Redis.Services
             return newEvent.Id;
         }
 
-        public async Task<Event> GetEvent(string id)
+        public async Task<Event> GetEvent(string id, CancellationToken _ = default)
         {
             var raw = await _redis.HashGetAsync($"{_prefix}.{EVENT_SET}", id);
             return JsonConvert.DeserializeObject<Event>(raw, _serializerSettings);
         }
 
-        public async Task<IEnumerable<string>> GetRunnableEvents(DateTime asAt)
+        public async Task<IEnumerable<string>> GetRunnableEvents(DateTime asAt, CancellationToken _ = default)
         {
             var result = new List<string>();
             var data = await _redis.SortedSetRangeByScoreAsync($"{_prefix}.{EVENT_SET}.{RUNNABLE_INDEX}", -1, asAt.Ticks);
@@ -194,7 +195,7 @@ namespace WorkflowCore.Providers.Redis.Services
             return result;
         }
 
-        public async Task<IEnumerable<string>> GetEvents(string eventName, string eventKey, DateTime asOf)
+        public async Task<IEnumerable<string>> GetEvents(string eventName, string eventKey, DateTime asOf, CancellationToken _ = default)
         {
             var result = new List<string>();
             var data = await _redis.SortedSetRangeByScoreAsync($"{_prefix}.{EVENT_SET}.{EVENTSLUG_INDEX}.{eventName}-{eventKey}", asOf.Ticks);
@@ -205,25 +206,25 @@ namespace WorkflowCore.Providers.Redis.Services
             return result;
         }
 
-        public async Task MarkEventProcessed(string id)
+        public async Task MarkEventProcessed(string id, CancellationToken cancellationToken = default)
         {
-            var evt = await GetEvent(id);
+            var evt = await GetEvent(id, cancellationToken);
             evt.IsProcessed = true;
             var str = JsonConvert.SerializeObject(evt, _serializerSettings);
             await _redis.HashSetAsync($"{_prefix}.{EVENT_SET}", evt.Id, str);
             await _redis.SortedSetRemoveAsync($"{_prefix}.{EVENT_SET}.{RUNNABLE_INDEX}", id);
         }
 
-        public async Task MarkEventUnprocessed(string id)
+        public async Task MarkEventUnprocessed(string id, CancellationToken cancellationToken = default)
         {
-            var evt = await GetEvent(id);
+            var evt = await GetEvent(id, cancellationToken);
             evt.IsProcessed = false;
             var str = JsonConvert.SerializeObject(evt, _serializerSettings);
             await _redis.HashSetAsync($"{_prefix}.{EVENT_SET}", evt.Id, str);
             await _redis.SortedSetAddAsync($"{_prefix}.{EVENT_SET}.{RUNNABLE_INDEX}", evt.Id, evt.EventTime.Ticks);
         }
 
-        public Task PersistErrors(IEnumerable<ExecutionError> errors)
+        public Task PersistErrors(IEnumerable<ExecutionError> errors, CancellationToken _ = default)
         {
             return Task.CompletedTask;
         }


### PR DESCRIPTION
**Describe the change**
CancellationToken +
Change CosmosDB methods to be more async: https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.container.getitemlinqqueryable?view=azure-dotnet#examples

**Describe your implementation or design**
IPersistenceProvider may be used not only in WorkflowCore itself, but maybe injected to custom services with CancellationToken.

**Tests**
There are already tests.

**Breaking change**
It shouldn't be breaking changes as CancellationToken = default is optional.

@danielgerlag could you please share your thoughts ?
