### PR TITLE
Add a new lock provider using MySql GET_LOCK and RELEASE_LOCK

### DIFF
--- a/WorkflowCore.sln
+++ b/WorkflowCore.sln
@@ -150,7 +150,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Tests.QueuePro
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Sample19", "src\samples\WorkflowCore.Sample19\WorkflowCore.Sample19.csproj", "{1223ED47-3E5E-4960-B70D-DFAF550F6666}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkflowCore.Persistence.RavenDB", "src\providers\WorkflowCore.Persistence.RavenDB\WorkflowCore.Persistence.RavenDB.csproj", "{AF205715-C8B7-42EF-BF14-AFC9E7F27242}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.Persistence.RavenDB", "src\providers\WorkflowCore.Persistence.RavenDB\WorkflowCore.Persistence.RavenDB.csproj", "{AF205715-C8B7-42EF-BF14-AFC9E7F27242}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowCore.LockProviders.MySQL", "src\providers\WorkflowCore.LockProviders.MySQL\WorkflowCore.LockProviders.MySQL.csproj", "{18A45CAD-38CD-40DC-801D-6D6F23EBCBE2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -374,6 +376,10 @@ Global
 		{AF205715-C8B7-42EF-BF14-AFC9E7F27242}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AF205715-C8B7-42EF-BF14-AFC9E7F27242}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AF205715-C8B7-42EF-BF14-AFC9E7F27242}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18A45CAD-38CD-40DC-801D-6D6F23EBCBE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18A45CAD-38CD-40DC-801D-6D6F23EBCBE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18A45CAD-38CD-40DC-801D-6D6F23EBCBE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18A45CAD-38CD-40DC-801D-6D6F23EBCBE2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -436,6 +442,7 @@ Global
 		{54DE20BA-EBA7-4BF0-9BD9-F03766849716} = {E6CEAD8D-F565-471E-A0DC-676F54EAEDEB}
 		{1223ED47-3E5E-4960-B70D-DFAF550F6666} = {5080DB09-CBE8-4C45-9957-C3BB7651755E}
 		{AF205715-C8B7-42EF-BF14-AFC9E7F27242} = {2EEE6ABD-EE9B-473F-AF2D-6DABB85D7BA2}
+		{18A45CAD-38CD-40DC-801D-6D6F23EBCBE2} = {2EEE6ABD-EE9B-473F-AF2D-6DABB85D7BA2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DC0FA8D3-6449-4FDA-BB46-ECF58FAD23B4}

--- a/src/providers/WorkflowCore.LockProviders.MySQL/MySqlLockProvider.cs
+++ b/src/providers/WorkflowCore.LockProviders.MySQL/MySqlLockProvider.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using WorkflowCore.Interface;
+using System.Data;
+using System.Collections.Generic;
+using System.Threading;
+using MySql.Data.MySqlClient;
+
+namespace WorkflowCore.LockProviders.MySQL
+{
+    public class MySqlLockProvider : IDistributedLockProvider
+    {
+        private const string Prefix = "wfc";
+
+        private readonly string _connectionString;
+        private readonly ILogger _logger;
+        private readonly Dictionary<string, MySqlConnection> _locks = new Dictionary<string, MySqlConnection>();
+        private readonly AutoResetEvent _mutex = new AutoResetEvent(true);
+
+        public MySqlLockProvider(string connectionString, ILoggerFactory logFactory)
+        {
+            _logger = logFactory.CreateLogger<MySqlLockProvider>();
+            var csb = new MySqlConnectionStringBuilder(connectionString);
+            csb.Pooling = true;
+            _connectionString = csb.ToString();
+        }
+
+
+        public async Task<bool> AcquireLock(string Id, CancellationToken cancellationToken)
+        {
+            if (_mutex.WaitOne())
+            {
+                try
+                {
+                    var connection = new MySqlConnection(_connectionString);
+                    await connection.OpenAsync(cancellationToken);
+                    try
+                    {
+                        var cmd = connection.CreateCommand();
+                        cmd.CommandText = $"SELECT GET_LOCK('{Prefix}:{Id}', 10)";                                                
+                        
+                        var returnValue = await cmd.ExecuteScalarAsync(cancellationToken);
+
+                        if (returnValue == null)
+                        {
+                            _logger.LogError($"Acquire lock provider error for {Id}");
+                            return false;
+                        }
+
+                        var result = Convert.ToInt32(returnValue);                        
+                        if (result > 0)
+                        {
+                            _logger.LogDebug($"Acquired lock for {Id}");
+                            _locks[Id] = connection;
+                            return true;
+                        }
+                        else
+                        {
+                            _logger.LogError($"The acquire lock request timed out for {Id}");
+                            connection.Close();
+                            return false;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        connection.Close();
+                        throw ex;
+                    }
+                }
+                finally
+                {
+                    _mutex.Set();
+                }
+            }
+            return false;
+        }
+
+        public async Task ReleaseLock(string Id)
+        {
+            if (_mutex.WaitOne())
+            {
+                try
+                {
+                    MySqlConnection connection = null;
+
+                    if (_locks.ContainsKey(Id))
+                        connection = _locks[Id];
+                                        
+                    if (connection == null)
+                    {
+                        _logger.LogError($"Release lock connection not found for {Id}");
+                        return;
+                    }
+
+                    try
+                    {
+                        var cmd = connection.CreateCommand();
+                        cmd.CommandText = $"SELECT RELEASE_LOCK('{Prefix}:{Id}')";
+                        cmd.CommandType = CommandType.Text;                        
+
+                        var returnValue = await cmd.ExecuteScalarAsync();
+                        if (returnValue == null)
+                        {
+                            _logger.LogError($"Release lock provider error for {Id}");                            
+                        }
+
+                        var result = Convert.ToInt32(returnValue);
+
+                        if (result > 0)
+                        {
+                            _logger.LogDebug($"Released lock for {Id}");
+                        }
+                        else
+                        {
+                            _logger.LogError($"Release lock returned 0 for {Id}");
+                            
+                        }                        
+                    }
+                    finally
+                    {
+                        connection.Close();
+                        _locks.Remove(Id);
+                    }
+                }
+                finally
+                {
+                    _mutex.Set();
+                }
+            }
+        }
+
+        public Task Start() => Task.CompletedTask;
+        
+        public Task Stop() => Task.CompletedTask;
+        
+    }
+}

--- a/src/providers/WorkflowCore.LockProviders.MySQL/README.md
+++ b/src/providers/WorkflowCore.LockProviders.MySQL/README.md
@@ -1,0 +1,20 @@
+# MySQL DLM provider for Workflow Core
+
+Provides [DLM](https://en.wikipedia.org/wiki/Distributed_lock_manager) support  on [Workflow Core](../../README.md) using MySQL's GET_LOCK and RELEASE_LOCK.
+
+This makes it possible to have a cluster of nodes processing your workflows, along with a queue provider.
+
+## Installing
+
+Install the NuGet package "WorkflowCore.LockProviders.MySQL"
+
+```
+PM> Install-Package WorkflowCore.LockProviders.MySQL
+```
+
+## Usage
+
+Use the .UseMySqlLocking extension method when building your service provider.
+
+```C#
+services.AddWorkflow(x => x.UseMySqlLocking("connection string"));

--- a/src/providers/WorkflowCore.LockProviders.MySQL/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.LockProviders.MySQL/ServiceCollectionExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using WorkflowCore.LockProviders.MySQL;
+using WorkflowCore.Models;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static WorkflowOptions UseMySqlLocking(this WorkflowOptions options, string connectionString)
+        {
+            options.UseDistributedLockManager(sp => new MySqlLockProvider(connectionString, sp.GetService<ILoggerFactory>()));
+            return options;
+        }
+    }
+}

--- a/src/providers/WorkflowCore.LockProviders.MySQL/WorkflowCore.LockProviders.MySQL.csproj
+++ b/src/providers/WorkflowCore.LockProviders.MySQL/WorkflowCore.LockProviders.MySQL.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Description>Distributed lock provider for Workflow-core using MySQL</Description>
+    <PackageProjectUrl>https://github.com/danielgerlag/workflow-core</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/danielgerlag/workflow-core/blob/master/LICENSE.md</PackageLicenseUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MySql.Data" Version="8.0.25" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\WorkflowCore\WorkflowCore.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
A new provider to allow distributed locking using MySql as the provider. It uses the GET_LOCK / RELEASE_LOCK functionality provided by MySql to acquire / release a lock. The code structure follows a similar structure like the lock provider for Sql Server