### PR TITLE
Use lock on event subscription

### DIFF
--- a/src/WorkflowCore/Services/BackgroundTasks/RunnablePoller.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/RunnablePoller.cs
@@ -93,7 +93,6 @@ namespace WorkflowCore.Services.BackgroundTasks
                             if (_greylist.Contains($"evt:{item}"))
                             {
                                 _logger.LogDebug($"Got greylisted event {item}");
-                                _greylist.Add($"evt:{item}");
                                 continue;
                             }
                             _logger.LogDebug($"Got unprocessed event {item}");

--- a/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
@@ -35,10 +35,10 @@ namespace WorkflowCore.Services.BackgroundTasks
                 Logger.LogInformation("Workflow locked {0}", itemId);
                 return;
             }
-            
+
             WorkflowInstance workflow = null;
             WorkflowExecutorResult result = null;
-            
+
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -77,9 +77,9 @@ namespace WorkflowCore.Services.BackgroundTasks
                     }
                 }
             }
-            
+
         }
-        
+
         private async Task SubscribeEvent(EventSubscription subscription, IPersistenceProvider persistenceStore, CancellationToken cancellationToken)
         {
             //TODO: move to own class
@@ -100,8 +100,8 @@ namespace WorkflowCore.Services.BackgroundTasks
                         int attempt = 0;
                         while (!acquiredLock && attempt < 10)
                         {
-                            acquiredLock = await _lockProvider.AcquireLock(eventKey, cancellationToken);
                             await Task.Delay(Options.IdleTime, cancellationToken);
+                            acquiredLock = await _lockProvider.AcquireLock(eventKey, cancellationToken);
 
                             attempt++;
                         }
@@ -112,9 +112,9 @@ namespace WorkflowCore.Services.BackgroundTasks
                         }
                         else
                         {
+                            _greylist.Remove(eventKey);
                             await persistenceStore.MarkEventUnprocessed(evt, cancellationToken);
                             await QueueProvider.QueueWork(evt, QueueType.Event);
-                            _greylist.Remove(eventKey);
                         }
                     }
                     finally

--- a/test/WorkflowCore.IntegrationTests/Scenarios/ParallelEventsScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/ParallelEventsScenario.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using Xunit;
+using FluentAssertions;
+using WorkflowCore.Testing;
+using System.Threading;
+
+namespace WorkflowCore.IntegrationTests.Scenarios
+{
+    public sealed class ParallelEventsScenario
+        : WorkflowTest<ParallelEventsScenario.ParallelEventsWorkflow, ParallelEventsScenario.MyDataClass>
+    {
+        private const string EVENT_KEY = nameof(EVENT_KEY);
+
+        public class MyDataClass
+        {
+            public string StrValue1 { get; set; }
+            public string StrValue2 { get; set; }
+        }
+
+        public class ParallelEventsWorkflow : IWorkflow<MyDataClass>
+        {
+            public string Id => "EventWorkflow";
+            public int Version => 1;
+            public void Build(IWorkflowBuilder<MyDataClass> builder)
+            {
+                builder
+                    .StartWith(context => ExecutionResult.Next())
+                    .Parallel()
+                    .Do(then =>
+                        then.WaitFor("Event1", data => EVENT_KEY).Then(x =>
+                        {
+                            Thread.Sleep(300);
+                            return ExecutionResult.Next();
+                        }))
+                    .Do(then =>
+                        then.WaitFor("Event2", data => EVENT_KEY).Then(x =>
+                        {
+                            Thread.Sleep(100);
+                            return ExecutionResult.Next();
+                        }))
+                   .Do(then =>
+                        then.WaitFor("Event3", data => EVENT_KEY).Then(x =>
+                        {
+                            Thread.Sleep(1000);
+                            return ExecutionResult.Next();
+                        }))
+                   .Do(then =>
+                        then.WaitFor("Event4", data => EVENT_KEY).Then(x =>
+                        {
+                            Thread.Sleep(100);
+                            return ExecutionResult.Next();
+                        }))
+                   .Do(then =>
+                        then.WaitFor("Event5", data => EVENT_KEY).Then(x =>
+                        {
+                            Thread.Sleep(100);
+                            return ExecutionResult.Next();
+                        }))
+                .Join()
+                .Then(x =>
+                {
+                    return ExecutionResult.Next();
+                });
+            }
+        }
+
+        public ParallelEventsScenario()
+        {
+            Setup();
+        }
+
+        [Fact]
+        public void Scenario()
+        {
+            var eventKey = Guid.NewGuid().ToString();
+            var workflowId = StartWorkflow(new MyDataClass { StrValue1 = eventKey, StrValue2 = eventKey });
+            Host.PublishEvent("Event1", EVENT_KEY, "Pass1");
+            Host.PublishEvent("Event2", EVENT_KEY, "Pass2");
+            Host.PublishEvent("Event3", EVENT_KEY, "Pass3");
+            Host.PublishEvent("Event4", EVENT_KEY, "Pass4");
+            Host.PublishEvent("Event5", EVENT_KEY, "Pass5");
+
+            WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(30));
+
+            GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
+            UnhandledStepErrors.Count.Should().Be(0);
+        }
+    }
+}


### PR DESCRIPTION
Maybe related to https://github.com/danielgerlag/workflow-core/pull/782

Hi @danielgerlag ,

Let me share some scenario:
Input: Workflow with multiple Parallel steps and in each of it WaitFor tasks.
At some point we are facing next situation:

1. In custom step we are sending some work to process (in our case it is a queue).
2. After that we are adding WaitFor to subscribe on event (and it is working well). Job is returned back even if we didn't subscribe yet for it with WaitFor.
This case if handled in:
But Event is not locked here : https://github.com/danielgerlag/workflow-core/blob/master/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs#L94

3. After subscription we are reseting event back to unprocessed state. Which is ok.
4. Poller on line: https://github.com/danielgerlag/workflow-core/blob/master/src/WorkflowCore/Services/BackgroundTasks/RunnablePoller.cs#L90 . Will pickup this event because it is unprocessed.
5. But workflow can still be locked, because one of the parallel steps are doing their job. Event Consumer again won't process event and Poller will put Event to greylisted list till forever for one instance.
https://github.com/danielgerlag/workflow-core/blob/master/src/WorkflowCore/Services/BackgroundTasks/RunnablePoller.cs#L96

(will be in greylist forever)