### PR TITLE
Allow mongo client configuration

### DIFF
--- a/src/providers/WorkflowCore.Persistence.MongoDB/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/ServiceCollectionExtensions.cs
@@ -9,17 +9,25 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ServiceCollectionExtensions
     {
-        public static WorkflowOptions UseMongoDB(this WorkflowOptions options, string mongoUrl, string databaseName)
+        public static WorkflowOptions UseMongoDB(
+            this WorkflowOptions options, 
+            string mongoUrl, 
+            string databaseName, 
+            Action<MongoClientSettings> configureClient = default)
         {
             options.UsePersistence(sp =>
             {
-                var client = new MongoClient(mongoUrl);
+                var mongoClientSettings = MongoClientSettings.FromConnectionString(mongoUrl);
+                configureClient?.Invoke(mongoClientSettings);
+                var client = new MongoClient(mongoClientSettings);
                 var db = client.GetDatabase(databaseName);
                 return new MongoPersistenceProvider(db);
             });
             options.Services.AddTransient<IWorkflowPurger>(sp =>
             {
-                var client = new MongoClient(mongoUrl);
+                var mongoClientSettings = MongoClientSettings.FromConnectionString(mongoUrl);
+                configureClient?.Invoke(mongoClientSettings);
+                var client = new MongoClient(mongoClientSettings);
                 var db = client.GetDatabase(databaseName);
                 return new WorkflowPurger(db);
             });


### PR DESCRIPTION
This change will allow configuring mongo client, e.g. like subscribing to events for diagnostics.

```csharp
services
   .AddWorkflow(o => o.UseMongoDB(dbOptions.ConnectionString, dbOptions.DatabaseName, s =>
   {
       s.ClusterConfigurator = builder => builder.Subscribe(new MongoDbEventSubscriber());
   }));
```