### PR TITLE
Overload GetPendingActivity with workflowId parameter. Solves #542 issue.

### DIFF
--- a/src/WorkflowCore/Interface/IActivityController.cs
+++ b/src/WorkflowCore/Interface/IActivityController.cs
@@ -15,6 +15,7 @@ namespace WorkflowCore.Interface
     public interface IActivityController
     {
         Task<PendingActivity> GetPendingActivity(string activityName, string workerId, TimeSpan? timeout = null);
+        Task<PendingActivity> GetPendingActivity(string activityName, string workflowId, string workerId, TimeSpan? timeout = null);
         Task ReleaseActivityToken(string token);
         Task SubmitActivitySuccess(string token, object result);
         Task SubmitActivityFailure(string token, object result);

--- a/src/WorkflowCore/Interface/Persistence/ISubscriptionRepository.cs
+++ b/src/WorkflowCore/Interface/Persistence/ISubscriptionRepository.cs
@@ -17,7 +17,9 @@ namespace WorkflowCore.Interface
         Task<EventSubscription> GetSubscription(string eventSubscriptionId, CancellationToken cancellationToken = default);
 
         Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken = default);
-        
+
+        Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, string workflowId, DateTime asOf, CancellationToken cancellationToken = default);
+
         Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken cancellationToken = default);
         
         Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken cancellationToken = default);

--- a/src/WorkflowCore/Services/DefaultProviders/MemoryPersistenceProvider.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/MemoryPersistenceProvider.cs
@@ -152,6 +152,16 @@ namespace WorkflowCore.Services
             }
         }
 
+        public Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, string workflowId, DateTime asOf, CancellationToken _ = default)
+        {
+            lock (_subscriptions)
+            {
+                var result = _subscriptions
+                    .FirstOrDefault(x => x.ExternalToken == null && x.EventName == eventName && x.EventKey == eventKey && x.WorkflowId == workflowId && x.SubscribeAsOf <= asOf);
+                return Task.FromResult(result);
+            }
+        }
+
         public Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken _ = default)
         {
             lock (_subscriptions)

--- a/src/WorkflowCore/Services/DefaultProviders/TransientMemoryPersistenceProvider.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/TransientMemoryPersistenceProvider.cs
@@ -53,6 +53,8 @@ namespace WorkflowCore.Services
 
         public Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf, CancellationToken _ = default) => _innerService.GetFirstOpenSubscription(eventName, eventKey, asOf);
 
+        public Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, string workflowId, DateTime asOf, CancellationToken _ = default) => _innerService.GetFirstOpenSubscription(eventName, eventKey, workflowId, asOf);
+
         public Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken _ = default) => _innerService.SetSubscriptionToken(eventSubscriptionId, token, workerId, expiry);
 
         public Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken _ = default) => _innerService.ClearSubscriptionToken(eventSubscriptionId, token);

--- a/src/WorkflowCore/Services/WorkflowHost.cs
+++ b/src/WorkflowCore/Services/WorkflowHost.cs
@@ -170,6 +170,11 @@ namespace WorkflowCore.Services
             return _activityController.GetPendingActivity(activityName, workerId, timeout);
         }
 
+        public Task<PendingActivity> GetPendingActivity(string activityName, string workflowId, string workerId, TimeSpan? timeout = null)
+        {
+            return _activityController.GetPendingActivity(activityName, workflowId, workerId, timeout);
+        }
+
         public Task ReleaseActivityToken(string token)
         {
             return _activityController.ReleaseActivityToken(token);

--- a/src/providers/WorkflowCore.Persistence.EntityFramework/Services/EntityFrameworkPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.EntityFramework/Services/EntityFrameworkPersistenceProvider.cs
@@ -327,6 +327,16 @@ namespace WorkflowCore.Persistence.EntityFramework.Services
             }
         }
 
+        public async Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, string workflowId, DateTime asOf, CancellationToken cancellationToken = default)
+        {
+            using (var db = ConstructDbContext())
+            {
+                var raw = await db.Set<PersistedSubscription>().FirstOrDefaultAsync(x => x.EventName == eventName && x.EventKey == eventKey && x.WorkflowId == workflowId && x.SubscribeAsOf <= asOf && x.ExternalToken == null, cancellationToken);
+
+                return raw?.ToEventSubscription();
+            }
+        }
+
         public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken cancellationToken = default)
         {
             using (var db = ConstructDbContext())

--- a/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
@@ -205,6 +205,14 @@ namespace WorkflowCore.Persistence.MongoDB.Services
             return await query.FirstOrDefaultAsync(cancellationToken);
         }
 
+        public async Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, string workflowId, DateTime asOf, CancellationToken cancellationToken = default)
+        {
+            var query = EventSubscriptions
+                .Find(x => x.EventName == eventName && x.EventKey == eventKey && x.WorkflowId == workflowId && x.SubscribeAsOf <= asOf && x.ExternalToken == null);
+
+            return await query.FirstOrDefaultAsync(cancellationToken);
+        }
+
         public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken cancellationToken = default)
         {
             var update = Builders<EventSubscription>.Update

--- a/src/providers/WorkflowCore.Persistence.RavenDB/Services/RavendbPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.RavenDB/Services/RavendbPersistenceProvider.cs
@@ -172,6 +172,22 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 			}
 		}
 
+		public async Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, string workflowId, DateTime asOf, CancellationToken cancellationToken = default)
+		{
+			using (var session = _database.OpenAsyncSession())
+			{
+				var q = session.Query<EventSubscription>().Where(x =>
+					x.EventName == eventKey
+					&& x.EventKey == eventKey
+					&& x.WorkflowId == workflowId
+					&& x.SubscribeAsOf <= asOf
+					&& x.ExternalToken == null
+				);
+
+				return await q.FirstOrDefaultAsync(cancellationToken);
+			}
+		}
+
 		public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken cancellationToken = default)
 		{
 			try

--- a/src/providers/WorkflowCore.Providers.Redis/Services/RedisPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Providers.Redis/Services/RedisPersistenceProvider.cs
@@ -117,7 +117,7 @@ namespace WorkflowCore.Providers.Redis.Services
             }
 
             return result;
-        }
+        }        
 
         public async Task TerminateSubscription(string eventSubscriptionId, CancellationToken _ = default)
         {
@@ -136,6 +136,11 @@ namespace WorkflowCore.Providers.Redis.Services
         public async Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken = default)
         {
             return (await GetSubscriptions(eventName, eventKey, asOf, cancellationToken)).FirstOrDefault(sub => string.IsNullOrEmpty(sub.ExternalToken));
+        }
+
+        public async Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, string workflowId, DateTime asOf, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
         }
 
         public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken _ = default)

--- a/src/samples/WorkflowCore.Sample18/Program.cs
+++ b/src/samples/WorkflowCore.Sample18/Program.cs
@@ -20,7 +20,7 @@ namespace WorkflowCore.Sample18
 
             var workflowId = host.StartWorkflow("activity-sample", new MyData { Request = "Spend $1,000,000" }).Result;
 
-            var approval = host.GetPendingActivity("get-approval", "worker1", TimeSpan.FromMinutes(1)).Result;
+            var approval = host.GetPendingActivity("get-approval", workflowId, "worker1", TimeSpan.FromMinutes(1)).Result;
 
             if (approval != null)
             {                
@@ -37,8 +37,8 @@ namespace WorkflowCore.Sample18
             //setup dependency injection
             IServiceCollection services = new ServiceCollection();
             //services.AddWorkflow();
-            services.AddWorkflow(x => x.UseMongoDB(@"mongodb://localhost:27017", "workflow"));
-            //services.AddWorkflow(x => x.UseSqlServer(@"Server=.;Database=WorkflowCore;Trusted_Connection=True;", true, true));
+            //services.AddWorkflow(x => x.UseMongoDB(@"mongodb://localhost:27017", "workflow"));
+            services.AddWorkflow(x => x.UseSqlServer(@"Server=.\\SqlExpress;Database=WFCore;Trusted_Connection=True;", true, true));
             //services.AddWorkflow(x => x.UsePostgreSQL(@"Server=127.0.0.1;Port=5432;Database=workflow;User Id=postgres;", true, true));
             services.AddLogging(cfg => 
             {

--- a/test/WorkflowCore.IntegrationTests/Scenarios/ActivityScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/ActivityScenario.cs
@@ -50,7 +50,7 @@ namespace WorkflowCore.IntegrationTests.Scenarios
         public void Scenario()
         {
             var workflowId = StartWorkflow(new MyDataClass { ActivityInput = new ActivityInput { Value1 = "a", Value2 = 1 } });
-            var activity = Host.GetPendingActivity("act-1", "worker1", TimeSpan.FromSeconds(30)).Result;
+            var activity = Host.GetPendingActivity("act-1", workflowId, "worker1", TimeSpan.FromSeconds(30)).Result;
 
             if (activity != null)
             {


### PR DESCRIPTION
**Describe the change**
An overload on the `GetPendingActivity `on `ActivityController` to include `workflowId ` parameter, this overload allows the host to get only the pending activities from a specific workflow. Helping to solve the issue #542  

**Describe your implementation or design**
How did you go about implementing the change?
It's only a overload, follows the same implementation that the master branch, but now help the host to get pending activities with a new filter, the workflowId.

**Tests**
Did you cover your changes with tests?
Yes

**Breaking change**
Do you changes break compatibility with previous versions?
No

**Additional context**
This change is not supported only on Redis provider. I couldn't implements this overload for Redis.