### PR TITLE
Parallel Events test fixes

### DIFF
--- a/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
@@ -89,19 +89,8 @@ namespace WorkflowCore.Services.BackgroundTasks
             if (subscription.EventName != Event.EventTypeActivity)
             {
                 var events = await persistenceStore.GetEvents(subscription.EventName, subscription.EventKey, subscription.SubscribeAsOf, cancellationToken);
-
                 foreach (var evt in events)
                 {
-                    var locked = await _lockProvider.AcquireLock($"evt:{evt}", cancellationToken);
-                    int attempt = 0;
-                    while (locked && attempt < 10)
-                    {
-                        locked = await _lockProvider.AcquireLock($"evt:{evt}", cancellationToken);
-                        await Task.Delay(Options.IdleTime);
-
-                        attempt++;
-                    }
-
                     await persistenceStore.MarkEventUnprocessed(evt, cancellationToken);
                     await QueueProvider.QueueWork(evt, QueueType.Event);
                 }


### PR DESCRIPTION
@danielgerlag it is another version of Unit test for Parallel events.
PS. previous version working fine for me, only one reason that I can see that default poller is 10 second and test rely on this, so I decided to change for test timing to be 1 second. Also id on a test was same.

Please let me know if it works for you. Sorry for inconvinience and thank you for library support.