### PR TITLE
Quick fix for sending WorkflowCompleted lifecycle event when EndWorkflow in workflow definition is reached.

### DIFF
--- a/src/WorkflowCore/Services/WorkflowExecutor.cs
+++ b/src/WorkflowCore/Services/WorkflowExecutor.cs
@@ -218,50 +218,48 @@ namespace WorkflowCore.Services
             //TODO: move to own class
             workflow.NextExecution = null;
 
-            if (workflow.Status == WorkflowStatus.Complete)
+            if (workflow.Status != WorkflowStatus.Complete)
             {
-                return;
-            }
-
-            foreach (var pointer in workflow.ExecutionPointers.Where(x => x.Active && (x.Children ?? new List<string>()).Count == 0))
-            {
-                if (!pointer.SleepUntil.HasValue)
+                foreach (var pointer in workflow.ExecutionPointers.Where(x => x.Active && (x.Children ?? new List<string>()).Count == 0))
                 {
-                    workflow.NextExecution = 0;
+                    if (!pointer.SleepUntil.HasValue)
+                    {
+                        workflow.NextExecution = 0;
+                        return;
+                    }
+
+                    var pointerSleep = pointer.SleepUntil.Value.ToUniversalTime().Ticks;
+                    workflow.NextExecution = Math.Min(pointerSleep, workflow.NextExecution ?? pointerSleep);
+                }
+
+                foreach (var pointer in workflow.ExecutionPointers.Where(x => x.Active && (x.Children ?? new List<string>()).Count > 0))
+                {
+                    if (!workflow.ExecutionPointers.FindByScope(pointer.Id).All(x => x.EndTime.HasValue))
+                        continue;
+
+                    if (!pointer.SleepUntil.HasValue)
+                    {
+                        workflow.NextExecution = 0;
+                        return;
+                    }
+
+                    var pointerSleep = pointer.SleepUntil.Value.ToUniversalTime().Ticks;
+                    workflow.NextExecution = Math.Min(pointerSleep, workflow.NextExecution ?? pointerSleep);
+                }
+
+                if ((workflow.NextExecution != null) || (workflow.ExecutionPointers.Any(x => x.EndTime == null)))
+                {
                     return;
                 }
 
-                var pointerSleep = pointer.SleepUntil.Value.ToUniversalTime().Ticks;
-                workflow.NextExecution = Math.Min(pointerSleep, workflow.NextExecution ?? pointerSleep);
-            }
+                workflow.Status = WorkflowStatus.Complete;
+                workflow.CompleteTime = _datetimeProvider.UtcNow;
 
-            foreach (var pointer in workflow.ExecutionPointers.Where(x => x.Active && (x.Children ?? new List<string>()).Count > 0))
-            {
-                if (!workflow.ExecutionPointers.FindByScope(pointer.Id).All(x => x.EndTime.HasValue))
-                    continue;
-
-                if (!pointer.SleepUntil.HasValue)
+                using (var scope = _serviceProvider.CreateScope())
                 {
-                    workflow.NextExecution = 0;
-                    return;
+                    var middlewareRunner = scope.ServiceProvider.GetRequiredService<IWorkflowMiddlewareRunner>();
+                    await middlewareRunner.RunPostMiddleware(workflow, def);
                 }
-
-                var pointerSleep = pointer.SleepUntil.Value.ToUniversalTime().Ticks;
-                workflow.NextExecution = Math.Min(pointerSleep, workflow.NextExecution ?? pointerSleep);
-            }
-
-            if ((workflow.NextExecution != null) || (workflow.ExecutionPointers.Any(x => x.EndTime == null)))
-            {
-                return;
-            }
-
-            workflow.Status = WorkflowStatus.Complete;
-            workflow.CompleteTime = _datetimeProvider.UtcNow;
-
-            using (var scope = _serviceProvider.CreateScope())
-            {
-                var middlewareRunner = scope.ServiceProvider.GetRequiredService<IWorkflowMiddlewareRunner>();
-                await middlewareRunner.RunPostMiddleware(workflow, def);
             }
 
             _publisher.PublishNotification(new WorkflowCompleted

--- a/test/WorkflowCore.IntegrationTests/Scenarios/EndStepScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/EndStepScenario.cs
@@ -2,6 +2,7 @@
 using System;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
+using WorkflowCore.Models.LifeCycleEvents;
 using WorkflowCore.Testing;
 using Xunit;
 
@@ -12,6 +13,8 @@ namespace WorkflowCore.IntegrationTests.Scenarios
         internal static int StartStepCounter = 0;
         internal static int MidStepCounter = 0;
         internal static int EndStepCounter = 0;
+
+        private int workflowCompletedEventTriggered = 0;
 
         public class ScenarioWorkflow : IWorkflow
         {
@@ -49,6 +52,13 @@ namespace WorkflowCore.IntegrationTests.Scenarios
         [Fact]
         public void Scenario()
         {
+            Host.OnLifeCycleEvent += (e) =>
+            {
+                if (e is WorkflowCompleted)
+                {
+                    workflowCompletedEventTriggered++;
+                }
+            };
             var workflowId = StartWorkflow(null);
             WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(30));
 
@@ -56,6 +66,7 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             StartStepCounter.Should().Be(1);
             MidStepCounter.Should().Be(1);
             EndStepCounter.Should().Be(0);
+            workflowCompletedEventTriggered.Should().Be(1);
         }
     }
 }


### PR DESCRIPTION
Fixing WorkflowExecutor.DetermineNextExecutionTime to perform forgotten side effect before returning from the method.

**Tests**
EndStepScenario

fixes #836 