### PR TITLE
Fix SQL Server tests

### DIFF
--- a/test/WorkflowCore.Tests.SqlServer/DockerSetup.cs
+++ b/test/WorkflowCore.Tests.SqlServer/DockerSetup.cs
@@ -11,7 +11,7 @@ namespace WorkflowCore.Tests.SqlServer
         public static string ConnectionString { get; set; }
         public static string ScenarioConnectionString { get; set; }
 
-        public override string ImageName => "microsoft/mssql-server-linux";
+        public override string ImageName => "mcr.microsoft.com/mssql/server";
         public override int InternalPort => 1433;
         public override TimeSpan TimeOut => TimeSpan.FromSeconds(120);
 


### PR DESCRIPTION
The repository` microsoft/mssql-server-linux` is no longer maintained and the container image cannot be pulled.
The `mcr.microsoft.com/mssql/server` should be used instead.

See https://cloudblogs.microsoft.com/sqlserver/2021/05/20/microsoft-sql-server-linux-based-container-images-to-be-available-only-from-the-microsoft-container-registry/ for details.

Without the fix test fail with the following error:
"`pull access denied for microsoft/mssql-server-linux, repository does not exist or may require 'docker login': denied: requested access to the resource is denied`".