### PR TITLE
Fix DynamoDB tests

### DIFF
--- a/test/WorkflowCore.Tests.DynamoDB/DynamoDbDockerSetup.cs
+++ b/test/WorkflowCore.Tests.DynamoDB/DynamoDbDockerSetup.cs
@@ -11,7 +11,7 @@ namespace WorkflowCore.Tests.DynamoDB
     {
         public static string ConnectionString { get; set; }
 
-        public static AWSCredentials Credentials => new EnvironmentVariablesAWSCredentials();
+        public static AWSCredentials Credentials => new BasicAWSCredentials("DUMMYIDEXAMPLE", "DUMMYEXAMPLEKEY");
 
         public override string ImageName => @"amazon/dynamodb-local";
         public override int InternalPort => 8000;
@@ -30,7 +30,7 @@ namespace WorkflowCore.Tests.DynamoDB
                 {
                     ServiceURL = $"http://localhost:{ExternalPort}"
                 };
-                AmazonDynamoDBClient client = new AmazonDynamoDBClient(clientConfig);
+                AmazonDynamoDBClient client = new AmazonDynamoDBClient(Credentials, clientConfig);
                 var resp = client.ListTablesAsync().Result;
 
                 return resp.HttpStatusCode == HttpStatusCode.OK;


### PR DESCRIPTION
The recent `amazon/dynamodb-local` images introduce breaking change and require dummy credentials, see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html.

Without the fix, tests fail with the timeout error in `DockerSetup.StartContainer` method but the real error is "`Unable to get IAM security credentials from EC2 Instance Metadata Service.`" in the `DynamoDbDockerSetup.TestReady` method.