### PR TITLE
Added condition so the resolved value is only cast to string and pars…

### DIFF
--- a/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
+++ b/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
@@ -276,7 +276,8 @@ namespace WorkflowCore.Services.DefinitionStorage
             void acn(IStepBody pStep, object pData, IStepExecutionContext pContext)
             {
                 object resolvedValue = sourceExpr.Compile().DynamicInvoke(pData, pContext, Environment.GetEnvironmentVariables());
-                if (stepProperty.PropertyType.IsEnum)
+                if (stepProperty.PropertyType.IsEnum
+                    && (!stepProperty.PropertyType.IsAssignableFrom(resolvedValue.GetType())))
                     stepProperty.SetValue(pStep, Enum.Parse(stepProperty.PropertyType, (string)resolvedValue, true));
                 else
                 {


### PR DESCRIPTION
…ed to an enum if it is not directly assignable.


**Describe the change**
A clear and concise description of what the change is. Any PR submitted without a description of the change will not be reviewed.

Fixed a condition in the DefinitionLoader that made it so that inputs could not be assigned from enums that matched the type of the property to assign to.

**Describe your implementation or design**
How did you go about implementing the change?

Added a condition, similar to that in the else statement underneath to cover the case when the enum object is directly assignable to the `stepProperty`.

**Tests**
Did you cover your changes with tests?

No, the DefinitionLoader class is not really built in a testable way. Without modifying the accessibility levels of the methods in DefinitionLoader, I don't really feel comfortable writing new unit tests for the class. Besides, the class has terrible test coverage already.

**Breaking change**
Do you changes break compatibility with previous versions?

Would not think so.

**Additional context**
Any additional information you'd like to provide?

See issue https://github.com/danielgerlag/workflow-core/issues/916 .