### PR TITLE
Add (auto) Id property to `WorkflowCore.Models.ExecutionError` so that it can easily be deserialized.

### DIFF
--- a/src/WorkflowCore/Models/ExecutionError.cs
+++ b/src/WorkflowCore/Models/ExecutionError.cs
@@ -4,7 +4,9 @@ namespace WorkflowCore.Models
 {
     public class ExecutionError
     {
-        public DateTime ErrorTime { get; set; }
+	    public string Id { get; set; } = Guid.NewGuid().ToString();
+	    
+	    public DateTime ErrorTime { get; set; }
 
         public string WorkflowId { get; set; }
 


### PR DESCRIPTION
**Describe the change**
Add (auto) Id property to `WorkflowCore.Models.ExecutionError` so that it can easily be deserialized using the MongoDb driver.