### PR TITLE
Fix GitHub actions build.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,20 +16,20 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.*
+        dotnet-version: 3.1.*
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
     - name: Unit Tests
-      run: dotnet test test/WorkflowCore.UnitTests --no-build --verbosity normal
+      run: dotnet test test/WorkflowCore.UnitTests --no-build --verbosity normal -p:ParallelizeTestCollections=false
     - name: Integration Tests
-      run: dotnet test test/WorkflowCore.IntegrationTests --no-build --verbosity normal
+      run: dotnet test test/WorkflowCore.IntegrationTests --no-build --verbosity normal -p:ParallelizeTestCollections=false
     - name: PostgreSQL Tests
-      run: dotnet test test/WorkflowCore.Tests.PostgreSQL --no-build --verbosity normal
+      run: dotnet test test/WorkflowCore.Tests.PostgreSQL --no-build --verbosity normal -p:ParallelizeTestCollections=false
     - name: Redis Tests
-      run: dotnet test test/WorkflowCore.Tests.Redis --no-build --verbosity normal
+      run: dotnet test test/WorkflowCore.Tests.Redis --no-build --verbosity normal -p:ParallelizeTestCollections=false
     - name: SQL Server Tests
-      run: dotnet test test/WorkflowCore.Tests.SqlServer --no-build --verbosity normal
+      run: dotnet test test/WorkflowCore.Tests.SqlServer --no-build --verbosity normal -p:ParallelizeTestCollections=false
     - name: Elasticsearch Tests
-      run: dotnet test test/WorkflowCore.Tests.Elasticsearch --no-build --verbosity normal
+      run: dotnet test test/WorkflowCore.Tests.Elasticsearch --no-build --verbosity normal -p:ParallelizeTestCollections=false

--- a/src/WorkflowCore/WorkflowCore.csproj
+++ b/src/WorkflowCore/WorkflowCore.csproj
@@ -26,7 +26,9 @@
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
-	<InternalsVisibleTo Include="WorkflowCore.IntegrationTests" />
+	<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+		<_Parameter1>WorkflowCore.IntegrationTests</_Parameter1>
+	</AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR is aimed to fix the failing GitHub actions build, which might be beneficial for the fork maintainers and for the original repository.

It includes three fixes:
- Use .NET SDK 3.1 instead of .NET SDK 5 since sample projects target 3.1 (yet?).
- Disable parallel tests to avoid race conditions since some code is not expected to be thread-safe.
- Change the `InternalsVisibleTo` attribute so it works on GitHub build.

Please let me know if it can be improved/extended.