### PR TITLE
Resolve #957, E11000 duplicate key error

### DIFF
--- a/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
@@ -321,6 +321,12 @@ namespace WorkflowCore.Persistence.MongoDB.Services
                      return;
                 throw;
             }
+            catch (MongoBulkWriteException ex)
+            {
+                if (ex.WriteErrors.All(x => x.Category == ServerErrorCategory.DuplicateKey))
+                    return;
+                throw;
+            }
         }
 
         public async Task ProcessCommands(DateTimeOffset asOf, Func<ScheduledCommand, Task> action, CancellationToken cancellationToken = default)

--- a/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
@@ -315,9 +315,9 @@ namespace WorkflowCore.Persistence.MongoDB.Services
             {
                 await ScheduledCommands.InsertOneAsync(command);
             }
-            catch (MongoBulkWriteException ex)
+            catch (MongoWriteException ex)
             {
-                if (ex.WriteErrors.All(x => x.Category == ServerErrorCategory.DuplicateKey))
+                if (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
                      return;
                 throw;
             }


### PR DESCRIPTION
**Describe the change**
Resolve #957. `InsertOneAsync` will throw a `MongoWriteException` and not a `MongoBulkWriteException`. Hence the original catch would have never triggered.

**Describe your implementation or design**
- Changed `MongoBulkWriteException` to `MongoWriteException` and changed the check on the `WriteErrors` property to a check on `WriteError`. 
- Also changed the `.` to `?.` (if the error is a WriteConcernError, the `WriteError` property won't be set)

**Tests**
I couldn't find any automated tests to modify in WorkflowCore.Tests.MongoDB, so I manually tested it (i.e. made sure the `MongoWriteException` is triggered, caught and ignored)

**Breaking change**
NOT a breaking change

**Additional context**
None