### PR TITLE
Fix parsing step inputs.

### DIFF
--- a/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
+++ b/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
@@ -401,7 +401,8 @@ namespace WorkflowCore.Services.DefinitionStorage
                         stack.Push(child);
                 }
 
-                stepProperty.SetValue(pStep, destObj);
+                var destValue = destObj.ToObject(stepProperty.PropertyType);
+                stepProperty.SetValue(pStep, destValue);
             }
             return acn;
         }


### PR DESCRIPTION
**Describe the change**
This change fixes wrong type assignment to property info value. It used to assign `JObject` to any property of any type. It resulted in exceptions.

**Describe your implementation or design**
Went through the JSON interpretation process with debugger and saw a type mismatch.

**Tests**
No

**Breaking change**
No clue
