### PR TITLE
Cannot start WorkflowHost with MySql on NET6, DbContext injection missing

### DIFF
--- a/src/providers/WorkflowCore.Persistence.MySQL/MysqlContext.cs
+++ b/src/providers/WorkflowCore.Persistence.MySQL/MysqlContext.cs
@@ -23,7 +23,7 @@ namespace WorkflowCore.Persistence.MySQL
             base.OnConfiguring(optionsBuilder);
 #if NETSTANDARD2_0
             optionsBuilder.UseMySql(_connectionString, _mysqlOptionsAction);
-#elif NETSTANDARD2_1_OR_GREATER
+#elif NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
             optionsBuilder.UseMySql(_connectionString, ServerVersion.AutoDetect(_connectionString), _mysqlOptionsAction);
 #endif
         }


### PR DESCRIPTION
Hello Daniel,

After the changes on WorkflowCore to run with NET6, MySQL provider stopped working, throwing an error when trying to start de WorkflowCore Host.

The issue only occurs when using MySQL provider with NET6 projects.

After investigating, I found a condition in "MysqlContext" class that validate only NetStandard.

So I'm making a PR and adding the NET6 verification.

Thanks