### PR TITLE
Fix failing integration tests: DockerApiException and PSQL timestamps

### DIFF
--- a/test/Docker.Testify/Docker.Testify.csproj
+++ b/test/Docker.Testify/Docker.Testify.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Docker.DotNet" Version="3.125.2" />
+    <PackageReference Include="Docker.DotNet" Version="3.125.5" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />

--- a/test/WorkflowCore.Tests.PostgreSQL/DockerSetup.cs
+++ b/test/WorkflowCore.Tests.PostgreSQL/DockerSetup.cs
@@ -26,6 +26,8 @@ namespace WorkflowCore.Tests.PostgreSQL
 
         public override bool TestReady()
         {
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+
             try
             {
                 var connection = new NpgsqlConnection($"Server=127.0.0.1;Port={ExternalPort};Database=postgres;User Id=postgres;");


### PR DESCRIPTION
**Describe the change**
The Docker.DotNet package needs to be updated to be compatible with the latest Docker Desktop releases.

Otherwise, all integration tests fail with the following error:
```
System.AggregateException : One or more errors occurred. (One or more errors occurred. (One or more errors occurred. (Docker API responded with status code=BadRequest, response=400 Bad Request))) (The following constructor parameters did not have matching fixture data: DynamoDbDockerSetup dockerSetup)
---- System.AggregateException : One or more errors occurred. (One or more errors occurred. (Docker API responded with status code=BadRequest, response=400 Bad Request))
-------- System.AggregateException : One or more errors occurred. (Docker API responded with status code=BadRequest, response=400 Bad Request)
------------ Docker.DotNet.DockerApiException : Docker API responded with status code=BadRequest, response=400 Bad Request
```

Another issue is PostgreSQL has changed the timestamp behavior, and we need to enable legacy behavior for compatibility.
```
System.AggregateException : One or more errors occurred. (Cannot write DateTime with Kind=Local to PostgreSQL type 'timestamp with time zone', only UTC is supported. Note that it's not possible to mix DateTimes with different Kinds in an array/range. See the Npgsql.EnableLegacyTimestampBehavior AppContext switch to enable legacy behavior.)
---- System.InvalidCastException : Cannot write DateTime with Kind=Local to PostgreSQL type 'timestamp with time zone', only UTC is supported. Note that it's not possible to mix DateTimes with different Kinds in an array/range. See the Npgsql.EnableLegacyTimestampBehavior AppContext switch to enable legacy behavior.
```

**Describe your implementation or design**
Update the Docker.DotNet package.

Enable legacy timestamp behavior for compatibility.

**Tests**
No need for new tests.

**Breaking change**
No.