### PR TITLE
Add ProceedOnCancel to WorkflowCore.DSL definition loader

### DIFF
--- a/src/WorkflowCore.DSL/Models/v1/StepSourceV1.cs
+++ b/src/WorkflowCore.DSL/Models/v1/StepSourceV1.cs
@@ -7,7 +7,7 @@ namespace WorkflowCore.Models.DefinitionStorage.v1
     public class StepSourceV1
     {
         public string StepType { get; set; }
-        
+
         public string Id { get; set; }
 
         public string Name { get; set; }
@@ -29,8 +29,9 @@ namespace WorkflowCore.Models.DefinitionStorage.v1
         public ExpandoObject Inputs { get; set; } = new ExpandoObject();
 
         public Dictionary<string, string> Outputs { get; set; } = new Dictionary<string, string>();
-        
+
         public Dictionary<string, string> SelectNextStep { get; set; } = new Dictionary<string, string>();
 
+        public bool ProceedOnCancel { get; set; } = false;
     }
 }

--- a/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
+++ b/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
@@ -101,6 +101,7 @@ namespace WorkflowCore.Services.DefinitionStorage
                 targetStep.ErrorBehavior = nextStep.ErrorBehavior;
                 targetStep.RetryInterval = nextStep.RetryInterval;
                 targetStep.ExternalId = $"{nextStep.Id}";
+                targetStep.ProceedOnCancel = nextStep.ProceedOnCancel;
 
                 AttachInputs(nextStep, dataType, stepType, targetStep);
                 AttachOutputs(nextStep, dataType, stepType, targetStep);

--- a/test/WorkflowCore.IntegrationTests/Scenarios/StoredJsonScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/StoredJsonScenario.cs
@@ -31,6 +31,7 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             data.Counter6.Should().Be(1);
             data.Counter7.Should().Be(1);
             data.Counter8.Should().Be(0);
+            data.Counter10.Should().Be(1);
         }
 
         [Fact(DisplayName = "Execute branch 2")]
@@ -50,6 +51,7 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             data.Counter6.Should().Be(1);
             data.Counter7.Should().Be(0);
             data.Counter8.Should().Be(1);
+            data.Counter10.Should().Be(1);
         }
 
         [Fact]
@@ -64,7 +66,8 @@ namespace WorkflowCore.IntegrationTests.Scenarios
                 ["Counter3"] = 0,
                 ["Counter4"] = 0,
                 ["Counter5"] = 0,
-                ["Counter6"] = 0
+                ["Counter6"] = 0,
+                ["Counter10"] = 0
             };
 
             var workflowId = StartWorkflow(TestAssets.Utils.GetTestDefinitionDynamicJson(), initialData);
@@ -79,6 +82,7 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             data["Counter4"].Should().Be(1);
             data["Counter5"].Should().Be(0);
             data["Counter6"].Should().Be(1);
+            data["Counter10"].Should().Be(1);
         }
     }
 }

--- a/test/WorkflowCore.IntegrationTests/Scenarios/StoredYamlScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/StoredYamlScenario.cs
@@ -29,6 +29,7 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             data.Counter4.Should().Be(1);
             data.Counter5.Should().Be(0);
             data.Counter6.Should().Be(1);
+            data.Counter10.Should().Be(1);
         }
     }
 }

--- a/test/WorkflowCore.TestAssets/DataTypes/CounterBoard.cs
+++ b/test/WorkflowCore.TestAssets/DataTypes/CounterBoard.cs
@@ -13,6 +13,7 @@ namespace WorkflowCore.TestAssets.DataTypes
         public int Counter7 { get; set; }
         public int Counter8 { get; set; }
         public int Counter9 { get; set; }
+        public int Counter10 { get; set; }
         public bool Flag1 { get; set; }
         public bool Flag2 { get; set; }
         public bool Flag3 { get; set; }

--- a/test/WorkflowCore.TestAssets/stored-definition.json
+++ b/test/WorkflowCore.TestAssets/stored-definition.json
@@ -58,6 +58,26 @@
             "Inputs": { "Value": "data.Counter5" },
             "Outputs": { "Counter5": "step.Value" }
           }
+        ],
+        [
+          {
+            "Id": "Step3.3.1",
+            "StepType": "WorkflowCore.Primitives.WaitFor, WorkflowCore",
+            "NextStepId": "Step3.3.2",
+            "CancelCondition": "data.Flag2",
+            "ProceedOnCancel": true,
+            "Inputs": {
+              "EventName": "\"Event1\"",
+              "EventKey": "\"Key1\"",
+              "EffectiveDate": "DateTime.Now"
+            }
+          },
+          {
+            "Id": "Step3.3.2",
+            "StepType": "WorkflowCore.TestAssets.Steps.Counter, WorkflowCore.TestAssets",
+            "Inputs": { "Value": "data.Counter10" },
+            "Outputs": { "Counter10": "step.Value" }
+          }
         ]
       ]
     },

--- a/test/WorkflowCore.TestAssets/stored-definition.yaml
+++ b/test/WorkflowCore.TestAssets/stored-definition.yaml
@@ -50,6 +50,21 @@ Steps:
         Value: data.Counter5
       Outputs:
         Counter5: step.Value
+  - - Id: Step3.3.1
+      StepType: WorkflowCore.Primitives.WaitFor, WorkflowCore
+      NextStepId: Step3.3.2
+      CancelCondition: data.Flag2
+      ProceedOnCancel: true
+      Inputs:
+        EventName: '"Event1"'
+        EventKey: '"Key1"'
+        EffectiveDate: DateTime.Now
+    - Id: Step3.3.2
+      StepType: WorkflowCore.TestAssets.Steps.Counter, WorkflowCore.TestAssets
+      Inputs:
+        Value: data.Counter10
+      Outputs:
+        Counter10: step.Value
 - Id: Step4
   StepType: WorkflowCore.TestAssets.Steps.Counter, WorkflowCore.TestAssets
   Inputs:

--- a/test/WorkflowCore.TestAssets/stored-dynamic-definition.json
+++ b/test/WorkflowCore.TestAssets/stored-dynamic-definition.json
@@ -57,6 +57,26 @@
             "Inputs": { "Value": "data[\"Counter5\"]" },
             "Outputs": { "Counter5": "step.Value" }
           }
+        ],
+        [
+          {
+            "Id": "Step3.3.1",
+            "StepType": "WorkflowCore.Primitives.WaitFor, WorkflowCore",
+            "NextStepId": "Step3.3.2",
+            "CancelCondition": "object.Equals(data[\"Flag2\"], true)",
+            "ProceedOnCancel": true,
+            "Inputs": {
+              "EventName": "\"Event1\"",
+              "EventKey": "\"Key1\"",
+              "EffectiveDate": "DateTime.Now"
+            }
+          },
+          {
+            "Id": "Step3.3.2",
+            "StepType": "WorkflowCore.TestAssets.Steps.Counter, WorkflowCore.TestAssets",
+            "Inputs": { "Value": "data[\"Counter10\"]" },
+            "Outputs": { "Counter10": "step.Value" }
+          }
         ]
       ]
     },

--- a/test/WorkflowCore.TestAssets/stored-dynamic-definition.yaml
+++ b/test/WorkflowCore.TestAssets/stored-dynamic-definition.yaml
@@ -50,6 +50,21 @@ Steps:
         Value: data.Counter5
       Outputs:
         Counter5: step.Value
+  - - Id: Step3.3.1
+      StepType: WorkflowCore.Primitives.WaitFor, WorkflowCore
+      NextStepId: Step3.3.2
+      CancelCondition: data.Flag2
+      ProceedOnCancel: true
+      Inputs:
+        EventName: '"Event1"'
+        EventKey: '"Key1"'
+        EffectiveDate: DateTime.Now
+    - Id: Step3.3.2
+      StepType: WorkflowCore.TestAssets.Steps.Counter, WorkflowCore.TestAssets
+      Inputs:
+        Value: data.Counter10
+      Outputs:
+        Counter10: step.Value
 - Id: Step4
   StepType: WorkflowCore.TestAssets.Steps.Counter, WorkflowCore.TestAssets
   Inputs:


### PR DESCRIPTION
Hi Daniel,

during my research to find a way to create a step with deadline, I found some post that suggest to use a .Parallel() with .WaitFor() on one branch and .Sleep() on another branch, and use .CancelCondition(<condition>, **true**) to the Parallel.

I could simulate my scenario and it works perfectly with FluentAPI, but I'm using the JSON Loader extension on WorkflowCore.DSL, and this loader not have how to pass the property "ProceedOnCancel".

So I added property "ProceedOnCancel" to StepSourceV1 and pass it value to the targetStep on ConvertStep at definitionLoader. And also change some tests to contemple this property.

Thank you for this amazing workflow engine.