### PR TITLE
Do not push duplicates to Redis queue, simulate unique list behavior

### DIFF
--- a/src/providers/WorkflowCore.Providers.Redis/Services/RedisQueueProvider.cs
+++ b/src/providers/WorkflowCore.Providers.Redis/Services/RedisQueueProvider.cs
@@ -36,7 +36,13 @@ namespace WorkflowCore.Providers.Redis.Services
             if (_redis == null)
                 throw new InvalidOperationException();
 
-            await _redis.ListRightPushAsync(GetQueueName(queue), id, When.Always);
+            var queueName = GetQueueName(queue);
+
+            var insertResult = await _redis.ListInsertBeforeAsync(queueName, id, id);
+            if (insertResult == -1 || insertResult == 0)
+                await _redis.ListRightPushAsync(queueName, id, When.Always);
+            else
+                await _redis.ListRemoveAsync(queueName, id, 1);
         }
 
         public async Task<string> DequeueWork(QueueType queue, CancellationToken cancellationToken)


### PR DESCRIPTION
There's an issue with having duplicates in Redis queue. After polling runnable workflows it can have thousands of duplicated records. When you add new workflows, they are added at the end of the list and can be started only when all duplicates are checked that they are processed, in my environment it takes minutes and hours. Application is just checking duplicates and doing nothing.

This change works in this way:
1. Try to add an Id before the same Id.
2. If the Id is not found (-1) or the list is empty (0) then just push the Id to the list as before.
3. If an existing item is found and the duplicate is inserted, then remove the first 1 value from the list (actually the item we added).