### PR TITLE
Add prefix to RedisLockProvider #1044

### DIFF
--- a/src/providers/WorkflowCore.Providers.Redis/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Providers.Redis/ServiceCollectionExtensions.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Extensions.DependencyInjection
             return options;
         }
 
-        public static WorkflowOptions UseRedisLocking(this WorkflowOptions options, string connectionString)
+        public static WorkflowOptions UseRedisLocking(this WorkflowOptions options, string connectionString, string prefix = null)
         {
-            options.UseDistributedLockManager(sp => new RedisLockProvider(connectionString, sp.GetService<ILoggerFactory>()));
+            options.UseDistributedLockManager(sp => new RedisLockProvider(connectionString, prefix, sp.GetService<ILoggerFactory>()));
             return options;
         }
 


### PR DESCRIPTION
We use the same Redis connection string for all services which run WorkflowCore and have their own databases.
Current behavior locks other services from polling runnable workflows, events, etc. It uses on key to lock for different services.
Adding prefix can solve this problem.

And I also found that there's an open issue to have it.