### PR TITLE
Fixes a bug that occures when a compensation is nested in a branch

### DIFF
--- a/src/WorkflowCore/Services/FluentBuilders/WorkflowBuilder.cs
+++ b/src/WorkflowCore/Services/FluentBuilders/WorkflowBuilder.cs
@@ -84,6 +84,11 @@ namespace WorkflowCore.Services
                         if (step2.Children[i] == oldId)
                             step2.Children[i] = step.Id;
                     }
+
+                    if (step2.CompensationStepId == oldId)
+                    {
+                        step2.CompensationStepId = step.Id;
+                    }
                 }
             }
 
@@ -103,6 +108,11 @@ namespace WorkflowCore.Services
                     {
                         if (step2.Children[i] == oldId)
                             step2.Children[i] = step.Id;
+                    }
+
+                    if (step2.CompensationStepId == oldId)
+                    {
+                        step2.CompensationStepId = step.Id;
                     }
                 }
             }

--- a/test/WorkflowCore.IntegrationTests/Scenarios/ForeachWithCompensationScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/ForeachWithCompensationScenario.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using Xunit;
+using FluentAssertions;
+using WorkflowCore.Testing;
+
+namespace WorkflowCore.IntegrationTests.Scenarios
+{
+    public class ForeachWithCompensationScenario : WorkflowTest<ForeachWithCompensationScenario.ForeachWorkflow, ForeachWithCompensationScenario.MyDataClass>
+    {
+        internal static int Step1Ticker = 0;
+        internal static int Step2Ticker = 0;
+        internal static int Step3Ticker = 0;
+        internal static int CompensateTicker = 0;
+
+        public class MyDataClass
+        {
+        }
+
+        public class ForeachWorkflow : IWorkflow<MyDataClass>
+        {
+            public string Id => "ForeachWithCompensationWorkflow";
+            public int Version => 1;
+            public void Build(IWorkflowBuilder<MyDataClass> builder)
+            {
+                builder
+                .StartWith(data => {
+                    Step1Ticker++;
+                })
+                .Then(data => {
+                    Step2Ticker++;
+                })
+                .ForEach(step => new List<int> { 1 })
+                    .Do(then => then
+                        .Decide(data => 1)
+                            .Branch(1, builder.CreateBranch()
+                                .StartWith(data => {
+                                    Step3Ticker++;
+                                    throw new Exception();
+                                })
+                                .CompensateWithSequence(builder => builder.StartWith(_ => {
+                                    CompensateTicker++;
+                                })))
+                    );
+            }
+        }
+
+        public ForeachWithCompensationScenario()
+        {
+            Setup();
+        }
+
+        [Fact]
+        public void Scenario()
+        {
+            var workflowId = StartWorkflow(new MyDataClass());
+            WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(30));
+
+            Step1Ticker.Should().Be(1);
+            Step2Ticker.Should().Be(1);
+            Step3Ticker.Should().Be(1);
+            CompensateTicker.Should().Be(1);
+            GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
+            UnhandledStepErrors.Count.Should().Be(1);
+        }
+    }
+}


### PR DESCRIPTION
**Describe the change**
Fixes a bug reported in #1045 that causes an infinite loop when a compensation is nested inside a branch. The problem is caused by a missed correction of `CompensationStepId` during manipulation of step ids when building a branch.

**Describe your implementation or design**
I've added two `if` statements that do the required correction, similar to the other two `if` blocks.

**Tests**
An integration test was added to cover the situation that causes the bug.

**Breaking change**
No breaking change.
