### PR TITLE
Remove CancellationToken from writing persistence operations

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,10 +4,10 @@
     <PackageLicenseUrl>https://github.com/danielgerlag/workflow-core/blob/master/LICENSE.md</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/danielgerlag/workflow-core.git</RepositoryUrl>
-    <Version>3.6.4</Version>
-    <AssemblyVersion>3.6.4.0</AssemblyVersion>
-    <FileVersion>3.6.4.0</FileVersion>
+    <Version>4.0.0</Version>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <FileVersion>4.0.0.0</FileVersion>
     <PackageIconUrl>https://github.com/danielgerlag/workflow-core/raw/master/src/logo.png</PackageIconUrl>
-    <PackageVersion>3.6.4</PackageVersion>
+    <PackageVersion>4.0.0</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/WorkflowCore.Testing/WorkflowTest.cs
+++ b/src/WorkflowCore.Testing/WorkflowTest.cs
@@ -17,6 +17,7 @@ namespace WorkflowCore.Testing
         protected IWorkflowHost Host;
         protected IPersistenceProvider PersistenceProvider;
         protected List<StepError> UnhandledStepErrors = new List<StepError>();
+        private bool isDisposed;
 
         protected virtual void Setup()
         {
@@ -116,9 +117,22 @@ namespace WorkflowCore.Testing
             return (TData)instance.Data;
         }
 
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!isDisposed)
+            {
+                if (disposing)
+                {
+                    Host.Stop();
+                }
+                isDisposed = true;
+            }
+        }
+
         public void Dispose()
         {
-            Host.Stop();
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 

--- a/src/WorkflowCore/Interface/Persistence/IEventRepository.cs
+++ b/src/WorkflowCore/Interface/Persistence/IEventRepository.cs
@@ -8,7 +8,7 @@ namespace WorkflowCore.Interface
 {
     public interface IEventRepository
     {
-        Task<string> CreateEvent(Event newEvent, CancellationToken cancellationToken = default);
+        Task<string> CreateEvent(Event newEvent);
 
         Task<Event> GetEvent(string id, CancellationToken cancellationToken = default);
 
@@ -16,9 +16,9 @@ namespace WorkflowCore.Interface
 
         Task<IEnumerable<string>> GetEvents(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken = default);
 
-        Task MarkEventProcessed(string id, CancellationToken cancellationToken = default);
+        Task MarkEventProcessed(string id);
 
-        Task MarkEventUnprocessed(string id, CancellationToken cancellationToken = default);
+        Task MarkEventUnprocessed(string id);
 
     }
 }

--- a/src/WorkflowCore/Interface/Persistence/IPersistenceProvider.cs
+++ b/src/WorkflowCore/Interface/Persistence/IPersistenceProvider.cs
@@ -9,7 +9,7 @@ namespace WorkflowCore.Interface
     public interface IPersistenceProvider : IWorkflowRepository, ISubscriptionRepository, IEventRepository, IScheduledCommandRepository
     {        
 
-        Task PersistErrors(IEnumerable<ExecutionError> errors, CancellationToken cancellationToken = default);
+        Task PersistErrors(IEnumerable<ExecutionError> errors);
 
         void EnsureStoreExists();
 

--- a/src/WorkflowCore/Interface/Persistence/ISubscriptionRepository.cs
+++ b/src/WorkflowCore/Interface/Persistence/ISubscriptionRepository.cs
@@ -8,19 +8,19 @@ namespace WorkflowCore.Interface
 {
     public interface ISubscriptionRepository
     {        
-        Task<string> CreateEventSubscription(EventSubscription subscription, CancellationToken cancellationToken = default);
+        Task<string> CreateEventSubscription(EventSubscription subscription);
 
         Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken = default);
 
-        Task TerminateSubscription(string eventSubscriptionId, CancellationToken cancellationToken = default);
+        Task TerminateSubscription(string eventSubscriptionId);
 
         Task<EventSubscription> GetSubscription(string eventSubscriptionId, CancellationToken cancellationToken = default);
 
         Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken = default);
         
-        Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken cancellationToken = default);
+        Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry);
         
-        Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken cancellationToken = default);
+        Task ClearSubscriptionToken(string eventSubscriptionId, string token);
 
     }
 }

--- a/src/WorkflowCore/Interface/Persistence/IWorkflowRepository.cs
+++ b/src/WorkflowCore/Interface/Persistence/IWorkflowRepository.cs
@@ -8,9 +8,9 @@ namespace WorkflowCore.Interface
 {
     public interface IWorkflowRepository
     {
-        Task<string> CreateNewWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken = default);
+        Task<string> CreateNewWorkflow(WorkflowInstance workflow);
 
-        Task PersistWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken = default);
+        Task PersistWorkflow(WorkflowInstance workflow);
 
         Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt, CancellationToken cancellationToken = default);
 

--- a/src/WorkflowCore/Services/BackgroundTasks/EventConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/EventConsumer.cs
@@ -59,7 +59,7 @@ namespace WorkflowCore.Services.BackgroundTasks
                         if (activity == null)
                         {
                             Logger.LogWarning($"Activity already processed - {(evt.EventData as ActivityResult).SubscriptionId}");
-                            await _eventRepository.MarkEventProcessed(itemId, cancellationToken);
+                            await _eventRepository.MarkEventProcessed(itemId);
                             return;
                         }
                         subs = new List<EventSubscription> { activity };
@@ -77,7 +77,7 @@ namespace WorkflowCore.Services.BackgroundTasks
 
                     if (complete)
                     {
-                        await _eventRepository.MarkEventProcessed(itemId, cancellationToken);
+                        await _eventRepository.MarkEventProcessed(itemId);
                     }
                     else
                     {
@@ -135,8 +135,8 @@ namespace WorkflowCore.Services.BackgroundTasks
                     p.Active = true;
                 }
                 workflow.NextExecution = 0;
-                await _workflowRepository.PersistWorkflow(workflow, cancellationToken);
-                await _subscriptionRepository.TerminateSubscription(sub.Id, cancellationToken);
+                await _workflowRepository.PersistWorkflow(workflow);
+                await _subscriptionRepository.TerminateSubscription(sub.Id);
                 return true;
             }
             catch (Exception ex)

--- a/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
@@ -55,7 +55,7 @@ namespace WorkflowCore.Services.BackgroundTasks
                     finally
                     {
                         WorkflowActivity.Enrich(result);
-                        await _persistenceStore.PersistWorkflow(workflow, cancellationToken);
+                        await _persistenceStore.PersistWorkflow(workflow);
                         await QueueProvider.QueueWork(itemId, QueueType.Index);
                         _greylist.Remove($"wf:{itemId}");
                     }
@@ -71,7 +71,7 @@ namespace WorkflowCore.Services.BackgroundTasks
                         await SubscribeEvent(sub, _persistenceStore, cancellationToken);
                     }
 
-                    await _persistenceStore.PersistErrors(result.Errors, cancellationToken);
+                    await _persistenceStore.PersistErrors(result.Errors);
 
                     if ((workflow.Status == WorkflowStatus.Runnable) && workflow.NextExecution.HasValue)
                     {
@@ -103,7 +103,7 @@ namespace WorkflowCore.Services.BackgroundTasks
             //TODO: move to own class
             Logger.LogDebug("Subscribing to event {0} {1} for workflow {2} step {3}", subscription.EventName, subscription.EventKey, subscription.WorkflowId, subscription.StepId);
 
-            await persistenceStore.CreateEventSubscription(subscription, cancellationToken);
+            await persistenceStore.CreateEventSubscription(subscription);
             if (subscription.EventName != Event.EventTypeActivity)
             {
                 var events = await persistenceStore.GetEvents(subscription.EventName, subscription.EventKey, subscription.SubscribeAsOf, cancellationToken);
@@ -131,7 +131,7 @@ namespace WorkflowCore.Services.BackgroundTasks
                         else
                         {
                             _greylist.Remove(eventKey);
-                            await persistenceStore.MarkEventUnprocessed(evt, cancellationToken);
+                            await persistenceStore.MarkEventUnprocessed(evt);
                             await QueueProvider.QueueWork(evt, QueueType.Event);
                         }
                     }

--- a/src/WorkflowCore/Services/DefaultProviders/MemoryPersistenceProvider.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/MemoryPersistenceProvider.cs
@@ -26,7 +26,7 @@ namespace WorkflowCore.Services
 
         public bool SupportsScheduledCommands => false;
 
-        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow, CancellationToken _ = default)
+        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow)
         {
             lock (_instances)
             {
@@ -36,7 +36,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task PersistWorkflow(WorkflowInstance workflow, CancellationToken _ = default)
+        public async Task PersistWorkflow(WorkflowInstance workflow)
         {
             lock (_instances)
             {
@@ -107,7 +107,7 @@ namespace WorkflowCore.Services
         }
 
 
-        public async Task<string> CreateEventSubscription(EventSubscription subscription, CancellationToken _ = default)
+        public async Task<string> CreateEventSubscription(EventSubscription subscription)
         {
             lock (_subscriptions)
             {
@@ -126,7 +126,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task TerminateSubscription(string eventSubscriptionId, CancellationToken _ = default)
+        public async Task TerminateSubscription(string eventSubscriptionId)
         {
             lock (_subscriptions)
             {
@@ -154,7 +154,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken _ = default)
+        public Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry)
         {
             lock (_subscriptions)
             {
@@ -167,7 +167,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken _ = default)
+        public Task ClearSubscriptionToken(string eventSubscriptionId, string token)
         {
             lock (_subscriptions)
             {
@@ -186,7 +186,7 @@ namespace WorkflowCore.Services
         {
         }
 
-        public async Task<string> CreateEvent(Event newEvent, CancellationToken _ = default)
+        public async Task<string> CreateEvent(Event newEvent)
         {
             lock (_events)
             {
@@ -196,7 +196,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task MarkEventProcessed(string id, CancellationToken _ = default)
+        public async Task MarkEventProcessed(string id)
         {
             lock (_events)
             {
@@ -238,7 +238,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task MarkEventUnprocessed(string id, CancellationToken _ = default)
+        public async Task MarkEventUnprocessed(string id)
         {
             lock (_events)
             {
@@ -250,7 +250,7 @@ namespace WorkflowCore.Services
             }
         }
 
-        public async Task PersistErrors(IEnumerable<ExecutionError> errors, CancellationToken _ = default)
+        public async Task PersistErrors(IEnumerable<ExecutionError> errors)
         {
             lock (errors)
             {

--- a/src/WorkflowCore/Services/DefaultProviders/TransientMemoryPersistenceProvider.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/TransientMemoryPersistenceProvider.cs
@@ -18,11 +18,11 @@ namespace WorkflowCore.Services
             _innerService = innerService;
         }
 
-        public Task<string> CreateEvent(Event newEvent, CancellationToken _ = default) => _innerService.CreateEvent(newEvent);
+        public Task<string> CreateEvent(Event newEvent) => _innerService.CreateEvent(newEvent);
 
-        public Task<string> CreateEventSubscription(EventSubscription subscription, CancellationToken _ = default) => _innerService.CreateEventSubscription(subscription);
+        public Task<string> CreateEventSubscription(EventSubscription subscription) => _innerService.CreateEventSubscription(subscription);
 
-        public Task<string> CreateNewWorkflow(WorkflowInstance workflow, CancellationToken _ = default) => _innerService.CreateNewWorkflow(workflow);
+        public Task<string> CreateNewWorkflow(WorkflowInstance workflow) => _innerService.CreateNewWorkflow(workflow);
 
         public void EnsureStoreExists() => _innerService.EnsureStoreExists();
 
@@ -42,22 +42,22 @@ namespace WorkflowCore.Services
 
         public Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(WorkflowStatus? status, string type, DateTime? createdFrom, DateTime? createdTo, int skip, int take) => _innerService.GetWorkflowInstances(status, type, createdFrom, createdTo, skip, take);
 
-        public Task MarkEventProcessed(string id, CancellationToken _ = default) => _innerService.MarkEventProcessed(id);
+        public Task MarkEventProcessed(string id) => _innerService.MarkEventProcessed(id);
 
-        public Task MarkEventUnprocessed(string id, CancellationToken _ = default) => _innerService.MarkEventUnprocessed(id);
+        public Task MarkEventUnprocessed(string id) => _innerService.MarkEventUnprocessed(id);
 
-        public Task PersistErrors(IEnumerable<ExecutionError> errors, CancellationToken _ = default) => _innerService.PersistErrors(errors);
+        public Task PersistErrors(IEnumerable<ExecutionError> errors) => _innerService.PersistErrors(errors);
 
-        public Task PersistWorkflow(WorkflowInstance workflow, CancellationToken _ = default) => _innerService.PersistWorkflow(workflow);
+        public Task PersistWorkflow(WorkflowInstance workflow) => _innerService.PersistWorkflow(workflow);
 
-        public Task TerminateSubscription(string eventSubscriptionId, CancellationToken _ = default) => _innerService.TerminateSubscription(eventSubscriptionId);
+        public Task TerminateSubscription(string eventSubscriptionId) => _innerService.TerminateSubscription(eventSubscriptionId);
         public Task<EventSubscription> GetSubscription(string eventSubscriptionId, CancellationToken _ = default) => _innerService.GetSubscription(eventSubscriptionId);
 
         public Task<EventSubscription> GetFirstOpenSubscription(string eventName, string eventKey, DateTime asOf, CancellationToken _ = default) => _innerService.GetFirstOpenSubscription(eventName, eventKey, asOf);
 
-        public Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken _ = default) => _innerService.SetSubscriptionToken(eventSubscriptionId, token, workerId, expiry);
+        public Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry) => _innerService.SetSubscriptionToken(eventSubscriptionId, token, workerId, expiry);
 
-        public Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken _ = default) => _innerService.ClearSubscriptionToken(eventSubscriptionId, token);
+        public Task ClearSubscriptionToken(string eventSubscriptionId, string token) => _innerService.ClearSubscriptionToken(eventSubscriptionId, token);
 
         public Task ScheduleCommand(ScheduledCommand command)
         {

--- a/src/WorkflowCore/Services/SyncWorkflowRunner.cs
+++ b/src/WorkflowCore/Services/SyncWorkflowRunner.cs
@@ -72,7 +72,7 @@ namespace WorkflowCore.Services
             var id = Guid.NewGuid().ToString();
 
             if (persistSate)
-                id = await _persistenceStore.CreateNewWorkflow(wf, token);
+                id = await _persistenceStore.CreateNewWorkflow(wf);
             else
                 wf.Id = id;
 
@@ -89,7 +89,7 @@ namespace WorkflowCore.Services
                 {
                     await _executor.Execute(wf, token);
                     if (persistSate)
-                        await _persistenceStore.PersistWorkflow(wf, token);
+                        await _persistenceStore.PersistWorkflow(wf);
                 }
             }
             finally

--- a/src/providers/WorkflowCore.Persistence.EntityFramework/Services/EntityFrameworkPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.EntityFramework/Services/EntityFrameworkPersistenceProvider.cs
@@ -26,26 +26,26 @@ namespace WorkflowCore.Persistence.EntityFramework.Services
             _canMigrateDB = canMigrateDB;
         }
 
-        public async Task<string> CreateEventSubscription(EventSubscription subscription, CancellationToken cancellationToken = default)
+        public async Task<string> CreateEventSubscription(EventSubscription subscription)
         {
             using (var db = ConstructDbContext())
             {
                 subscription.Id = Guid.NewGuid().ToString();
                 var persistable = subscription.ToPersistable();
                 var result = db.Set<PersistedSubscription>().Add(persistable);
-                await db.SaveChangesAsync(cancellationToken);
+                await db.SaveChangesAsync();
                 return subscription.Id;
             }
         }
 
-        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken = default)
+        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow)
         {
             using (var db = ConstructDbContext())
             {
                 workflow.Id = Guid.NewGuid().ToString();
                 var persistable = workflow.ToPersistable();
                 var result = db.Set<PersistedWorkflow>().Add(persistable);
-                await db.SaveChangesAsync(cancellationToken);
+                await db.SaveChangesAsync();
                 return workflow.Id;
             }
         }
@@ -134,7 +134,7 @@ namespace WorkflowCore.Persistence.EntityFramework.Services
             }
         }
 
-        public async Task PersistWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken = default)
+        public async Task PersistWorkflow(WorkflowInstance workflow)
         {
             using (var db = ConstructDbContext())
             {
@@ -145,21 +145,21 @@ namespace WorkflowCore.Persistence.EntityFramework.Services
                     .ThenInclude(ep => ep.ExtensionAttributes)
                     .Include(wf => wf.ExecutionPointers)
                     .AsTracking()
-                    .FirstAsync(cancellationToken);
+                    .FirstAsync();
 
                 var persistable = workflow.ToPersistable(existingEntity);
-                await db.SaveChangesAsync(cancellationToken);
+                await db.SaveChangesAsync();
             }
         }
 
-        public async Task TerminateSubscription(string eventSubscriptionId, CancellationToken cancellationToken = default)
+        public async Task TerminateSubscription(string eventSubscriptionId)
         {
             using (var db = ConstructDbContext())
             {
                 var uid = new Guid(eventSubscriptionId);
-                var existing = await db.Set<PersistedSubscription>().FirstAsync(x => x.SubscriptionId == uid, cancellationToken);
+                var existing = await db.Set<PersistedSubscription>().FirstAsync(x => x.SubscriptionId == uid);
                 db.Set<PersistedSubscription>().Remove(existing);
-                await db.SaveChangesAsync(cancellationToken);
+                await db.SaveChangesAsync();
             }
         }
 
@@ -194,14 +194,14 @@ namespace WorkflowCore.Persistence.EntityFramework.Services
             }
         }
 
-        public async Task<string> CreateEvent(Event newEvent, CancellationToken cancellationToken = default)
+        public async Task<string> CreateEvent(Event newEvent)
         {
             using (var db = ConstructDbContext())
             {
                 newEvent.Id = Guid.NewGuid().ToString();
                 var persistable = newEvent.ToPersistable();
                 var result = db.Set<PersistedEvent>().Add(persistable);
-                await db.SaveChangesAsync(cancellationToken);
+                await db.SaveChangesAsync();
                 return newEvent.Id;
             }
         }
@@ -237,7 +237,7 @@ namespace WorkflowCore.Persistence.EntityFramework.Services
             }
         }
 
-        public async Task MarkEventProcessed(string id, CancellationToken cancellationToken = default)
+        public async Task MarkEventProcessed(string id)
         {
             using (var db = ConstructDbContext())
             {
@@ -245,10 +245,10 @@ namespace WorkflowCore.Persistence.EntityFramework.Services
                 var existingEntity = await db.Set<PersistedEvent>()
                     .Where(x => x.EventId == uid)
                     .AsTracking()
-                    .FirstAsync(cancellationToken);
+                    .FirstAsync();
 
                 existingEntity.IsProcessed = true;
-                await db.SaveChangesAsync(cancellationToken);
+                await db.SaveChangesAsync();
             }
         }
 
@@ -271,7 +271,7 @@ namespace WorkflowCore.Persistence.EntityFramework.Services
             }
         }
 
-        public async Task MarkEventUnprocessed(string id, CancellationToken cancellationToken = default)
+        public async Task MarkEventUnprocessed(string id)
         {
             using (var db = ConstructDbContext())
             {
@@ -279,14 +279,14 @@ namespace WorkflowCore.Persistence.EntityFramework.Services
                 var existingEntity = await db.Set<PersistedEvent>()
                     .Where(x => x.EventId == uid)
                     .AsTracking()
-                    .FirstAsync(cancellationToken);
+                    .FirstAsync();
 
                 existingEntity.IsProcessed = false;
-                await db.SaveChangesAsync(cancellationToken);
+                await db.SaveChangesAsync();
             }
         }
 
-        public async Task PersistErrors(IEnumerable<ExecutionError> errors, CancellationToken cancellationToken = default)
+        public async Task PersistErrors(IEnumerable<ExecutionError> errors)
         {
             using (var db = ConstructDbContext())
             {
@@ -297,7 +297,7 @@ namespace WorkflowCore.Persistence.EntityFramework.Services
                     {
                         db.Set<PersistedExecutionError>().Add(error.ToPersistable());
                     }
-                    await db.SaveChangesAsync(cancellationToken);
+                    await db.SaveChangesAsync();
 
                 }
             }
@@ -329,7 +329,7 @@ namespace WorkflowCore.Persistence.EntityFramework.Services
             }
         }
 
-        public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken cancellationToken = default)
+        public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry)
         {
             using (var db = ConstructDbContext())
             {
@@ -337,18 +337,18 @@ namespace WorkflowCore.Persistence.EntityFramework.Services
                 var existingEntity = await db.Set<PersistedSubscription>()
                     .Where(x => x.SubscriptionId == uid)
                     .AsTracking()
-                    .FirstAsync(cancellationToken);
+                    .FirstAsync();
 
                 existingEntity.ExternalToken = token;
                 existingEntity.ExternalWorkerId = workerId;
                 existingEntity.ExternalTokenExpiry = expiry;
-                await db.SaveChangesAsync(cancellationToken);
+                await db.SaveChangesAsync();
 
                 return true;
             }
         }
 
-        public async Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken cancellationToken = default)
+        public async Task ClearSubscriptionToken(string eventSubscriptionId, string token)
         {
             using (var db = ConstructDbContext())
             {
@@ -356,7 +356,7 @@ namespace WorkflowCore.Persistence.EntityFramework.Services
                 var existingEntity = await db.Set<PersistedSubscription>()
                     .Where(x => x.SubscriptionId == uid)
                     .AsTracking()
-                    .FirstAsync(cancellationToken);
+                    .FirstAsync();
                 
                 if (existingEntity.ExternalToken != token)
                     throw new InvalidOperationException();
@@ -364,7 +364,7 @@ namespace WorkflowCore.Persistence.EntityFramework.Services
                 existingEntity.ExternalToken = null;
                 existingEntity.ExternalWorkerId = null;
                 existingEntity.ExternalTokenExpiry = null;
-                await db.SaveChangesAsync(cancellationToken);
+                await db.SaveChangesAsync();
             }
         }
 

--- a/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
@@ -138,15 +138,15 @@ namespace WorkflowCore.Persistence.MongoDB.Services
 
         private IMongoCollection<ScheduledCommand> ScheduledCommands => _database.GetCollection<ScheduledCommand>("wfc.scheduled_commands");
 
-        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken = default)
+        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow)
         {
-            await WorkflowInstances.InsertOneAsync(workflow, cancellationToken: cancellationToken);
+            await WorkflowInstances.InsertOneAsync(workflow);
             return workflow.Id;
         }
 
-        public async Task PersistWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken = default)
+        public async Task PersistWorkflow(WorkflowInstance workflow)
         {
-            await WorkflowInstances.ReplaceOneAsync(x => x.Id == workflow.Id, workflow, cancellationToken: cancellationToken);
+            await WorkflowInstances.ReplaceOneAsync(x => x.Id == workflow.Id, workflow);
         }
 
         public async Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt, CancellationToken cancellationToken = default)
@@ -195,15 +195,15 @@ namespace WorkflowCore.Persistence.MongoDB.Services
             return await result.Skip(skip).Take(take).ToListAsync();
         }
 
-        public async Task<string> CreateEventSubscription(EventSubscription subscription, CancellationToken cancellationToken = default)
+        public async Task<string> CreateEventSubscription(EventSubscription subscription)
         {
-            await EventSubscriptions.InsertOneAsync(subscription, cancellationToken: cancellationToken);
+            await EventSubscriptions.InsertOneAsync(subscription);
             return subscription.Id;
         }
 
-        public async Task TerminateSubscription(string eventSubscriptionId, CancellationToken cancellationToken = default)
+        public async Task TerminateSubscription(string eventSubscriptionId)
         {
-            await EventSubscriptions.DeleteOneAsync(x => x.Id == eventSubscriptionId, cancellationToken);
+            await EventSubscriptions.DeleteOneAsync(x => x.Id == eventSubscriptionId);
         }
 
         public async Task<EventSubscription> GetSubscription(string eventSubscriptionId, CancellationToken cancellationToken = default)
@@ -220,25 +220,25 @@ namespace WorkflowCore.Persistence.MongoDB.Services
             return await query.FirstOrDefaultAsync(cancellationToken);
         }
 
-        public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken cancellationToken = default)
+        public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry)
         {
             var update = Builders<EventSubscription>.Update
                 .Set(x => x.ExternalToken, token)
                 .Set(x => x.ExternalTokenExpiry, expiry)
                 .Set(x => x.ExternalWorkerId, workerId);
 
-            var result = await EventSubscriptions.UpdateOneAsync(x => x.Id == eventSubscriptionId && x.ExternalToken == null, update, cancellationToken: cancellationToken);
+            var result = await EventSubscriptions.UpdateOneAsync(x => x.Id == eventSubscriptionId && x.ExternalToken == null, update);
             return (result.ModifiedCount > 0);
         }
 
-        public async Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken cancellationToken = default)
+        public async Task ClearSubscriptionToken(string eventSubscriptionId, string token)
         {
             var update = Builders<EventSubscription>.Update
                 .Set(x => x.ExternalToken, null)
                 .Set(x => x.ExternalTokenExpiry, null)
                 .Set(x => x.ExternalWorkerId, null);
 
-            await EventSubscriptions.UpdateOneAsync(x => x.Id == eventSubscriptionId && x.ExternalToken == token, update, cancellationToken: cancellationToken);
+            await EventSubscriptions.UpdateOneAsync(x => x.Id == eventSubscriptionId && x.ExternalToken == token, update);
         }
 
         public void EnsureStoreExists()
@@ -254,9 +254,9 @@ namespace WorkflowCore.Persistence.MongoDB.Services
             return await query.ToListAsync(cancellationToken);
         }
 
-        public async Task<string> CreateEvent(Event newEvent, CancellationToken cancellationToken = default)
+        public async Task<string> CreateEvent(Event newEvent)
         {
-            await Events.InsertOneAsync(newEvent, cancellationToken: cancellationToken);
+            await Events.InsertOneAsync(newEvent);
             return newEvent.Id;
         }
 
@@ -276,12 +276,12 @@ namespace WorkflowCore.Persistence.MongoDB.Services
             return await query.ToListAsync(cancellationToken);
         }
 
-        public async Task MarkEventProcessed(string id, CancellationToken cancellationToken = default)
+        public async Task MarkEventProcessed(string id)
         {
             var update = Builders<Event>.Update
                 .Set(x => x.IsProcessed, true);
 
-            await Events.UpdateOneAsync(x => x.Id == id, update, cancellationToken: cancellationToken);
+            await Events.UpdateOneAsync(x => x.Id == id, update);
         }
 
         public async Task<IEnumerable<string>> GetEvents(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken)
@@ -293,18 +293,18 @@ namespace WorkflowCore.Persistence.MongoDB.Services
             return await query.ToListAsync(cancellationToken);
         }
 
-        public async Task MarkEventUnprocessed(string id, CancellationToken cancellationToken = default)
+        public async Task MarkEventUnprocessed(string id)
         {
             var update = Builders<Event>.Update
                 .Set(x => x.IsProcessed, false);
 
-            await Events.UpdateOneAsync(x => x.Id == id, update, cancellationToken: cancellationToken);
+            await Events.UpdateOneAsync(x => x.Id == id, update);
         }
 
-        public async Task PersistErrors(IEnumerable<ExecutionError> errors, CancellationToken cancellationToken = default)
+        public async Task PersistErrors(IEnumerable<ExecutionError> errors)
         {
             if (errors.Any())
-                await ExecutionErrors.InsertManyAsync(errors, cancellationToken: cancellationToken);
+                await ExecutionErrors.InsertManyAsync(errors);
         }
 
         public bool SupportsScheduledCommands => true;

--- a/src/providers/WorkflowCore.Persistence.MySQL/MysqlContext.cs
+++ b/src/providers/WorkflowCore.Persistence.MySQL/MysqlContext.cs
@@ -23,7 +23,7 @@ namespace WorkflowCore.Persistence.MySQL
             base.OnConfiguring(optionsBuilder);
 #if NETSTANDARD2_0
             optionsBuilder.UseMySql(_connectionString, _mysqlOptionsAction);
-#elif NETSTANDARD2_1_OR_GREATER
+#else
             optionsBuilder.UseMySql(_connectionString, ServerVersion.AutoDetect(_connectionString), _mysqlOptionsAction);
 #endif
         }

--- a/src/providers/WorkflowCore.Persistence.RavenDB/Services/RavendbPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.RavenDB/Services/RavendbPersistenceProvider.cs
@@ -41,18 +41,18 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 			}
 		}
 
-		public async Task<string> CreateNewWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken = default)
+		public async Task<string> CreateNewWorkflow(WorkflowInstance workflow)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
-				await session.StoreAsync(workflow, cancellationToken);
+				await session.StoreAsync(workflow);
 				var id = workflow.Id;
-				await session.SaveChangesAsync(cancellationToken);
+				await session.SaveChangesAsync();
 				return id;
 			}
 		}
 
-		public async Task PersistWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken = default)
+		public async Task PersistWorkflow(WorkflowInstance workflow)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
@@ -67,7 +67,7 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 				session.Advanced.Patch<WorkflowInstance, DateTime>(workflow.Id, x => x.CreateTime, workflow.CreateTime);
 				session.Advanced.Patch<WorkflowInstance, DateTime?>(workflow.Id, x => x.CompleteTime, workflow.CompleteTime);
 
-				await session.SaveChangesAsync(cancellationToken);
+				await session.SaveChangesAsync();
 			}
 		}
 
@@ -130,18 +130,18 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 			}
 		}
 
-		public async Task<string> CreateEventSubscription(EventSubscription subscription, CancellationToken cancellationToken = default)
+		public async Task<string> CreateEventSubscription(EventSubscription subscription)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
-				await session.StoreAsync(subscription, cancellationToken);
+				await session.StoreAsync(subscription);
 				var id = subscription.Id;
-				await session.SaveChangesAsync(cancellationToken);
+				await session.SaveChangesAsync();
 				return id;
 			}
 		}
 
-		public async Task TerminateSubscription(string eventSubscriptionId, CancellationToken _ = default)
+		public async Task TerminateSubscription(string eventSubscriptionId)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
@@ -174,7 +174,7 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 			}
 		}
 
-		public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken cancellationToken = default)
+		public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry)
 		{
 			try
 			{
@@ -189,7 +189,7 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 				strbuilder.Append($"e.ExternalWorkerId = 'workerId'");
 				strbuilder.Append("}");
 
-				var operation = await _database.Operations.SendAsync(new PatchByQueryOperation(strbuilder.ToString()), token: cancellationToken);
+				var operation = await _database.Operations.SendAsync(new PatchByQueryOperation(strbuilder.ToString()));
 				operation.WaitForCompletion();
 				return true;
 			}
@@ -199,7 +199,7 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 			}
 		}
 
-		public async Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken cancellationToken = default)
+		public async Task ClearSubscriptionToken(string eventSubscriptionId, string token)
 		{
 			try
 			{
@@ -214,7 +214,7 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 				strbuilder.Append($"e.ExternalWorkerId = null");
 				strbuilder.Append("}");
 
-				var operation = await _database.Operations.SendAsync(new PatchByQueryOperation(strbuilder.ToString()), token: cancellationToken);
+				var operation = await _database.Operations.SendAsync(new PatchByQueryOperation(strbuilder.ToString()));
 				operation.WaitForCompletion();
 			}
 			catch (Exception e)
@@ -239,13 +239,13 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 			}
 		}
 
-		public async Task<string> CreateEvent(Event newEvent, CancellationToken cancellationToken = default)
+		public async Task<string> CreateEvent(Event newEvent)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
-				await session.StoreAsync(newEvent, cancellationToken);
+				await session.StoreAsync(newEvent);
 				var id = newEvent.Id;
-				await session.SaveChangesAsync(cancellationToken);
+				await session.SaveChangesAsync();
 				return id;
 			}
 		}
@@ -272,13 +272,13 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 			}
 		}
 
-		public async Task MarkEventProcessed(string id, CancellationToken cancellationToken = default)
+		public async Task MarkEventProcessed(string id)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
 				session.Advanced.Patch<Event, bool>(id, x => x.IsProcessed, true);
 
-				await session.SaveChangesAsync(cancellationToken);
+				await session.SaveChangesAsync();
 			}
 		}
 
@@ -297,21 +297,21 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 			}
 		}
 
-		public async Task MarkEventUnprocessed(string id, CancellationToken cancellationToken = default)
+		public async Task MarkEventUnprocessed(string id)
 		{
 			using (var session = _database.OpenAsyncSession())
 			{
 				session.Advanced.Patch<Event, bool>(id, x => x.IsProcessed, false);
 
-				await session.SaveChangesAsync(cancellationToken);
+				await session.SaveChangesAsync();
 			}
 		}
 
-		public async Task PersistErrors(IEnumerable<ExecutionError> errors, CancellationToken cancellationToken = default)
+		public async Task PersistErrors(IEnumerable<ExecutionError> errors)
 		{
 			if (errors.Any())
 			{
-				var blk = _database.BulkInsert(token: cancellationToken);
+				var blk = _database.BulkInsert();
 				foreach (var error in errors)
 					await blk.StoreAsync(error);
 

--- a/src/providers/WorkflowCore.Providers.AWS/Services/DynamoPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/Services/DynamoPersistenceProvider.cs
@@ -34,7 +34,7 @@ namespace WorkflowCore.Providers.AWS.Services
             _provisioner = provisioner;
         }
 
-        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken = default)
+        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow)
         {
             workflow.Id = Guid.NewGuid().ToString();
 
@@ -45,12 +45,12 @@ namespace WorkflowCore.Providers.AWS.Services
                 ConditionExpression = "attribute_not_exists(id)"
             };
 
-            var _ = await _client.PutItemAsync(req, cancellationToken);
+            var _ = await _client.PutItemAsync(req);
 
             return workflow.Id;
         }
 
-        public async Task PersistWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken = default)
+        public async Task PersistWorkflow(WorkflowInstance workflow)
         {
             var request = new PutItemRequest
             {
@@ -58,7 +58,7 @@ namespace WorkflowCore.Providers.AWS.Services
                 Item = workflow.ToDynamoMap()
             };
 
-            var response = await _client.PutItemAsync(request, cancellationToken);
+            var response = await _client.PutItemAsync(request);
         }
 
         public async Task<IEnumerable<string>> GetRunnableInstances(DateTime asAt, CancellationToken cancellationToken = default)
@@ -163,7 +163,7 @@ namespace WorkflowCore.Providers.AWS.Services
             return result.Select(i => i.ToWorkflowInstance());
         }
 
-        public async Task<string> CreateEventSubscription(EventSubscription subscription, CancellationToken cancellationToken = default)
+        public async Task<string> CreateEventSubscription(EventSubscription subscription)
         {
             subscription.Id = Guid.NewGuid().ToString();
 
@@ -174,7 +174,7 @@ namespace WorkflowCore.Providers.AWS.Services
                 ConditionExpression = "attribute_not_exists(id)"
             };
 
-            var response = await _client.PutItemAsync(req, cancellationToken);
+            var response = await _client.PutItemAsync(req);
 
             return subscription.Id;
         }
@@ -215,7 +215,7 @@ namespace WorkflowCore.Providers.AWS.Services
             return result;
         }
 
-        public async Task TerminateSubscription(string eventSubscriptionId, CancellationToken cancellationToken = default)
+        public async Task TerminateSubscription(string eventSubscriptionId)
         {
             var request = new DeleteItemRequest
             {
@@ -225,10 +225,10 @@ namespace WorkflowCore.Providers.AWS.Services
                     { "id", new AttributeValue(eventSubscriptionId) }
                 }
             };
-            await _client.DeleteItemAsync(request, cancellationToken);
+            await _client.DeleteItemAsync(request);
         }
 
-        public async Task<string> CreateEvent(Event newEvent, CancellationToken cancellationToken = default)
+        public async Task<string> CreateEvent(Event newEvent)
         {
             newEvent.Id = Guid.NewGuid().ToString();
 
@@ -239,7 +239,7 @@ namespace WorkflowCore.Providers.AWS.Services
                 ConditionExpression = "attribute_not_exists(id)"
             };
 
-            var _ = await _client.PutItemAsync(req, cancellationToken);
+            var _ = await _client.PutItemAsync(req);
 
             return newEvent.Id;
         }
@@ -329,7 +329,7 @@ namespace WorkflowCore.Providers.AWS.Services
             return result;
         }
 
-        public async Task MarkEventProcessed(string id, CancellationToken cancellationToken = default)
+        public async Task MarkEventProcessed(string id)
         {
             var request = new UpdateItemRequest
             {
@@ -340,10 +340,10 @@ namespace WorkflowCore.Providers.AWS.Services
                 },
                 UpdateExpression = "REMOVE not_processed"
             };
-            await _client.UpdateItemAsync(request, cancellationToken);
+            await _client.UpdateItemAsync(request);
         }
 
-        public async Task MarkEventUnprocessed(string id, CancellationToken cancellationToken = default)
+        public async Task MarkEventUnprocessed(string id)
         {
             var request = new UpdateItemRequest
             {
@@ -358,10 +358,10 @@ namespace WorkflowCore.Providers.AWS.Services
                     { ":n" , new AttributeValue { N = 1.ToString() } }
                 }
             };
-            await _client.UpdateItemAsync(request, cancellationToken);
+            await _client.UpdateItemAsync(request);
         }
 
-        public Task PersistErrors(IEnumerable<ExecutionError> errors, CancellationToken _ = default)
+        public Task PersistErrors(IEnumerable<ExecutionError> errors)
         {
             //TODO
             return Task.CompletedTask;
@@ -423,7 +423,7 @@ namespace WorkflowCore.Providers.AWS.Services
             return result.FirstOrDefault();
         }
 
-        public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken cancellationToken = default)
+        public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry)
         {
             var request = new UpdateItemRequest
             {
@@ -443,7 +443,7 @@ namespace WorkflowCore.Providers.AWS.Services
             };
             try
             {
-                await _client.UpdateItemAsync(request, cancellationToken);
+                await _client.UpdateItemAsync(request);
                 return true;
             }
             catch (ConditionalCheckFailedException)
@@ -452,7 +452,7 @@ namespace WorkflowCore.Providers.AWS.Services
             }
         }
 
-        public async Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken cancellationToken = default)
+        public async Task ClearSubscriptionToken(string eventSubscriptionId, string token)
         {
             var request = new UpdateItemRequest
             {
@@ -469,7 +469,7 @@ namespace WorkflowCore.Providers.AWS.Services
                 }
             };
             
-            await _client.UpdateItemAsync(request, cancellationToken);
+            await _client.UpdateItemAsync(request);
         }
 
         public Task ScheduleCommand(ScheduledCommand command)

--- a/src/providers/WorkflowCore.Providers.Azure/Services/CosmosDbPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Providers.Azure/Services/CosmosDbPersistenceProvider.cs
@@ -37,7 +37,7 @@ namespace WorkflowCore.Providers.Azure.Services
 
         public bool SupportsScheduledCommands => false;
 
-        public async Task ClearSubscriptionToken(string eventSubscriptionId, string token, CancellationToken cancellationToken = default)
+        public async Task ClearSubscriptionToken(string eventSubscriptionId, string token)
         {
             var existing = await _subscriptionContainer.Value.ReadItemAsync<PersistedSubscription>(eventSubscriptionId, new PartitionKey(eventSubscriptionId));
             
@@ -47,27 +47,27 @@ namespace WorkflowCore.Providers.Azure.Services
             existing.Resource.ExternalWorkerId = null;
             existing.Resource.ExternalTokenExpiry = null;
 
-            await _subscriptionContainer.Value.ReplaceItemAsync(existing.Resource, eventSubscriptionId, cancellationToken: cancellationToken);
+            await _subscriptionContainer.Value.ReplaceItemAsync(existing.Resource, eventSubscriptionId);
         }
 
-        public async Task<string> CreateEvent(Event newEvent, CancellationToken cancellationToken)
+        public async Task<string> CreateEvent(Event newEvent)
         {
             newEvent.Id = Guid.NewGuid().ToString();
-            var result = await _eventContainer.Value.CreateItemAsync(PersistedEvent.FromInstance(newEvent), cancellationToken: cancellationToken);
+            var result = await _eventContainer.Value.CreateItemAsync(PersistedEvent.FromInstance(newEvent));
             return result.Resource.id;
         }
 
-        public async Task<string> CreateEventSubscription(EventSubscription subscription, CancellationToken cancellationToken)
+        public async Task<string> CreateEventSubscription(EventSubscription subscription)
         {
             subscription.Id = Guid.NewGuid().ToString();
-            var result = await _subscriptionContainer.Value.CreateItemAsync(PersistedSubscription.FromInstance(subscription), cancellationToken: cancellationToken);
+            var result = await _subscriptionContainer.Value.CreateItemAsync(PersistedSubscription.FromInstance(subscription));
             return result.Resource.id;
         }
 
-        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken)
+        public async Task<string> CreateNewWorkflow(WorkflowInstance workflow)
         {
             workflow.Id = Guid.NewGuid().ToString();
-            var result = await _workflowContainer.Value.CreateItemAsync(PersistedWorkflow.FromInstance(workflow), cancellationToken: cancellationToken);
+            var result = await _workflowContainer.Value.CreateItemAsync(PersistedWorkflow.FromInstance(workflow));
             return result.Resource.id;
         }
 
@@ -203,28 +203,28 @@ namespace WorkflowCore.Providers.Azure.Services
             throw new NotImplementedException();
         }
 
-        public async Task MarkEventProcessed(string id, CancellationToken cancellationToken)
+        public async Task MarkEventProcessed(string id)
         {
-            var evt = await _eventContainer.Value.ReadItemAsync<PersistedEvent>(id, new PartitionKey(id), cancellationToken: cancellationToken);
+            var evt = await _eventContainer.Value.ReadItemAsync<PersistedEvent>(id, new PartitionKey(id));
             evt.Resource.IsProcessed = true;
-            await _eventContainer.Value.ReplaceItemAsync(evt.Resource, id, cancellationToken: cancellationToken);
+            await _eventContainer.Value.ReplaceItemAsync(evt.Resource, id);
         }
 
-        public async Task MarkEventUnprocessed(string id, CancellationToken cancellationToken)
+        public async Task MarkEventUnprocessed(string id)
         {
-            var evt = await _eventContainer.Value.ReadItemAsync<PersistedEvent>(id, new PartitionKey(id), cancellationToken: cancellationToken);
+            var evt = await _eventContainer.Value.ReadItemAsync<PersistedEvent>(id, new PartitionKey(id));
             evt.Resource.IsProcessed = false;
-            await _eventContainer.Value.ReplaceItemAsync(evt.Resource, id, cancellationToken: cancellationToken);
+            await _eventContainer.Value.ReplaceItemAsync(evt.Resource, id);
         }
 
-        public Task PersistErrors(IEnumerable<ExecutionError> errors, CancellationToken _ = default)
+        public Task PersistErrors(IEnumerable<ExecutionError> errors)
         {
             return Task.CompletedTask;
         }
 
-        public async Task PersistWorkflow(WorkflowInstance workflow, CancellationToken cancellationToken)
+        public async Task PersistWorkflow(WorkflowInstance workflow)
         {
-            await _workflowContainer.Value.UpsertItemAsync(PersistedWorkflow.FromInstance(workflow), cancellationToken: cancellationToken);
+            await _workflowContainer.Value.UpsertItemAsync(PersistedWorkflow.FromInstance(workflow));
         }
 
         public Task ProcessCommands(DateTimeOffset asOf, Func<ScheduledCommand, Task> action, CancellationToken cancellationToken = default)
@@ -237,22 +237,22 @@ namespace WorkflowCore.Providers.Azure.Services
             throw new NotImplementedException();
         }
 
-        public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry, CancellationToken cancellationToken)
+        public async Task<bool> SetSubscriptionToken(string eventSubscriptionId, string token, string workerId, DateTime expiry)
         {
-            var sub = await _subscriptionContainer.Value.ReadItemAsync<PersistedSubscription>(eventSubscriptionId, new PartitionKey(eventSubscriptionId), cancellationToken: cancellationToken);
+            var sub = await _subscriptionContainer.Value.ReadItemAsync<PersistedSubscription>(eventSubscriptionId, new PartitionKey(eventSubscriptionId));
             var existingEntity = sub.Resource;
             existingEntity.ExternalToken = token;
             existingEntity.ExternalWorkerId = workerId;
             existingEntity.ExternalTokenExpiry = expiry;
             
-            await _subscriptionContainer.Value.ReplaceItemAsync(existingEntity, eventSubscriptionId, cancellationToken: cancellationToken);
+            await _subscriptionContainer.Value.ReplaceItemAsync(existingEntity, eventSubscriptionId);
 
             return true;
         }
 
-        public async Task TerminateSubscription(string eventSubscriptionId, CancellationToken cancellationToken)
+        public async Task TerminateSubscription(string eventSubscriptionId)
         {
-            await _subscriptionContainer.Value.DeleteItemAsync<PersistedSubscription>(eventSubscriptionId, new PartitionKey(eventSubscriptionId), cancellationToken: cancellationToken);
+            await _subscriptionContainer.Value.DeleteItemAsync<PersistedSubscription>(eventSubscriptionId, new PartitionKey(eventSubscriptionId));
         }
     }
 }

--- a/test/Docker.Testify/Docker.Testify.csproj
+++ b/test/Docker.Testify/Docker.Testify.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Docker.DotNet" Version="3.125.2" />
+    <PackageReference Include="Docker.DotNet" Version="3.125.10" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />

--- a/test/WorkflowCore.IntegrationTests/Scenarios/StopScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/StopScenario.cs
@@ -1,0 +1,52 @@
+﻿using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using Xunit;
+using FluentAssertions;
+using WorkflowCore.Testing;
+using WorkflowCore.Models.LifeCycleEvents;
+using System.Threading.Tasks;
+using System.Threading;
+using Moq;
+
+namespace WorkflowCore.IntegrationTests.Scenarios
+{
+    public class StopScenario : WorkflowTest<StopScenario.StopWorkflow, object>
+    {
+        public class StopWorkflow : IWorkflow
+        {
+            public string Id => "StopWorkflow";
+            public int Version => 1;
+            public void Build(IWorkflowBuilder<object> builder)
+            {
+                builder.StartWith(context => ExecutionResult.Next());                    
+            }
+        }
+
+        public StopScenario()
+        {
+            Setup();
+        }
+
+        [Fact]
+        public async Task Scenario()
+        {
+            var tcs = new TaskCompletionSource<object>();
+            Host.OnLifeCycleEvent += (evt) => OnLifeCycleEvent(evt, tcs);
+            var workflowId = StartWorkflow(null);
+
+            await tcs.Task;
+            GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
+        }
+
+        private async void OnLifeCycleEvent(LifeCycleEvent evt, TaskCompletionSource<object> tcs)
+        {
+            if (evt is WorkflowCompleted)
+            {
+                await Host.StopAsync(CancellationToken.None);
+                tcs.SetResult(new());
+            }
+        }
+
+        protected override void Dispose(bool disposing) { }
+    }
+}

--- a/test/WorkflowCore.Tests.DynamoDB/Scenarios/DynamoStopScenario.cs
+++ b/test/WorkflowCore.Tests.DynamoDB/Scenarios/DynamoStopScenario.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Amazon.DynamoDBv2;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using Xunit;
+
+namespace WorkflowCore.Tests.DynamoDB.Scenarios
+{
+    [Collection("DynamoDb collection")]
+    public class DynamoStopScenario : StopScenario
+    {        
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            var cfg = new AmazonDynamoDBConfig {ServiceURL = DynamoDbDockerSetup.ConnectionString};
+            services.AddWorkflow(x => x.UseAwsDynamoPersistence(DynamoDbDockerSetup.Credentials, cfg, "tests-"));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.MongoDB/Scenarios/MongoStopScenario.cs
+++ b/test/WorkflowCore.Tests.MongoDB/Scenarios/MongoStopScenario.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using Xunit;
+
+namespace WorkflowCore.Tests.MongoDB.Scenarios
+{
+    [Collection("Mongo collection")]
+    public class MongoStopScenario : StopScenario
+    {        
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseMongoDB(MongoDockerSetup.ConnectionString, "integration-tests"));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlStopScenario.cs
+++ b/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlStopScenario.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using Xunit;
+
+namespace WorkflowCore.Tests.MySQL.Scenarios
+{
+    [Collection("Mysql collection")]
+    public class MysqlStopScenario : StopScenario
+    {
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseMySQL(MysqlDockerSetup.ScenarioConnectionString, true, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.PostgreSQL/Scenarios/PostgresStopScenario.cs
+++ b/test/WorkflowCore.Tests.PostgreSQL/Scenarios/PostgresStopScenario.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using Xunit;
+
+namespace WorkflowCore.Tests.PostgreSQL.Scenarios
+{
+    [Collection("Postgres collection")]
+    public class PostgresStopScenario : StopScenario
+    {        
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UsePostgreSQL(PostgresDockerSetup.ScenarioConnectionString, true, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.Redis/Scenarios/RedisStopScenario.cs
+++ b/test/WorkflowCore.Tests.Redis/Scenarios/RedisStopScenario.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using Xunit;
+
+namespace WorkflowCore.Tests.Redis.Scenarios
+{
+    [Collection("Redis collection")]
+    public class RedisStopScenario : StopScenario
+    {        
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseRedisPersistence(RedisDockerSetup.ConnectionString, "scenario-"));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.SqlServer/Scenarios/SqlServerStopScenario.cs
+++ b/test/WorkflowCore.Tests.SqlServer/Scenarios/SqlServerStopScenario.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using Xunit;
+
+namespace WorkflowCore.Tests.SqlServer.Scenarios
+{
+    [Collection("SqlServer collection")]
+    public class SqlServerStopScenario : StopScenario
+    {        
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseSqlServer(SqlDockerSetup.ScenarioConnectionString, true, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.Sqlite/Scenarios/SqliteStopScenario.cs
+++ b/test/WorkflowCore.Tests.Sqlite/Scenarios/SqliteStopScenario.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using WorkflowCore.IntegrationTests.Scenarios;
+using WorkflowCore.Tests.Sqlite;
+using Xunit;
+
+namespace WorkflowCore.Tests.Sqlite.Scenarios
+{
+    [Collection("Sqlite collection")]
+    public class SqliteStopScenario : StopScenario
+    {
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWorkflow(x => x.UseSqlite(SqliteSetup.ConnectionString, true));
+        }
+    }
+}

--- a/test/WorkflowCore.Tests.Sqlite/SqliteCollection.cs
+++ b/test/WorkflowCore.Tests.Sqlite/SqliteCollection.cs
@@ -10,7 +10,7 @@ namespace WorkflowCore.Tests.Sqlite
 
     public class SqliteSetup : IDisposable
     {
-        public string ConnectionString { get; set; }
+        public static string ConnectionString { get; set; }
 
         public SqliteSetup()
         {

--- a/test/WorkflowCore.Tests.Sqlite/SqlitePersistenceProviderFixture.cs
+++ b/test/WorkflowCore.Tests.Sqlite/SqlitePersistenceProviderFixture.cs
@@ -10,18 +10,11 @@ namespace WorkflowCore.Tests.Sqlite
     [Collection("Sqlite collection")]
     public class SqlitePersistenceProviderFixture : BasePersistenceFixture
     {
-        string _connectionString;
-
-        public SqlitePersistenceProviderFixture(SqliteSetup setup)
-        {
-            _connectionString = setup.ConnectionString;
-        }
-
         protected override IPersistenceProvider Subject
         {
             get
-            {                
-                var db = new EntityFrameworkPersistenceProvider(new SqliteContextFactory(_connectionString), true, false);
+            {
+                var db = new EntityFrameworkPersistenceProvider(new SqliteContextFactory(SqliteSetup.ConnectionString), true, false);
                 db.EnsureStoreExists();
                 return db;
             }


### PR DESCRIPTION
**Describe the change**
Removed the `CancellationToken` parameter from all writing persistence operations. This prevents cancelling workflows or stopping the host from cancelling writing persistence operations and thus losing data.

Fixes #953
Fixes #1032 

**Describe your implementation or design**
Removed the `CancellationToken` parameter from all writing persistence operations. 

**Tests**
Yes. I reproduced the issue by adding a `StopScenario` for persistence providers. After the change, this scenario passes.

**Breaking change**
Yes. Removed `CancellationToken` parameter from multiple public methods.