### PR TITLE
Make QueueConsumer.Stop() idempotent

### DIFF
--- a/src/WorkflowCore/Services/BackgroundTasks/QueueConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/QueueConsumer.cs
@@ -53,8 +53,11 @@ namespace WorkflowCore.Services.BackgroundTasks
         public virtual void Stop()
         {
             _cancellationTokenSource.Cancel();
-            DispatchTask.Wait();
-            DispatchTask = null;
+            if (DispatchTask != null)
+            {
+                DispatchTask.Wait();
+                DispatchTask = null;
+            }
         }
 
         private async Task Execute()


### PR DESCRIPTION
**Describe the change**
Added a null check before calling `Wait()` on `DispatchTask`. This way, the `Stop()` method can be called multiple times.

**Describe your implementation or design**

**Tests**
No

**Breaking change**
No

**Additional context**
Fixes #1085 