### PR TITLE
externaltoken size fix

### DIFF
--- a/src/providers/WorkflowCore.Persistence.EntityFramework/Models/PersistedSubscription.cs
+++ b/src/providers/WorkflowCore.Persistence.EntityFramework/Models/PersistedSubscription.cs
@@ -30,7 +30,7 @@ namespace WorkflowCore.Persistence.EntityFramework.Models
 
         public string SubscriptionData { get; set; }
         
-        [MaxLength(200)]
+        [MaxLength(500)]
         public string ExternalToken { get; set; }
         
         [MaxLength(200)]

--- a/src/providers/WorkflowCore.Persistence.SqlServer/Migrations/20191221210710_Activities.cs
+++ b/src/providers/WorkflowCore.Persistence.SqlServer/Migrations/20191221210710_Activities.cs
@@ -18,7 +18,7 @@ namespace WorkflowCore.Persistence.SqlServer.Migrations
                 name: "ExternalToken",
                 schema: "wfc",
                 table: "Subscription",
-                maxLength: 200,
+                maxLength: 500,
                 nullable: true);
 
             migrationBuilder.AddColumn<DateTime>(

--- a/src/providers/WorkflowCore.Persistence.SqlServer/Migrations/SqlServerPersistenceProviderModelSnapshot.cs
+++ b/src/providers/WorkflowCore.Persistence.SqlServer/Migrations/SqlServerPersistenceProviderModelSnapshot.cs
@@ -250,8 +250,8 @@ namespace WorkflowCore.Persistence.SqlServer.Migrations
                         .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("ExternalToken")
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasMaxLength(500)
+                        .HasColumnType("nvarchar(500)");
 
                     b.Property<DateTime?>("ExternalTokenExpiry")
                         .HasColumnType("datetime2");


### PR DESCRIPTION
**Describe the change**
The [wfc].[Subscription].[ExternalToken] field is not long enough for the encoded string. As the string contains 3 guids converted to json and encoded to base64, it can be longer than 200 chars.

**Describe your implementation or design**
Increased the max size limit to 500 chars, in both migration files and model. I could not create a new migration. Some documentation might be helpful about how to create migrations.

**Tests**
No test created.

**Breaking change**
- 

**Additional context**
-