### PR TITLE
(Bug) Updated definition loader to evaluate children inputs

### DIFF
--- a/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
+++ b/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
@@ -400,20 +400,20 @@ namespace WorkflowCore.Services.DefinitionStorage
 
                     foreach (var child in subobj.Children())
                     {
-                        var jobj = destObj.SelectToken(child.Path);
+                        var childObject = destObj.SelectToken(child.Path);
 
-                        if (jobj is JObject)
+                        if (childObject is JObject)
                         {
-                            stack.Push(jobj as JObject);
+                            stack.Push(childObject as JObject);
                         }
-                        else if (jobj is JArray)
+                        else if (childObject is JArray)
                         {
-                            foreach (var obj in jobj as JArray)
+                            foreach (var item in childObject as JArray)
                             {
-                                var jobj2 = destObj.SelectToken(obj.Path);
-                                if (jobj2 is JObject)
+                                var elem = destObj.SelectToken(item.Path);
+                                if (elem is JObject)
                                 {
-                                    stack.Push(jobj2 as JObject);
+                                    stack.Push(elem as JObject);
                                 }
                             }
                         }

--- a/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
+++ b/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
@@ -398,12 +398,30 @@ namespace WorkflowCore.Services.DefinitionStorage
                         }
                     }
 
-                    foreach (var child in subobj.Children<JObject>())
-                        stack.Push(child);
+                    foreach (var child in subobj.Children())
+                    {
+                        var jobj = destObj.SelectToken(child.Path);
+
+                        if (jobj is JObject)
+                        {
+                            stack.Push(jobj as JObject);
+                        }
+                        else if (jobj is JArray)
+                        {
+                            foreach (var obj in jobj as JArray)
+                            {
+                                var jobj2 = destObj.SelectToken(obj.Path);
+                                if (jobj2 is JObject)
+                                {
+                                    stack.Push(jobj2 as JObject);
+                                }
+                            }
+                        }
+                    }
                 }
 
                 stepProperty.SetValue(pStep, destObj);
-            }
+            }   
             return acn;
         }
 

--- a/test/WorkflowCore.TestAssets/Steps/DynamicDataStep.cs
+++ b/test/WorkflowCore.TestAssets/Steps/DynamicDataStep.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json.Linq;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+
+namespace WorkflowCore.TestAssets.Steps
+{
+    public class DynamicDataStep : StepBody
+    {
+        public JObject DynamicData { get; set; }
+
+        public override ExecutionResult Run(IStepExecutionContext context)
+        {
+            return ExecutionResult.Next();
+        }
+    }
+}

--- a/test/WorkflowCore.TestAssets/stored-dynamic-definition.json
+++ b/test/WorkflowCore.TestAssets/stored-dynamic-definition.json
@@ -83,8 +83,26 @@
     {
       "Id": "Step4",
       "StepType": "WorkflowCore.TestAssets.Steps.Counter, WorkflowCore.TestAssets",
+      "NextStepId": "Step5",
       "Inputs": { "Value": "data[\"Counter6\"]" },
       "Outputs": { "Counter6": "step.Value" }
+    },
+    {
+      "Id": "Step5",
+      "StepType": "WorkflowCore.TestAssets.Steps.DynamicDataStep, WorkflowCore.TestAssets",
+      "Inputs": {
+        "DynamicData": {
+          "ComplexObject": {
+            "@Integer": "data[\"Counter1\"]",
+            "Array": [
+              {
+                "@Computed": "data[\"Counter6\"]"
+              },
+              "string"
+            ]
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
**Describe the change**
Updated the way of getting children of a JObject in order to evaluate expressions for inputs that have child elements.

**Describe your implementation or design**
Used the select token method in order to select the children then evaluate the type of the token before adding to the stack of JObjects.

**Tests**
Created a new step, DynamicDataStep that I have added into stored-dynamic-definition.json with a complex object in Inputs.

**Breaking change**
No, this is an added functionality on top. It is a bug fix because children items were not evaluated.

**Additional context**
We discovered the issue when working for a dynamic workflow solution for one of our clients.