### PR TITLE
[Bug] Fix MongoDB persist workflow when no subscription

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,10 +4,10 @@
     <PackageLicenseUrl>https://github.com/danielgerlag/workflow-core/blob/master/LICENSE.md</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/danielgerlag/workflow-core.git</RepositoryUrl>
-    <Version>3.8.0</Version>
-    <AssemblyVersion>3.8.0.0</AssemblyVersion>
-    <FileVersion>3.8.0.0</FileVersion>
+    <Version>3.8.1</Version>
+    <AssemblyVersion>3.8.1.0</AssemblyVersion>
+    <FileVersion>3.8.1.0</FileVersion>
     <PackageIconUrl>https://github.com/danielgerlag/workflow-core/raw/master/src/logo.png</PackageIconUrl>
-    <PackageVersion>3.8.0</PackageVersion>
+    <PackageVersion>3.8.1</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
@@ -55,7 +55,7 @@ namespace WorkflowCore.Services.BackgroundTasks
                     finally
                     {
                         WorkflowActivity.Enrich(result);
-                        await _persistenceStore.PersistWorkflow(workflow, result.Subscriptions, cancellationToken);
+                        await _persistenceStore.PersistWorkflow(workflow, result?.Subscriptions, cancellationToken);
                         await QueueProvider.QueueWork(itemId, QueueType.Index);
                         _greylist.Remove($"wf:{itemId}");
                     }

--- a/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
@@ -154,12 +154,18 @@ namespace WorkflowCore.Persistence.MongoDB.Services
 
         public async Task PersistWorkflow(WorkflowInstance workflow, List<EventSubscription> subscriptions, CancellationToken cancellationToken = default)
         {
-            using (var session = await _database.Client.StartSessionAsync())
+            if (subscriptions == null || subscriptions.Count < 1)
+            {
+                await PersistWorkflow(workflow, cancellationToken);
+                return;
+            }
+
+            using (var session = await _database.Client.StartSessionAsync(cancellationToken: cancellationToken))
             {
                 session.StartTransaction();
                 await PersistWorkflow(workflow, cancellationToken);
                 await EventSubscriptions.InsertManyAsync(subscriptions, cancellationToken: cancellationToken);
-                await session.CommitTransactionAsync();
+                await session.CommitTransactionAsync(cancellationToken);
             }
         }
 


### PR DESCRIPTION
MongoDB Driver is throwing an exception when saving a list with no item and in our case we don't have any `subscription`
```
System.ArgumentException: Must contain at least 1 request. (Parameter 'requests') at 
MongoDB.Driver.MongoCollectionImpl`1.BulkWriteAsync(IClientSessionHandle session, IEnumerable`1 requests, BulkWriteOptions options, CancellationToken cancellationToken) at 
MongoDB.Driver.MongoCollectionImpl`1.UsingImplicitSessionAsync[TResult](Func`2 funcAsync, CancellationToken cancellationToken) at 
WorkflowCore.Persistence.MongoDB.Services.MongoPersistenceProvider.PersistWorkflow(WorkflowInstance workflow, List`1 subscriptions, CancellationToken cancellationToken)
```