### PR TITLE
multi priority queues

### DIFF
--- a/src/WorkflowCore/Interface/IQueueProvider.cs
+++ b/src/WorkflowCore/Interface/IQueueProvider.cs
@@ -14,15 +14,17 @@ namespace WorkflowCore.Interface
         /// <summary>
         /// Enqueues work to be processed by a host in the cluster
         /// </summary>
-        /// <param name="Id"></param>
-        /// <returns></returns>
         Task QueueWork(string id, QueueType queue);
+
+        /// <summary>
+        /// Enqueues work to be processed by a host in the cluster
+        /// </summary>
+        Task QueueWork(string id, QueueType queue, QueuePriority priority);
 
         /// <summary>
         /// Fetches the next work item from the front of the process queue.
         /// If the queue is empty, NULL is returned
         /// </summary>
-        /// <returns></returns>
         Task<string> DequeueWork(QueueType queue, CancellationToken cancellationToken);
 
         bool IsDequeueBlocking { get; }
@@ -33,4 +35,5 @@ namespace WorkflowCore.Interface
     }
 
     public enum QueueType { Workflow = 0, Event = 1, Index = 2 }
+    public enum QueuePriority { Normal = 1, High = 3 }
 }

--- a/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
@@ -157,7 +157,7 @@ namespace WorkflowCore.Services.BackgroundTasks
                     await Task.Delay(TimeSpan.FromTicks(target), cancellationToken);
                 }
 
-                await QueueProvider.QueueWork(workflow.Id, QueueType.Workflow);
+                await QueueProvider.QueueWork(workflow.Id, QueueType.Workflow, QueuePriority.High);
             }
             catch (Exception ex)
             {

--- a/src/WorkflowCore/Services/DefaultProviders/SingleNodeQueueProvider.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/SingleNodeQueueProvider.cs
@@ -1,40 +1,65 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WorkflowCore.Interface;
 
 namespace WorkflowCore.Services
 {
-    #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-
     /// <summary>
     /// Single node in-memory implementation of IQueueProvider
     /// </summary>
     public class SingleNodeQueueProvider : IQueueProvider
     {
-        
-        private readonly Dictionary<QueueType, BlockingCollection<string>> _queues = new Dictionary<QueueType, BlockingCollection<string>>
+
+        private readonly Dictionary<(QueueType, QueuePriority), BlockingCollection<string>> _queues = new Dictionary<(QueueType, QueuePriority), BlockingCollection<string>>
         {
-            [QueueType.Workflow] = new BlockingCollection<string>(),
-            [QueueType.Event] = new BlockingCollection<string>(),
-            [QueueType.Index] = new BlockingCollection<string>()
+            [(QueueType.Workflow, QueuePriority.Normal)] = new BlockingCollection<string>(),
+            [(QueueType.Workflow, QueuePriority.High)] = new BlockingCollection<string>(),
+            [(QueueType.Event, QueuePriority.Normal)] = new BlockingCollection<string>(),
+            [(QueueType.Index, QueuePriority.Normal)] = new BlockingCollection<string>()
         };
+
+        private IEnumerable<BlockingCollection<string>> GetQueuesSortedByPriority(QueueType queue)
+        {
+            return _queues
+                .Where(kvp => kvp.Key.Item1 == queue)
+                .OrderByDescending(kvp => kvp.Key.Item2)
+                .Select(kvp => kvp.Value);
+        }
 
         public bool IsDequeueBlocking => true;
 
-        public Task QueueWork(string id, QueueType queue)
+        public Task QueueWork(string id, QueueType queue, QueuePriority priority)
         {
-            _queues[queue].Add(id);
+            _queues[(queue, priority)].Add(id);
             return Task.CompletedTask;
         }
 
-        public Task<string> DequeueWork(QueueType queue, CancellationToken cancellationToken)
-        {            
-            if (_queues[queue].TryTake(out string id, 100, cancellationToken))
+        public Task QueueWork(string id, QueueType queue)
+        {
+            return QueueWork(id, queue, QueuePriority.Normal);
+        }
+
+        private Task<string> DequeueWork(BlockingCollection<string> queue, CancellationToken cancellationToken)
+        {
+            if (queue.TryTake(out string id, 100, cancellationToken))
                 return Task.FromResult(id);
 
             return Task.FromResult<string>(null);
+        }
+
+        public async Task<string> DequeueWork(QueueType queue, CancellationToken cancellationToken)
+        {
+            foreach (var q in GetQueuesSortedByPriority(queue))
+            {
+                var result = await DequeueWork(q, cancellationToken);
+                if (result != null)
+                    return result;
+            }
+
+            return null;
         }
 
         public Task Start()
@@ -48,10 +73,7 @@ namespace WorkflowCore.Services
         }
 
         public void Dispose()
-        {            
+        {
         }
-        
     }
-
-    #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
 }

--- a/src/providers/WorkflowCore.Providers.AWS/Services/SQSQueueProvider.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/Services/SQSQueueProvider.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Amazon.Runtime;
 using Amazon.SQS;
 using Amazon.SQS.Model;
+using Microsoft.Extensions.Logging;
 using WorkflowCore.Interface;
 
 namespace WorkflowCore.Providers.AWS.Services
@@ -14,31 +13,40 @@ namespace WorkflowCore.Providers.AWS.Services
     public class SQSQueueProvider : IQueueProvider
     {
         private const int WaitTime = 5;
-        private readonly ILogger _logger;
         private readonly IAmazonSQS _client;
-        private readonly Dictionary<QueueType, string> _queues = new Dictionary<QueueType, string>();
+        private readonly Dictionary<(QueueType, QueuePriority), string> _queues = new Dictionary<(QueueType, QueuePriority), string>();
         private readonly string _queuesPrefix;
+
+        private IEnumerable<string> GetQueuesSortedByPriority(QueueType queue)
+        {
+            return _queues
+                .Where(kvp => kvp.Key.Item1 == queue)
+                .OrderByDescending(kvp => kvp.Key.Item2)
+                .Select(kvp => kvp.Value);
+        }
 
         public bool IsDequeueBlocking => true;
 
         public SQSQueueProvider(AWSCredentials credentials, AmazonSQSConfig config, ILoggerFactory logFactory, string queuesPrefix)
         {
-            _logger = logFactory.CreateLogger<SQSQueueProvider>();
             _client = new AmazonSQSClient(credentials, config);
             _queuesPrefix = queuesPrefix;
         }
 
-        public async Task QueueWork(string id, QueueType queue)
+        public async Task QueueWork(string id, QueueType queue, QueuePriority priority)
         {
-            var queueUrl = _queues[queue];
+            var queueUrl = _queues[(queue, priority)];
 
             await _client.SendMessageAsync(new SendMessageRequest(queueUrl, id));
         }
 
-        public async Task<string> DequeueWork(QueueType queue, CancellationToken cancellationToken)
+        public Task QueueWork(string id, QueueType queue)
         {
-            var queueUrl = _queues[queue];
+            return QueueWork(id, queue, QueuePriority.Normal);
+        }
 
+        private async Task<string> DequeueWork(string queueUrl)
+        {
             var result = await _client.ReceiveMessageAsync(new ReceiveMessageRequest(queueUrl)
             {
                 MaxNumberOfMessages = 1,
@@ -54,15 +62,29 @@ namespace WorkflowCore.Providers.AWS.Services
             return msg.Body;
         }
 
+        public async Task<string> DequeueWork(QueueType queue, CancellationToken cancellationToken)
+        {
+            foreach (var queueUrl in GetQueuesSortedByPriority(queue))
+            {
+                var result = await DequeueWork(queueUrl);
+                if (result != null)
+                    return result;
+            }
+
+            return null;
+        }
+
         public async Task Start()
         {
             var workflowQueue = await _client.CreateQueueAsync(new CreateQueueRequest($"{_queuesPrefix}-workflows"));
+            var workflowhighQueue = await _client.CreateQueueAsync(new CreateQueueRequest($"{_queuesPrefix}-workflowshigh"));
             var eventQueue = await _client.CreateQueueAsync(new CreateQueueRequest($"{_queuesPrefix}-events"));
             var indexQueue = await _client.CreateQueueAsync(new CreateQueueRequest($"{_queuesPrefix}-index"));
 
-            _queues[QueueType.Workflow] = workflowQueue.QueueUrl;
-            _queues[QueueType.Event] = eventQueue.QueueUrl;
-            _queues[QueueType.Index] = indexQueue.QueueUrl;
+            _queues[(QueueType.Workflow, QueuePriority.Normal)] = workflowQueue.QueueUrl;
+            _queues[(QueueType.Workflow, QueuePriority.High)] = workflowhighQueue.QueueUrl;
+            _queues[(QueueType.Event, QueuePriority.Normal)] = eventQueue.QueueUrl;
+            _queues[(QueueType.Index, QueuePriority.Normal)] = indexQueue.QueueUrl;
         }
 
         public Task Stop() => Task.CompletedTask;

--- a/src/providers/WorkflowCore.Providers.Azure/Services/AzureStorageQueueProvider.cs
+++ b/src/providers/WorkflowCore.Providers.Azure/Services/AzureStorageQueueProvider.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -11,33 +11,42 @@ namespace WorkflowCore.Providers.Azure.Services
 {
     public class AzureStorageQueueProvider : IQueueProvider
     {
-        private readonly ILogger _logger;
-        
-        private readonly Dictionary<QueueType, CloudQueue> _queues = new Dictionary<QueueType, CloudQueue>();
+        private readonly Dictionary<(QueueType, QueuePriority), CloudQueue> _queues = new Dictionary<(QueueType, QueuePriority), CloudQueue>();
 
         public bool IsDequeueBlocking => false;
 
         public AzureStorageQueueProvider(string connectionString, ILoggerFactory logFactory)
         {
-            _logger = logFactory.CreateLogger<AzureStorageQueueProvider>();
             var account = CloudStorageAccount.Parse(connectionString);
             var client = account.CreateCloudQueueClient();
 
-            _queues[QueueType.Workflow] = client.GetQueueReference("workflowcore-workflows");
-            _queues[QueueType.Event] = client.GetQueueReference("workflowcore-events");
-            _queues[QueueType.Index] = client.GetQueueReference("workflowcore-index");
+            _queues[(QueueType.Workflow, QueuePriority.Normal)] = client.GetQueueReference("workflowcore-workflows");
+            _queues[(QueueType.Workflow, QueuePriority.High)] = client.GetQueueReference("workflowcore-workflowshigh");
+            _queues[(QueueType.Event, QueuePriority.Normal)] = client.GetQueueReference("workflowcore-events");
+            _queues[(QueueType.Index, QueuePriority.Normal)] = client.GetQueueReference("workflowcore-index");
         }
 
-        public async Task QueueWork(string id, QueueType queue)
+        private IEnumerable<CloudQueue> GetQueuesSortedByPriority(QueueType queue)
+        {
+            return _queues
+                .Where(kvp => kvp.Key.Item1 == queue)
+                .OrderByDescending(kvp => kvp.Key.Item2)
+                .Select(kvp => kvp.Value);
+        }
+
+        public async Task QueueWork(string id, QueueType queue, QueuePriority priority)
         {
             var msg = new CloudQueueMessage(id);
-            await _queues[queue].AddMessageAsync(msg);
+            await _queues[(queue, priority)].AddMessageAsync(msg);
         }
 
-        public async Task<string> DequeueWork(QueueType queue, CancellationToken cancellationToken)
+        public Task QueueWork(string id, QueueType queue)
         {
-            CloudQueue cloudQueue = _queues[queue];
+            return QueueWork(id, queue, QueuePriority.Normal);
+        }
 
+        private async Task<string> DequeueWork(CloudQueue cloudQueue, CancellationToken cancellationToken)
+        {
             if (cloudQueue == null)
                 return null;
             
@@ -48,6 +57,29 @@ namespace WorkflowCore.Providers.Azure.Services
 
             await cloudQueue.DeleteMessageAsync(msg);
             return msg.AsString;
+        }
+
+        public async Task<string> DequeueWork(CloudQueue cloudQueue)
+        {
+            var msg = await cloudQueue.GetMessageAsync();
+
+            if (msg == null)
+                return null;
+
+            await cloudQueue.DeleteMessageAsync(msg);
+            return msg.AsString;
+        }
+
+        public async Task<string> DequeueWork(QueueType queue, CancellationToken cancellationToken)
+        {
+            foreach (var q in GetQueuesSortedByPriority(queue))
+            {
+                var result = await DequeueWork(q, cancellationToken);
+                if (result != null)
+                    return result;
+            }
+
+            return null;
         }
 
         public async Task Start()
@@ -63,5 +95,7 @@ namespace WorkflowCore.Providers.Azure.Services
         public void Dispose()
         {
         }
+
+
     }
 }

--- a/src/providers/WorkflowCore.Providers.Redis/Services/RedisQueueProvider.cs
+++ b/src/providers/WorkflowCore.Providers.Redis/Services/RedisQueueProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -10,33 +11,40 @@ namespace WorkflowCore.Providers.Redis.Services
 {
     public class RedisQueueProvider : IQueueProvider
     {
-        private readonly ILogger _logger;
         private readonly string _connectionString;
         private readonly string _prefix;
 
         private IConnectionMultiplexer _multiplexer;
         private IDatabase _redis;
 
-        private readonly Dictionary<QueueType, string> _queues = new Dictionary<QueueType, string>
+        private readonly Dictionary<(QueueType, QueuePriority), string> _queues = new Dictionary<(QueueType, QueuePriority), string>
         {
-            [QueueType.Workflow] = "workflows",
-            [QueueType.Event] = "events",
-            [QueueType.Index] = "index"
+            [(QueueType.Workflow, QueuePriority.Normal)] = "workflows",
+            [(QueueType.Workflow, QueuePriority.High)] = "workflowshigh",
+            [(QueueType.Event, QueuePriority.Normal)] = "events",
+            [(QueueType.Index, QueuePriority.Normal)] = "index"
         };
 
         public RedisQueueProvider(string connectionString, string prefix, ILoggerFactory logFactory)
         {
             _connectionString = connectionString;
             _prefix = prefix;
-            _logger = logFactory.CreateLogger(GetType());
         }
-        
-        public async Task QueueWork(string id, QueueType queue)
+
+        private IEnumerable<string> GetQueuesSortedByPriority(QueueType queue)
+        {
+            return _queues
+                .Where(kvp => kvp.Key.Item1 == queue)
+                .OrderByDescending(kvp => kvp.Key.Item2)
+                .Select(kvp => kvp.Value);
+        }
+
+        public async Task QueueWork(string id, QueueType queue, QueuePriority priority)
         {
             if (_redis == null)
                 throw new InvalidOperationException();
 
-            var queueName = GetQueueName(queue);
+            var queueName = GetQueueName(_queues[(queue, priority)]);
 
             var insertResult = await _redis.ListInsertBeforeAsync(queueName, id, id);
             if (insertResult == -1 || insertResult == 0)
@@ -45,7 +53,12 @@ namespace WorkflowCore.Providers.Redis.Services
                 await _redis.ListRemoveAsync(queueName, id, 1);
         }
 
-        public async Task<string> DequeueWork(QueueType queue, CancellationToken cancellationToken)
+        public Task QueueWork(string id, QueueType queue)
+        {
+            return QueueWork(id, queue, QueuePriority.Normal);
+        }
+
+        private async Task<string> DequeueWork(string queue)
         {
             if (_redis == null)
                 throw new InvalidOperationException();
@@ -56,6 +69,18 @@ namespace WorkflowCore.Providers.Redis.Services
                 return null;
 
             return result;
+        }
+
+        public async Task<string> DequeueWork(QueueType queue, CancellationToken cancellationToken)
+        {
+            foreach (var q in GetQueuesSortedByPriority(queue))
+            {
+                var result = await DequeueWork(q);
+                if (result != null)
+                    return result;
+            }
+
+            return null;
         }
 
         public bool IsDequeueBlocking => false;
@@ -77,6 +102,6 @@ namespace WorkflowCore.Providers.Redis.Services
         {
         }
 
-        private string GetQueueName(QueueType queue) => $"{_prefix}-{_queues[queue]}";
+        private string GetQueueName(string queue) => $"{_prefix}-{queue}";
     }
 }

--- a/src/providers/WorkflowCore.QueueProviders.RabbitMQ/Interfaces/IRabbitMqQueueNameProvider.cs
+++ b/src/providers/WorkflowCore.QueueProviders.RabbitMQ/Interfaces/IRabbitMqQueueNameProvider.cs
@@ -1,11 +1,12 @@
-﻿using System;
-using System.Linq;
+﻿using System.Collections.Generic;
 using WorkflowCore.Interface;
 
 namespace WorkflowCore.QueueProviders.RabbitMQ.Interfaces
 {
     public interface IRabbitMqQueueNameProvider
     {
+        IDictionary<(QueueType, QueuePriority), string> GetAll();
+        string GetQueueName(QueueType queue, QueuePriority priority);
         string GetQueueName(QueueType queue);
     }
 }

--- a/src/providers/WorkflowCore.QueueProviders.RabbitMQ/Services/DefaultRabbitMqQueueNameProvider.cs
+++ b/src/providers/WorkflowCore.QueueProviders.RabbitMQ/Services/DefaultRabbitMqQueueNameProvider.cs
@@ -1,23 +1,29 @@
-﻿using WorkflowCore.Interface;
+﻿using System.Collections.Generic;
+using WorkflowCore.Interface;
 using WorkflowCore.QueueProviders.RabbitMQ.Interfaces;
 
 namespace WorkflowCore.QueueProviders.RabbitMQ.Services
 {
     public class DefaultRabbitMqQueueNameProvider : IRabbitMqQueueNameProvider
     {
+        private readonly Dictionary<(QueueType, QueuePriority), string> _queues = new Dictionary<(QueueType, QueuePriority), string>
+        {
+            [(QueueType.Workflow, QueuePriority.Normal)] = "wfc.workflow_queue",
+            [(QueueType.Workflow, QueuePriority.High)] = "wfc.workflowhigh_queue",
+            [(QueueType.Event, QueuePriority.Normal)] = "wfc.event_queue",
+            [(QueueType.Index, QueuePriority.Normal)] = "wfc.index_queue"
+        };
+
+        public IDictionary<(QueueType, QueuePriority), string> GetAll() => _queues;
+
+        public string GetQueueName(QueueType queue, QueuePriority priority)
+        {
+            return _queues[(queue, priority)];
+        }
+
         public string GetQueueName(QueueType queue)
         {
-            switch (queue)
-            {
-                case QueueType.Workflow:
-                    return "wfc.workflow_queue";
-                case QueueType.Event:
-                    return "wfc.event_queue";
-                case QueueType.Index:
-                    return "wfc.index_queue";
-                default:
-                    return null;
-            }
+            return GetQueueName(queue, QueuePriority.Normal);
         }
     }
 }

--- a/src/providers/WorkflowCore.QueueProviders.SqlServer/Interfaces/IQueueConfigProvider.cs
+++ b/src/providers/WorkflowCore.QueueProviders.SqlServer/Interfaces/IQueueConfigProvider.cs
@@ -1,6 +1,7 @@
 ﻿#region using
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using WorkflowCore.Interface;
 using WorkflowCore.QueueProviders.SqlServer.Models;
@@ -11,6 +12,8 @@ namespace WorkflowCore.QueueProviders.SqlServer.Interfaces
 {    
     public interface IQueueConfigProvider
     {
+        IDictionary<(QueueType, QueuePriority), QueueConfig> GetAll();
         QueueConfig GetByQueue(QueueType queue);
+        QueueConfig GetByQueue(QueueType queue, QueuePriority priority);
     }
 }

--- a/src/providers/WorkflowCore.QueueProviders.SqlServer/Services/QueueConfigProvider.cs
+++ b/src/providers/WorkflowCore.QueueProviders.SqlServer/Services/QueueConfigProvider.cs
@@ -16,13 +16,21 @@ namespace WorkflowCore.QueueProviders.SqlServer.Services
     /// </summary>    
     public class QueueConfigProvider : IQueueConfigProvider
     {
-        private readonly Dictionary<QueueType, QueueConfig> _queues = new Dictionary<QueueType, QueueConfig>
+        private readonly Dictionary<(QueueType, QueuePriority), QueueConfig> _queues = new Dictionary<(QueueType, QueuePriority), QueueConfig>
         {
-            [QueueType.Workflow] = new QueueConfig("workflow"),
-            [QueueType.Event] = new QueueConfig("event"),
-            [QueueType.Index] = new QueueConfig("indexq")
+            [(QueueType.Workflow, QueuePriority.Normal)] = new QueueConfig("workflow"),
+            [(QueueType.Workflow, QueuePriority.High)] = new QueueConfig("workflowhigh"),
+            [(QueueType.Event, QueuePriority.Normal)] = new QueueConfig("event"),
+            [(QueueType.Index, QueuePriority.Normal)] = new QueueConfig("indexq")
         };
 
-        public QueueConfig GetByQueue(QueueType queue) => _queues[queue];
+        public IDictionary<(QueueType, QueuePriority), QueueConfig> GetAll() => _queues;
+
+        public QueueConfig GetByQueue(
+            QueueType queue) => GetByQueue(queue, QueuePriority.Normal);
+
+        public QueueConfig GetByQueue(
+            QueueType queue,
+            QueuePriority priority) => _queues[(queue, priority)];
     }
 }


### PR DESCRIPTION
**Describe the change**
Possibilty to implement several queue levels

**Describe your implementation or design**
By default, all the messages are enqueued and dequeued in the same queue.
But for some needs, we would like to set the priority of the enqueued message.
The goal of this change is to allow to enqueue a "high priority" message when the method WorkflowConsumer.FutureQueue is called. This will help to complete in priority the workflows that have started first.

**Tests**
no

**Breaking change**
no

**Additional context**
