### PR TITLE
Enable supply of pre-provisoned AWS clients

### DIFF
--- a/src/providers/WorkflowCore.Providers.AWS/README.md
+++ b/src/providers/WorkflowCore.Providers.AWS/README.md
@@ -34,6 +34,18 @@ services.AddWorkflow(cfg =>
 If any AWS resources do not exists, they will be automatcially created. By default, all DynamoDB tables and indexes will be provisioned with a throughput of 1, you can modify these values from the AWS console.
 You may also specify a prefix for the dynamo table names.
 
+If you have a preconfigured dynamoClient, you can pass this in instead of the credentials and config
+```C#
+var client = new AmazonDynamoDBClient();
+var sqsClient = new AmazonSQSClient();
+services.AddWorkflow(cfg =>
+{
+    cfg.UseAwsDynamoPersistenceWithProvisionedClient(client, "table-prefix");
+    cfg.UseAwsDynamoLockingWithProvisionedClient(client, "workflow-core-locks");
+    cfg.UseAwsSimpleQueueServiceWithProvisionedClient(sqsClient, "queues-prefix");
+});
+```
+
 
 ## Usage (Kinesis)
 

--- a/src/providers/WorkflowCore.Providers.AWS/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/ServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static WorkflowOptions UseAwsSimpleQueueService(this WorkflowOptions options, AWSCredentials credentials, AmazonSQSConfig config, string queuesPrefix = "workflowcore")
         {
             var sqsClient = new AmazonSQSClient(credentials, config);
-            return UseAwsSimpleQueueServiceWithProvisionedClient(options, sqsClient, queuesPrefix);
+            return options.UseAwsSimpleQueueServiceWithProvisionedClient(sqsClient, queuesPrefix);
         }
 
         public static WorkflowOptions UseAwsSimpleQueueServiceWithProvisionedClient(this WorkflowOptions options, AmazonSQSClient sqsClient, string queuesPrefix = "workflowcore")
@@ -29,7 +29,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static WorkflowOptions UseAwsDynamoLocking(this WorkflowOptions options, AWSCredentials credentials, AmazonDynamoDBConfig config, string tableName)
         {
             var dbClient = new AmazonDynamoDBClient(credentials, config);
-            return UseAwsDynamoLockingWithProvisionedClient(options, dbClient, tableName);
+            return options.UseAwsDynamoLockingWithProvisionedClient(dbClient, tableName);
         }
 
         public static WorkflowOptions UseAwsDynamoLockingWithProvisionedClient (this WorkflowOptions options, AmazonDynamoDBClient dynamoClient, string tableName)
@@ -41,7 +41,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static WorkflowOptions UseAwsDynamoPersistence(this WorkflowOptions options, AWSCredentials credentials, AmazonDynamoDBConfig config, string tablePrefix)
         {
             var dbClient = new AmazonDynamoDBClient(credentials, config);
-            return UseAwsDynamoPersistenceWithProvisionedClient(options, dbClient, tablePrefix);
+            return options.UseAwsDynamoPersistenceWithProvisionedClient(dbClient, tablePrefix);
         }
 
         public static WorkflowOptions UseAwsDynamoPersistenceWithProvisionedClient(this WorkflowOptions options, AmazonDynamoDBClient dynamoClient, string tablePrefix)
@@ -56,7 +56,7 @@ namespace Microsoft.Extensions.DependencyInjection
             var kinesisClient = new AmazonKinesisClient(credentials, region);
             var dynamoClient = new AmazonDynamoDBClient(credentials, region);
             
-            return UseAwsKinesisWithProvisionedClients(options, kinesisClient, dynamoClient,appName, streamName);
+            return options.UseAwsKinesisWithProvisionedClients(kinesisClient, dynamoClient,appName, streamName);
 
         }
 

--- a/src/providers/WorkflowCore.Providers.AWS/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/ServiceCollectionExtensions.cs
@@ -15,20 +15,39 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static WorkflowOptions UseAwsSimpleQueueService(this WorkflowOptions options, AWSCredentials credentials, AmazonSQSConfig config, string queuesPrefix = "workflowcore")
         {
-            options.UseQueueProvider(sp => new SQSQueueProvider(credentials, config, sp.GetService<ILoggerFactory>(), queuesPrefix));
+            options.UseQueueProvider(sp => new SQSQueueProvider(credentials, config, null, sp.GetService<ILoggerFactory>(), queuesPrefix));
+            return options;
+        }
+
+        public static WorkflowOptions UseAwsSimpleQueueServiceWithProvisionedClient(this WorkflowOptions options, AmazonSQSClient sqsClient, string queuesPrefix = "workflowcore")
+        {
+            options.UseQueueProvider(sp => new SQSQueueProvider(null, null, sqsClient, sp.GetService<ILoggerFactory>(), queuesPrefix));
             return options;
         }
 
         public static WorkflowOptions UseAwsDynamoLocking(this WorkflowOptions options, AWSCredentials credentials, AmazonDynamoDBConfig config, string tableName)
         {
-            options.UseDistributedLockManager(sp => new DynamoLockProvider(credentials, config, tableName, sp.GetService<ILoggerFactory>(), sp.GetService<IDateTimeProvider>()));
+            options.UseDistributedLockManager(sp => new DynamoLockProvider(credentials, config, null, tableName, sp.GetService<ILoggerFactory>(), sp.GetService<IDateTimeProvider>()));
+            return options;
+        }
+
+        public static WorkflowOptions UseAwsDynamoLockingWithProvisionedClient (this WorkflowOptions options, AmazonDynamoDBClient dynamoClient, string tableName)
+        {
+            options.UseDistributedLockManager(sp => new DynamoLockProvider(null, null, dynamoClient, tableName, sp.GetService<ILoggerFactory>(), sp.GetService<IDateTimeProvider>()));
             return options;
         }
 
         public static WorkflowOptions UseAwsDynamoPersistence(this WorkflowOptions options, AWSCredentials credentials, AmazonDynamoDBConfig config, string tablePrefix)
         {
-            options.Services.AddTransient<IDynamoDbProvisioner>(sp => new DynamoDbProvisioner(credentials, config, tablePrefix, sp.GetService<ILoggerFactory>()));
-            options.UsePersistence(sp => new DynamoPersistenceProvider(credentials, config, sp.GetService<IDynamoDbProvisioner>(), tablePrefix, sp.GetService<ILoggerFactory>()));
+            options.Services.AddTransient<IDynamoDbProvisioner>(sp => new DynamoDbProvisioner(credentials, config, null, tablePrefix, sp.GetService<ILoggerFactory>()));
+            options.UsePersistence(sp => new DynamoPersistenceProvider(credentials, config, null, sp.GetService<IDynamoDbProvisioner>(), tablePrefix, sp.GetService<ILoggerFactory>()));
+            return options;
+        }
+
+        public static WorkflowOptions UseAwsDynamoPersistenceWithProvisionedClient(this WorkflowOptions options, AmazonDynamoDBClient dynamoClient, string tablePrefix)
+        {
+            options.Services.AddTransient<IDynamoDbProvisioner>(sp => new DynamoDbProvisioner(null, null, dynamoClient, tablePrefix, sp.GetService<ILoggerFactory>()));
+            options.UsePersistence(sp => new DynamoPersistenceProvider(null, null, dynamoClient, sp.GetService<IDynamoDbProvisioner>(), tablePrefix, sp.GetService<ILoggerFactory>()));
             return options;
         }
 

--- a/src/providers/WorkflowCore.Providers.AWS/Services/DynamoDbProvisioner.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/Services/DynamoDbProvisioner.cs
@@ -15,10 +15,10 @@ namespace WorkflowCore.Providers.AWS.Services
         private readonly IAmazonDynamoDB _client;
         private readonly string _tablePrefix;
 
-        public DynamoDbProvisioner(AWSCredentials credentials, AmazonDynamoDBConfig config, AmazonDynamoDBClient dynamoDBClient, string tablePrefix, ILoggerFactory logFactory)
+        public DynamoDbProvisioner(AmazonDynamoDBClient dynamoDBClient, string tablePrefix, ILoggerFactory logFactory)
         {
             _logger = logFactory.CreateLogger<DynamoDbProvisioner>();
-            _client = dynamoDBClient ?? new AmazonDynamoDBClient(credentials, config);
+            _client = dynamoDBClient;
             _tablePrefix = tablePrefix;
         }
 

--- a/src/providers/WorkflowCore.Providers.AWS/Services/DynamoDbProvisioner.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/Services/DynamoDbProvisioner.cs
@@ -15,10 +15,10 @@ namespace WorkflowCore.Providers.AWS.Services
         private readonly IAmazonDynamoDB _client;
         private readonly string _tablePrefix;
 
-        public DynamoDbProvisioner(AWSCredentials credentials, AmazonDynamoDBConfig config, string tablePrefix, ILoggerFactory logFactory)
+        public DynamoDbProvisioner(AWSCredentials credentials, AmazonDynamoDBConfig config, AmazonDynamoDBClient dynamoDBClient, string tablePrefix, ILoggerFactory logFactory)
         {
             _logger = logFactory.CreateLogger<DynamoDbProvisioner>();
-            _client = new AmazonDynamoDBClient(credentials, config);
+            _client = dynamoDBClient ?? new AmazonDynamoDBClient(credentials, config);
             _tablePrefix = tablePrefix;
         }
 

--- a/src/providers/WorkflowCore.Providers.AWS/Services/DynamoLockProvider.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/Services/DynamoLockProvider.cs
@@ -25,10 +25,10 @@ namespace WorkflowCore.Providers.AWS.Services
         private readonly AutoResetEvent _mutex = new AutoResetEvent(true);
         private readonly IDateTimeProvider _dateTimeProvider;
 
-        public DynamoLockProvider(AWSCredentials credentials, AmazonDynamoDBConfig config, AmazonDynamoDBClient dynamoDBClient, string tableName, ILoggerFactory logFactory, IDateTimeProvider dateTimeProvider)
+        public DynamoLockProvider(AmazonDynamoDBClient dynamoDBClient, string tableName, ILoggerFactory logFactory, IDateTimeProvider dateTimeProvider)
         {
             _logger = logFactory.CreateLogger<DynamoLockProvider>();
-            _client = dynamoDBClient ?? new AmazonDynamoDBClient(credentials, config);
+            _client = dynamoDBClient;
             _localLocks = new List<string>();
             _tableName = tableName;
             _nodeId = Guid.NewGuid().ToString();

--- a/src/providers/WorkflowCore.Providers.AWS/Services/DynamoLockProvider.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/Services/DynamoLockProvider.cs
@@ -25,10 +25,10 @@ namespace WorkflowCore.Providers.AWS.Services
         private readonly AutoResetEvent _mutex = new AutoResetEvent(true);
         private readonly IDateTimeProvider _dateTimeProvider;
 
-        public DynamoLockProvider(AWSCredentials credentials, AmazonDynamoDBConfig config, string tableName, ILoggerFactory logFactory, IDateTimeProvider dateTimeProvider)
+        public DynamoLockProvider(AWSCredentials credentials, AmazonDynamoDBConfig config, AmazonDynamoDBClient dynamoDBClient, string tableName, ILoggerFactory logFactory, IDateTimeProvider dateTimeProvider)
         {
             _logger = logFactory.CreateLogger<DynamoLockProvider>();
-            _client = new AmazonDynamoDBClient(credentials, config);
+            _client = dynamoDBClient ?? new AmazonDynamoDBClient(credentials, config);
             _localLocks = new List<string>();
             _tableName = tableName;
             _nodeId = Guid.NewGuid().ToString();

--- a/src/providers/WorkflowCore.Providers.AWS/Services/DynamoPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/Services/DynamoPersistenceProvider.cs
@@ -26,10 +26,10 @@ namespace WorkflowCore.Providers.AWS.Services
 
         public bool SupportsScheduledCommands => false;
 
-        public DynamoPersistenceProvider(AWSCredentials credentials, AmazonDynamoDBConfig config, AmazonDynamoDBClient dynamoDBClient, IDynamoDbProvisioner provisioner, string tablePrefix, ILoggerFactory logFactory)
+        public DynamoPersistenceProvider(AmazonDynamoDBClient dynamoDBClient, IDynamoDbProvisioner provisioner, string tablePrefix, ILoggerFactory logFactory)
         {
             _logger = logFactory.CreateLogger<DynamoPersistenceProvider>();
-            _client = dynamoDBClient ?? new AmazonDynamoDBClient(credentials, config);
+            _client = dynamoDBClient;
             _tablePrefix = tablePrefix;
             _provisioner = provisioner;
         }

--- a/src/providers/WorkflowCore.Providers.AWS/Services/DynamoPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/Services/DynamoPersistenceProvider.cs
@@ -26,10 +26,10 @@ namespace WorkflowCore.Providers.AWS.Services
 
         public bool SupportsScheduledCommands => false;
 
-        public DynamoPersistenceProvider(AWSCredentials credentials, AmazonDynamoDBConfig config, IDynamoDbProvisioner provisioner, string tablePrefix, ILoggerFactory logFactory)
+        public DynamoPersistenceProvider(AWSCredentials credentials, AmazonDynamoDBConfig config, AmazonDynamoDBClient dynamoDBClient, IDynamoDbProvisioner provisioner, string tablePrefix, ILoggerFactory logFactory)
         {
             _logger = logFactory.CreateLogger<DynamoPersistenceProvider>();
-            _client = new AmazonDynamoDBClient(credentials, config);
+            _client = dynamoDBClient ?? new AmazonDynamoDBClient(credentials, config);
             _tablePrefix = tablePrefix;
             _provisioner = provisioner;
         }

--- a/src/providers/WorkflowCore.Providers.AWS/Services/KinesisProvider.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/Services/KinesisProvider.cs
@@ -26,7 +26,7 @@ namespace WorkflowCore.Providers.AWS.Services
         private readonly int _defaultShardCount = 1;
         private bool _started = false;
 
-        public KinesisProvider(AWSCredentials credentials, RegionEndpoint region, string appName, string streamName, IKinesisStreamConsumer consumer, ILoggerFactory logFactory)
+        public KinesisProvider(AmazonKinesisClient kinesisClient, string appName, string streamName, IKinesisStreamConsumer consumer, ILoggerFactory logFactory)
         {
             _logger = logFactory.CreateLogger(GetType());
             _appName = appName;
@@ -34,7 +34,7 @@ namespace WorkflowCore.Providers.AWS.Services
             _consumer = consumer;
             _serializer = new JsonSerializer();            
             _serializer.TypeNameHandling = TypeNameHandling.All;
-            _client = new AmazonKinesisClient(credentials, region);
+            _client = kinesisClient;
         }
 
         public async Task PublishNotification(LifeCycleEvent evt)

--- a/src/providers/WorkflowCore.Providers.AWS/Services/KinesisStreamConsumer.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/Services/KinesisStreamConsumer.cs
@@ -25,12 +25,12 @@ namespace WorkflowCore.Providers.AWS.Services
         private ICollection<ShardSubscription> _subscribers = new HashSet<ShardSubscription>();
         private readonly IDateTimeProvider _dateTimeProvider;
         
-        public KinesisStreamConsumer(AWSCredentials credentials, RegionEndpoint region, IKinesisTracker tracker, IDistributedLockProvider lockManager, ILoggerFactory logFactory, IDateTimeProvider dateTimeProvider)
+        public KinesisStreamConsumer(AmazonKinesisClient kinesisClient, IKinesisTracker tracker, IDistributedLockProvider lockManager, ILoggerFactory logFactory, IDateTimeProvider dateTimeProvider)
         {
             _logger = logFactory.CreateLogger(GetType());
             _tracker = tracker;
             _lockManager = lockManager;
-            _client = new AmazonKinesisClient(credentials, region);
+            _client = kinesisClient;
             _processTask = new Task(Process);
             _processTask.Start();
             _dateTimeProvider = dateTimeProvider;

--- a/src/providers/WorkflowCore.Providers.AWS/Services/KinesisTracker.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/Services/KinesisTracker.cs
@@ -17,10 +17,10 @@ namespace WorkflowCore.Providers.AWS.Services
         private readonly string _tableName;
         private bool _tableConfirmed = false;
 
-        public KinesisTracker(AWSCredentials credentials, RegionEndpoint region, string tableName, ILoggerFactory logFactory)
+        public KinesisTracker(AmazonDynamoDBClient client, string tableName, ILoggerFactory logFactory)
         {
             _logger = logFactory.CreateLogger(GetType());
-            _client = new AmazonDynamoDBClient(credentials, region);
+            _client = client;
             _tableName = tableName;
         }
 

--- a/src/providers/WorkflowCore.Providers.AWS/Services/SQSQueueProvider.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/Services/SQSQueueProvider.cs
@@ -21,10 +21,10 @@ namespace WorkflowCore.Providers.AWS.Services
 
         public bool IsDequeueBlocking => true;
 
-        public SQSQueueProvider(AWSCredentials credentials, AmazonSQSConfig config, AmazonSQSClient sqsClient, ILoggerFactory logFactory, string queuesPrefix)
+        public SQSQueueProvider(AmazonSQSClient sqsClient, ILoggerFactory logFactory, string queuesPrefix)
         {
             _logger = logFactory.CreateLogger<SQSQueueProvider>();
-            _client = sqsClient ?? new AmazonSQSClient(credentials, config);
+            _client = sqsClient;
             _queuesPrefix = queuesPrefix;
         }
 

--- a/src/providers/WorkflowCore.Providers.AWS/Services/SQSQueueProvider.cs
+++ b/src/providers/WorkflowCore.Providers.AWS/Services/SQSQueueProvider.cs
@@ -21,10 +21,10 @@ namespace WorkflowCore.Providers.AWS.Services
 
         public bool IsDequeueBlocking => true;
 
-        public SQSQueueProvider(AWSCredentials credentials, AmazonSQSConfig config, ILoggerFactory logFactory, string queuesPrefix)
+        public SQSQueueProvider(AWSCredentials credentials, AmazonSQSConfig config, AmazonSQSClient sqsClient, ILoggerFactory logFactory, string queuesPrefix)
         {
             _logger = logFactory.CreateLogger<SQSQueueProvider>();
-            _client = new AmazonSQSClient(credentials, config);
+            _client = sqsClient ?? new AmazonSQSClient(credentials, config);
             _queuesPrefix = queuesPrefix;
         }
 

--- a/test/WorkflowCore.Tests.DynamoDB/DynamoPersistenceProviderFixture.cs
+++ b/test/WorkflowCore.Tests.DynamoDB/DynamoPersistenceProviderFixture.cs
@@ -26,8 +26,9 @@ namespace WorkflowCore.Tests.DynamoDB
                 if (_subject == null)
                 {
                     var cfg = new AmazonDynamoDBConfig { ServiceURL = DynamoDbDockerSetup.ConnectionString };
-                    var provisioner = new DynamoDbProvisioner(DynamoDbDockerSetup.Credentials, cfg, null, "unittests", new LoggerFactory());
-                    var client = new DynamoPersistenceProvider(DynamoDbDockerSetup.Credentials, cfg, null, provisioner, "unittests", new LoggerFactory());
+                    var dbClient = new AmazonDynamoDBClient(DynamoDbDockerSetup.Credentials, cfg);
+                    var provisioner = new DynamoDbProvisioner(dbClient, "unittests", new LoggerFactory());
+                    var client = new DynamoPersistenceProvider(dbClient, provisioner, "unittests", new LoggerFactory());
                     client.EnsureStoreExists();
                     _subject = client;
                 }

--- a/test/WorkflowCore.Tests.DynamoDB/DynamoPersistenceProviderFixture.cs
+++ b/test/WorkflowCore.Tests.DynamoDB/DynamoPersistenceProviderFixture.cs
@@ -26,8 +26,8 @@ namespace WorkflowCore.Tests.DynamoDB
                 if (_subject == null)
                 {
                     var cfg = new AmazonDynamoDBConfig { ServiceURL = DynamoDbDockerSetup.ConnectionString };
-                    var provisioner = new DynamoDbProvisioner(DynamoDbDockerSetup.Credentials, cfg, "unittests", new LoggerFactory());
-                    var client = new DynamoPersistenceProvider(DynamoDbDockerSetup.Credentials, cfg, provisioner, "unittests", new LoggerFactory());
+                    var provisioner = new DynamoDbProvisioner(DynamoDbDockerSetup.Credentials, cfg, null, "unittests", new LoggerFactory());
+                    var client = new DynamoPersistenceProvider(DynamoDbDockerSetup.Credentials, cfg, null, provisioner, "unittests", new LoggerFactory());
                     client.EnsureStoreExists();
                     _subject = client;
                 }


### PR DESCRIPTION
**Describe the change**
Added the option to provide an existing SQS client or Dynamo client rather than having the lock , persistence and queue providers creating them.  

**Describe your implementation or design**
Added additional Service Collection extension methods to allow providing the clients. For default / current behaviour, the clients are now created in the extension method. For the new functionality, the client is passed into the extension method.  The constructors on each of the providers has been altered receive the client rather than create it itself

**Tests**
No changes to functionality - only to how the objects are created

**Breaking change**
This is not a breaking change as the existing methods and signatures remain and work in the same way

**Additional context**
Using explicit AWS credentials in applications is not best practice as there are many ways in which these can be compromised.  The encouraged practice is to execute your application in the context of an AWS role which will define the policies that the application is allow to execute.  This approach does not use explicit credentials.  Without this change, organisations that work in the encouraged manner cannot use the provided AWS lock, queue or persistence providers.