### PR TITLE
added a type resolver to be replaced by another implementation later.

### DIFF
--- a/src/WorkflowCore.DSL/Interface/ITypeResolver.cs
+++ b/src/WorkflowCore.DSL/Interface/ITypeResolver.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Linq;
+
+namespace WorkflowCore.Interface
+{
+    public interface ITypeResolver
+    {
+        Type FindType(string name);
+    }
+}

--- a/src/WorkflowCore.DSL/ServiceCollectionExtensions.cs
+++ b/src/WorkflowCore.DSL/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IServiceCollection AddWorkflowDSL(this IServiceCollection services)
         {
+            services.AddTransient<ITypeResolver, TypeResolver>();
             services.AddTransient<IDefinitionLoader, DefinitionLoader>();
             return services;
         }

--- a/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
+++ b/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
@@ -17,10 +17,12 @@ namespace WorkflowCore.Services.DefinitionStorage
     public class DefinitionLoader : IDefinitionLoader
     {
         private readonly IWorkflowRegistry _registry;
+        private readonly ITypeResolver _typeResolver;
 
-        public DefinitionLoader(IWorkflowRegistry registry)
+        public DefinitionLoader(IWorkflowRegistry registry, ITypeResolver typeResolver)
         {
             _registry = registry;
+            _typeResolver = typeResolver;
         }
 
         public WorkflowDefinition LoadDefinition(string source, Func<string, DefinitionSourceV1> deserializer)
@@ -220,10 +222,11 @@ namespace WorkflowCore.Services.DefinitionStorage
                 var dataParameter = Expression.Parameter(dataType, "data");
 
 
-                if(output.Key.Contains(".") || output.Key.Contains("["))
+                if (output.Key.Contains(".") || output.Key.Contains("["))
                 {
                     AttachNestedOutput(output, step, source, sourceExpr, dataParameter);
-                }else
+                }
+                else
                 {
                     AttachDirectlyOutput(output, step, dataType, sourceExpr, dataParameter);
                 }
@@ -259,11 +262,11 @@ namespace WorkflowCore.Services.DefinitionStorage
 
         }
 
-        private void AttachNestedOutput( KeyValuePair<string, string> output, WorkflowStep step, StepSourceV1 source, LambdaExpression sourceExpr, ParameterExpression dataParameter)
+        private void AttachNestedOutput(KeyValuePair<string, string> output, WorkflowStep step, StepSourceV1 source, LambdaExpression sourceExpr, ParameterExpression dataParameter)
         {
             PropertyInfo propertyInfo = null;
             String[] paths = output.Key.Split('.');
-         
+
             Expression targetProperty = dataParameter;
 
             bool hasAddOutput = false;
@@ -352,7 +355,7 @@ namespace WorkflowCore.Services.DefinitionStorage
 
         private Type FindType(string name)
         {
-            return Type.GetType(name, true, true);
+            return _typeResolver.FindType(name);
         }
 
         private static Action<IStepBody, object, IStepExecutionContext> BuildScalarInputAction(KeyValuePair<string, object> input, ParameterExpression dataParameter, ParameterExpression contextParameter, ParameterExpression environmentVarsParameter, PropertyInfo stepProperty)

--- a/src/WorkflowCore.DSL/Services/TypeResolver.cs
+++ b/src/WorkflowCore.DSL/Services/TypeResolver.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using WorkflowCore.Interface;
+
+namespace WorkflowCore.Services.DefinitionStorage
+{
+    public class TypeResolver : ITypeResolver
+    {
+        public Type FindType(string name)
+        {
+            return Type.GetType(name, true, true);
+        }
+    }
+}

--- a/test/WorkflowCore.UnitTests/Services/DefinitionStorage/DefinitionLoaderTests.cs
+++ b/test/WorkflowCore.UnitTests/Services/DefinitionStorage/DefinitionLoaderTests.cs
@@ -19,7 +19,7 @@ namespace WorkflowCore.UnitTests.Services.DefinitionStorage
         public DefinitionLoaderTests()
         {
             _registry = A.Fake<IWorkflowRegistry>();
-            _subject = new DefinitionLoader(_registry);
+            _subject = new DefinitionLoader(_registry, new TypeResolver());
         }
 
         [Fact(DisplayName = "Should register workflow")]


### PR DESCRIPTION
**Describe the change**
If the application, which uses the workflow core, is based on a plugin system (.NET6 AssemblyLoadContext and PluginLoadContext), it is helpful to replace the resolving of the type.

In order to be able to use a custom type resolver, there is a new interface and a the default implementation.

**Describe your implementation or design**
I added a new interface for the type resolver and injected a default implementation in the extension method to register the DSL.

**Tests**
The original tests are adapted to work with the default implementation.

**Breaking change**
It should not break anything, since the implementation is the same as before.

**Additional context**
The idea was to replace the typeresolver after registering the DSL like:

```
services.AddWorkflow();
services.AddWorkflowDSL();
services.AddTransient<ITypeResolver, CustomTypeResolver>();

var serviceProvider = services.BuildServiceProvider();

var definitionLoader = serviceProvider.GetService<IDefinitionLoader>();
```