### PR TITLE
RedisProvider - Remove the actual event record if we're tidying up after ourselves.

### DIFF
--- a/src/providers/WorkflowCore.Providers.Redis/Services/RedisPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Providers.Redis/Services/RedisPersistenceProvider.cs
@@ -182,8 +182,13 @@ namespace WorkflowCore.Providers.Redis.Services
             await _redis.HashSetAsync($"{_prefix}.{EVENT_SET}", newEvent.Id, str);
             await _redis.SortedSetAddAsync($"{_prefix}.{EVENT_SET}.{EVENTSLUG_INDEX}.{newEvent.EventName}-{newEvent.EventKey}", newEvent.Id, newEvent.EventTime.Ticks);
 
-            if (newEvent.IsProcessed)
+            if (newEvent.IsProcessed){
                 await _redis.SortedSetRemoveAsync($"{_prefix}.{EVENT_SET}.{RUNNABLE_INDEX}", newEvent.Id);
+                
+                if (_removeComplete){
+                    await _redis.SortedSetRemoveAsync($"{_prefix}.{EVENT_SET}", id);
+                }
+            }
             else
                 await _redis.SortedSetAddAsync($"{_prefix}.{EVENT_SET}.{RUNNABLE_INDEX}", newEvent.Id, newEvent.EventTime.Ticks);
 

--- a/src/providers/WorkflowCore.Providers.Redis/Services/RedisPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Providers.Redis/Services/RedisPersistenceProvider.cs
@@ -186,7 +186,7 @@ namespace WorkflowCore.Providers.Redis.Services
                 await _redis.SortedSetRemoveAsync($"{_prefix}.{EVENT_SET}.{RUNNABLE_INDEX}", newEvent.Id);
                 
                 if (_removeComplete){
-                    await _redis.SortedSetRemoveAsync($"{_prefix}.{EVENT_SET}", id);
+                    await _redis.SortedSetRemoveAsync($"{_prefix}.{EVENT_SET}", newEvent.Id);
                 }
             }
             else

--- a/src/providers/WorkflowCore.Providers.Redis/Services/RedisPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Providers.Redis/Services/RedisPersistenceProvider.cs
@@ -225,6 +225,9 @@ namespace WorkflowCore.Providers.Redis.Services
             var str = JsonConvert.SerializeObject(evt, _serializerSettings);
             await _redis.HashSetAsync($"{_prefix}.{EVENT_SET}", evt.Id, str);
             await _redis.SortedSetRemoveAsync($"{_prefix}.{EVENT_SET}.{RUNNABLE_INDEX}", id);
+            if (_removeComplete){
+                 await _redis.SortedSetRemoveAsync($"{_prefix}.{EVENT_SET}", id);
+            }
         }
 
         public async Task MarkEventUnprocessed(string id, CancellationToken cancellationToken = default)


### PR DESCRIPTION
**Describe the change**
Following the _removeComplete logic on PersistWorkflow, also remove events if this is set.

**Describe your implementation or design**
Followed the same logic from the PersistWorkflow method.

**Tests**
Tested locally.

**Breaking change**
No. There are no changes to the method signature or interface.  

**Additional context**
This is really useful in the Redis provider as there is no cleanup functionality available, finding the right keys within the events hash key is rather difficult, having it as part of the main logic would simplify this.