### PR TITLE
Fix Error Endpoint Routing does not support UseMvc

### DIFF
--- a/src/samples/WebApiSample/WebApiSample/Startup.cs
+++ b/src/samples/WebApiSample/WebApiSample/Startup.cs
@@ -44,11 +44,14 @@ namespace WebApiSample
             {
                 app.UseDeveloperExceptionPage();
             }
-                        
+            app.UseRouting();
             app.UseSwagger();            
             app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1"));
 
-            app.UseMvc();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllerRoute("default", "{controller=Workflows}/{action=Get}");
+            });
 
             var host = app.ApplicationServices.GetService<IWorkflowHost>();
             host.RegisterWorkflow<TestWorkflow, MyDataClass>();


### PR DESCRIPTION
 Endpoint Routing does not support UseMvc
Error Detail :
Endpoint Routing does not support 'IApplicationBuilder.UseMvc(...)'. To use 'IApplicationBuilder.UseMvc' set 'MvcOptions.EnableEndpointRouting = false' inside 'ConfigureServices(...).