### PR TITLE
Fixed usage of null WorkflowStep.Name in WorkflowActivity diagnostic service.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,10 +4,10 @@
     <PackageLicenseUrl>https://github.com/danielgerlag/workflow-core/blob/master/LICENSE.md</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/danielgerlag/workflow-core.git</RepositoryUrl>
-    <Version>3.9.0</Version>
-    <AssemblyVersion>3.9.0.0</AssemblyVersion>
-    <FileVersion>3.9.0.0</FileVersion>
+    <Version>3.9.1</Version>
+    <AssemblyVersion>3.9.1.0</AssemblyVersion>
+    <FileVersion>3.9.1.0</FileVersion>
     <PackageIconUrl>https://github.com/danielgerlag/workflow-core/raw/master/src/logo.png</PackageIconUrl>
-    <PackageVersion>3.9.0</PackageVersion>
+    <PackageVersion>3.9.1</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/WorkflowCore/Services/WorkflowActivity.cs
+++ b/src/WorkflowCore/Services/WorkflowActivity.cs
@@ -59,7 +59,7 @@ namespace WorkflowCore.Services
 
                 activity.DisplayName += $" step {stepName}";
                 activity.SetTag("workflow.step.id", workflowStep.Id);
-                activity.SetTag("workflow.step.name", workflowStep.Name);
+                activity.SetTag("workflow.step.name", stepName);
                 activity.SetTag("workflow.step.type", workflowStep.BodyType.Name);
             }
         }


### PR DESCRIPTION

**Describe the change**
In WorkflowActivity.Enrich(WorkflowStep workflowStep) there was a check for a null or empty WorkflowStep.Name and "inline" was used in it's place in the activity display name. A line immediately after referenced WorkflowStep.Name without that check and causes a NullReferenceException if System.Diagnostics.ActivitySource & System.Diagnostics.Activity are used by the host or workflow implementation.


**Describe your implementation or design**

Replaced workflowStep.Name with stepName defined several lines above which either contains the name or "inline" for unnamed steps (Sagas, Snline, etc).

**Tests**
Did you cover your changes with tests? No.

**Breaking change**
Do you changes break compatibility with previous versions? No.

**Additional context**
As far as I can tell usage of ActivitySource and related services like OpenTelemetry are not possible while this bug remains.