### PR TITLE
Fix sending of workflow completed event

### DIFF
--- a/src/WorkflowCore/Services/WorkflowExecutor.cs
+++ b/src/WorkflowCore/Services/WorkflowExecutor.cs
@@ -221,6 +221,7 @@ namespace WorkflowCore.Services
 
             if (workflow.Status == WorkflowStatus.Complete)
             {
+                PublishWorkflowCompleted(workflow);
                 return;
             }
 
@@ -265,6 +266,11 @@ namespace WorkflowCore.Services
                 await middlewareRunner.RunPostMiddleware(workflow, def);
             }
 
+            PublishWorkflowCompleted(workflow);
+        }
+
+        private void PublishWorkflowCompleted(WorkflowInstance workflow)
+        {
             _publisher.PublishNotification(new WorkflowCompleted
             {
                 EventTimeUtc = _datetimeProvider.UtcNow,


### PR DESCRIPTION
**Describe the change**
As described in #1097 a workflow that ends in an `EndStep` does not lead to the `WorkflowCompleted` `LifeCycleEvent` being published because `DetermineNextExecutionTime` returns too early.
This PR remedies that by sending the event also in case of an early return from `DetermineNextExecutionTime`.

**Describe your implementation or design**
Extracted publishing of `WorkflowCompleted` into a separate method and added a call to that function before the early return if workflow is completed.

**Tests**
Yes, added a failing unit test that is green after the implementation is changed.

**Breaking change**
No

**Additional context**
* This is a slightly cleaned up version of #1098 with the appropriate description to get this bug fixed.