### PR TITLE
[AOT] Trim compatibility for project WorkflowCore

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,120 @@
+<Project>
+  
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  
+  <!-- variables for managing package versions -->
+  <PropertyGroup>
+    <!-- Microsoft.EntityFrameworkCore.* -->
+    <EFCoreVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">3.1.2</EFCoreVersion>
+    <EFCoreVersion Condition=" '$(TargetFramework)' == 'netstandard2.1' ">5.0.1</EFCoreVersion>
+    <EFCoreVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">3.1.2</EFCoreVersion>
+    <EFCoreVersion Condition=" '$(TargetFramework)' == 'net6.0' ">6.0.0</EFCoreVersion>
+    <EFCoreVersion Condition=" '$(TargetFramework)' == 'net8.0' ">8.0.0</EFCoreVersion>
+    
+    <!-- Microsoft.Extensions.* -->
+    <MsExtsVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">3.1.2</MsExtsVersion>
+    <MsExtsVersion Condition=" '$(TargetFramework)' == 'netstandard2.1' ">3.1.2</MsExtsVersion>
+    <MsExtsVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">3.1.2</MsExtsVersion>
+    <MsExtsVersion Condition=" '$(TargetFramework)' == 'net6.0' ">6.0.0</MsExtsVersion>
+    <MsExtsVersion Condition=" '$(TargetFramework)' == 'net8.0' ">8.0.0</MsExtsVersion>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="4.3.1" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.3.11" />
+    <PackageVersion Include="AWSSDK.Kinesis" Version="3.7.1.32" />
+    <PackageVersion Include="AWSSDK.SQS" Version="3.7.2.33" />
+    <PackageVersion Include="coverlet.collector" Version="1.2.0" />
+    <PackageVersion Include="Docker.DotNet" Version="3.125.2" />
+    <PackageVersion Include="FakeItEasy" Version="8.1.0" />
+    <PackageVersion Include="FluentAssertions" Version="4.19.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.1.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.2.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.19.0" />
+    <PackageVersion Include="Microsoft.Azure.DocumentDB" Version="2.11.6" />
+    <PackageVersion Include="Microsoft.Azure.ServiceBus" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(EFCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EFCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EFCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="$(EFCoreVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MsExtsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MsExtsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MsExtsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MsExtsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MsExtsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MsExtsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="$(MsExtsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.19.0" />
+    <PackageVersion Include="Moq" Version="4.20.70" />
+    <PackageVersion Include="MySqlConnector" Version="2.3.5" />
+    <PackageVersion Include="NEST" Version="7.14.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="NUnit" Version="3.9.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageVersion Include="Polly" Version="7.2.1" />
+    <PackageVersion Include="RabbitMQ.Client" Version="4.1.3" />
+    <PackageVersion Include="RavenDB.Client" Version="5.1.2" />
+    <PackageVersion Include="RedLock.net" Version="2.2.0" />
+    <PackageVersion Include="SharpYaml" Version="1.6.5" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.0.601" />
+    <PackageVersion Include="Squadron.Elasticsearch" Version="0.18.0" />
+    <PackageVersion Include="Squadron.Mongo" Version="0.18.0" />
+    <PackageVersion Include="Squadron.MySql" Version="0.18.0" />
+    <PackageVersion Include="Squadron.PostgreSql" Version="0.18.0" />
+    <PackageVersion Include="Squadron.Redis" Version="0.18.0" />
+    <PackageVersion Include="Squadron.SqlServer" Version="0.18.0" />
+    <PackageVersion Include="System.Data.Common" Version="4.3.0" />
+    <PackageVersion Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageVersion Include="System.Diagnostics.Process" Version="4.3.0" />
+    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.3.0" />
+    <PackageVersion Include="System.Net.NetworkInformation" Version="4.3.0" />
+    <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" />
+    <PackageVersion Include="xunit" Version="2.6.6" />
+    <PackageVersion Include="xunit.core" Version="2.6.6" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.1" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.7.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.1" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.3.1" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.1" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.7.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.7.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.7.0" />
+  </ItemGroup>
+  
+</Project>

--- a/WorkflowCore.sln
+++ b/WorkflowCore.sln
@@ -1,12 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29509.3
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34518.117
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{EF47161E-E399-451C-BDE8-E92AAD3BD761}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F6AC9AEB-24EF-475A-B190-AA4D9E01270A}"
 	ProjectSection(SolutionItems) = preProject
+		Directory.Packages.props = Directory.Packages.props
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/src/WorkflowCore.DSL/WorkflowCore.DSL.csproj
+++ b/src/WorkflowCore.DSL/WorkflowCore.DSL.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Description>DSL extenstion for Workflow Core provding support for JSON and YAML workflow definitions.</Description>
     <Authors>Daniel Gerlag</Authors>
     <Company />
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="SharpYaml" Version="1.6.5" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.0" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="SharpYaml" />
+    <PackageReference Include="System.Linq.Dynamic.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WorkflowCore.Testing/WorkflowCore.Testing.csproj
+++ b/src/WorkflowCore.Testing/WorkflowCore.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <Version>3.5.2</Version>
     <AssemblyVersion>3.5.2.0</AssemblyVersion>
     <FileVersion>3.5.2.0</FileVersion>
@@ -9,9 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WorkflowCore/Interface/IContainerStepBuilder.cs
+++ b/src/WorkflowCore/Interface/IContainerStepBuilder.cs
@@ -1,8 +1,19 @@
 ﻿using System;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace WorkflowCore.Interface
 {
-    public interface IContainerStepBuilder<TData, TStepBody, TReturnStep>
+    public interface IContainerStepBuilder<TData,
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+        TStepBody,
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+        TReturnStep>
         where TStepBody : IStepBody
         where TReturnStep : IStepBody
     {

--- a/src/WorkflowCore/Interface/IParallelStepBuilder.cs
+++ b/src/WorkflowCore/Interface/IParallelStepBuilder.cs
@@ -1,9 +1,16 @@
 ﻿using System;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using WorkflowCore.Primitives;
 
 namespace WorkflowCore.Interface
 {
-    public interface IParallelStepBuilder<TData, TStepBody>
+    public interface IParallelStepBuilder<TData,
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+        TStepBody>
         where TStepBody : IStepBody
     {
         IParallelStepBuilder<TData, TStepBody> Do(Action<IWorkflowBuilder<TData>> builder);

--- a/src/WorkflowCore/Interface/IStepBody.cs
+++ b/src/WorkflowCore/Interface/IStepBody.cs
@@ -4,7 +4,7 @@ using WorkflowCore.Models;
 namespace WorkflowCore.Interface
 {
     public interface IStepBody
-    {        
-        Task<ExecutionResult> RunAsync(IStepExecutionContext context);        
+    {
+        Task<ExecutionResult> RunAsync(IStepExecutionContext context);
     }
 }

--- a/src/WorkflowCore/Interface/IStepBuilder.cs
+++ b/src/WorkflowCore/Interface/IStepBuilder.cs
@@ -1,14 +1,20 @@
 ﻿using System;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Linq.Expressions;
 using WorkflowCore.Models;
 
 namespace WorkflowCore.Interface
 {
-    public interface IStepBuilder<TData, TStepBody> : IWorkflowModifier<TData, TStepBody>
+    public interface IStepBuilder<TData,
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+        TStepBody> : IWorkflowModifier<TData, TStepBody>
         where TStepBody : IStepBody
     {
-
-        IWorkflowBuilder<TData> WorkflowBuilder { get; }        
+        IWorkflowBuilder<TData> WorkflowBuilder { get; }
 
         WorkflowStep<TStepBody> Step { get; set; }
 
@@ -46,14 +52,22 @@ namespace WorkflowCore.Interface
         /// </summary>
         /// <param name="outcomeValue"></param>
         /// <returns></returns>
-        IStepBuilder<TData, TStepBody> Branch<TStep>(object outcomeValue, IStepBuilder<TData, TStep> branch) where TStep : IStepBody;
+        IStepBuilder<TData, TStepBody> Branch<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(object outcomeValue, IStepBuilder<TData, TStep> branch) where TStep : IStepBody;
 
         /// <summary>
         /// Configure an outcome branch for this step, then wire it to another step
         /// </summary>
         /// <param name="outcomeExpression"></param>
         /// <returns></returns>
-        IStepBuilder<TData, TStepBody> Branch<TStep>(Expression<Func<TData, object, bool>> outcomeExpression, IStepBuilder<TData, TStep> branch) where TStep : IStepBody;
+        IStepBuilder<TData, TStepBody> Branch<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(Expression<Func<TData, object, bool>> outcomeExpression, IStepBuilder<TData, TStep> branch) where TStep : IStepBody;
 
         /// <summary>
         /// Map properties on the step to properties on the workflow data object before the step executes
@@ -97,7 +111,11 @@ namespace WorkflowCore.Interface
         /// <returns></returns>
         IStepBuilder<TData, TStepBody> Output(Action<TStepBody, TData> action);
 
-        IStepBuilder<TData, TStep> End<TStep>(string name) where TStep : IStepBody;
+        IStepBuilder<TData, TStep> End<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(string name) where TStep : IStepBody;
 
         /// <summary>
         /// Configure the behavior when this step throws an unhandled exception
@@ -119,7 +137,11 @@ namespace WorkflowCore.Interface
         /// <typeparam name="TStep">The type of the step to execute</typeparam>
         /// <param name="stepSetup">Configure additional parameters for this step</param>
         /// <returns></returns>
-        IStepBuilder<TData, TStepBody> CompensateWith<TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody;
+        IStepBuilder<TData, TStepBody> CompensateWith<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody;
 
         /// <summary>
         /// Undo step if unhandled exception is thrown by this step

--- a/src/WorkflowCore/Interface/IStepOutcomeBuilder.cs
+++ b/src/WorkflowCore/Interface/IStepOutcomeBuilder.cs
@@ -1,18 +1,29 @@
 ﻿using System;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using WorkflowCore.Models;
 using WorkflowCore.Primitives;
 
 namespace WorkflowCore.Interface
-{   
+{
     public interface IStepOutcomeBuilder<TData>
     {
         IWorkflowBuilder<TData> WorkflowBuilder { get; }
 
         ValueOutcome Outcome { get; }
 
-        IStepBuilder<TData, TStep> Then<TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody;
+        IStepBuilder<TData, TStep> Then<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody;
 
-        IStepBuilder<TData, TStep> Then<TStep>(IStepBuilder<TData, TStep> step) where TStep : IStepBody;
+        IStepBuilder<TData, TStep> Then<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(IStepBuilder<TData, TStep> step) where TStep : IStepBody;
 
         IStepBuilder<TData, InlineStepBody> Then(Func<IStepExecutionContext, ExecutionResult> body);
 

--- a/src/WorkflowCore/Interface/IWorkflowBuilder.cs
+++ b/src/WorkflowCore/Interface/IWorkflowBuilder.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Collections.Generic;
 using WorkflowCore.Models;
 using WorkflowCore.Primitives;
@@ -11,7 +14,11 @@ namespace WorkflowCore.Interface
 
         int LastStep { get; }
 
-        IWorkflowBuilder<T> UseData<T>();
+        IWorkflowBuilder<T> UseData<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            T>();
 
         WorkflowDefinition Build(string id, int version);
 
@@ -22,7 +29,11 @@ namespace WorkflowCore.Interface
 
     public interface IWorkflowBuilder<TData> : IWorkflowBuilder, IWorkflowModifier<TData, InlineStepBody>
     {
-        IStepBuilder<TData, TStep> StartWith<TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody;
+        IStepBuilder<TData, TStep> StartWith<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody;
 
         IStepBuilder<TData, InlineStepBody> StartWith(Func<IStepExecutionContext, ExecutionResult> body);
 

--- a/src/WorkflowCore/Interface/IWorkflowController.cs
+++ b/src/WorkflowCore/Interface/IWorkflowController.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace WorkflowCore.Interface
 {
@@ -11,8 +15,16 @@ namespace WorkflowCore.Interface
         Task<string> StartWorkflow<TData>(string workflowId, int? version, TData data = null, string reference=null) where TData : class, new();
 
         Task PublishEvent(string eventName, string eventKey, object eventData, DateTime? effectiveDate = null);
-        void RegisterWorkflow<TWorkflow>() where TWorkflow : IWorkflow;
-        void RegisterWorkflow<TWorkflow, TData>() where TWorkflow : IWorkflow<TData> where TData : new();
+        void RegisterWorkflow<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            TWorkflow>() where TWorkflow : IWorkflow;
+        void RegisterWorkflow<
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            TWorkflow, TData>() where TWorkflow : IWorkflow<TData> where TData : new();
 
         /// <summary>
         /// Suspend the execution of a given workflow until .ResumeWorkflow is called
@@ -29,11 +41,10 @@ namespace WorkflowCore.Interface
         Task<bool> ResumeWorkflow(string workflowId);
 
         /// <summary>
-        /// Permanently terminate the exeuction of a given workflow
+        /// Permanently terminate the execution of a given workflow
         /// </summary>
         /// <param name="workflowId"></param>
         /// <returns></returns>
         Task<bool> TerminateWorkflow(string workflowId);
-
     }
 }

--- a/src/WorkflowCore/Interface/IWorkflowModifier.cs
+++ b/src/WorkflowCore/Interface/IWorkflowModifier.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Collections;
 using System.Linq.Expressions;
 using WorkflowCore.Models;
@@ -6,182 +9,207 @@ using WorkflowCore.Primitives;
 
 namespace WorkflowCore.Interface
 {
-    public interface IWorkflowModifier<TData, TStepBody>
+    public interface IWorkflowModifier<TData,
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+        TStepBody>
         where TStepBody : IStepBody
 
     {
-    /// <summary>
-    /// Specify the next step in the workflow
-    /// </summary>
-    /// <typeparam name="TStep">The type of the step to execute</typeparam>
-    /// <param name="stepSetup">Configure additional parameters for this step</param>
-    /// <returns></returns>
-    IStepBuilder<TData, TStep> Then<TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody;
+        /// <summary>
+        /// Specify the next step in the workflow
+        /// </summary>
+        /// <typeparam name="TStep">The type of the step to execute</typeparam>
+        /// <param name="stepSetup">Configure additional parameters for this step</param>
+        /// <returns></returns>
+        IStepBuilder<TData, TStep> Then<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody;
 
-    /// <summary>
-    /// Specify the next step in the workflow
-    /// </summary>
-    /// <typeparam name="TStep"></typeparam>
-    /// <param name="newStep"></param>
-    /// <returns></returns>
-    IStepBuilder<TData, TStep> Then<TStep>(IStepBuilder<TData, TStep> newStep) where TStep : IStepBody;
+        /// <summary>
+        /// Specify the next step in the workflow
+        /// </summary>
+        /// <typeparam name="TStep"></typeparam>
+        /// <param name="newStep"></param>
+        /// <returns></returns>
+        IStepBuilder<TData, TStep> Then<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(IStepBuilder<TData, TStep> newStep) where TStep : IStepBody;
 
-    /// <summary>
-    /// Specify an inline next step in the workflow
-    /// </summary>
-    /// <param name="body"></param>
-    /// <returns></returns>
-    IStepBuilder<TData, InlineStepBody> Then(Func<IStepExecutionContext, ExecutionResult> body);
+        /// <summary>
+        /// Specify an inline next step in the workflow
+        /// </summary>
+        /// <param name="body"></param>
+        /// <returns></returns>
+        IStepBuilder<TData, InlineStepBody> Then(Func<IStepExecutionContext, ExecutionResult> body);
 
-    /// <summary>
-    /// Specify an inline next step in the workflow
-    /// </summary>
-    /// <param name="body"></param>
-    /// <returns></returns>
-    IStepBuilder<TData, ActionStepBody> Then(Action<IStepExecutionContext> body);
+        /// <summary>
+        /// Specify an inline next step in the workflow
+        /// </summary>
+        /// <param name="body"></param>
+        /// <returns></returns>
+        IStepBuilder<TData, ActionStepBody> Then(Action<IStepExecutionContext> body);
 
-    /// <summary>
-    /// Wait here until to specified event is published
-    /// </summary>
-    /// <param name="eventName">The name used to identify the kind of event to wait for</param>
-    /// <param name="eventKey">A specific key value within the context of the event to wait for</param>
-    /// <param name="effectiveDate">Listen for events as of this effective date</param>
-    /// <param name="cancelCondition">A conditon that when true will cancel this WaitFor</param>
-    /// <returns></returns>
-    IStepBuilder<TData, WaitFor> WaitFor(string eventName, Expression<Func<TData, string>> eventKey,
-        Expression<Func<TData, DateTime>> effectiveDate = null, Expression<Func<TData, bool>> cancelCondition = null);
+        /// <summary>
+        /// Wait here until to specified event is published
+        /// </summary>
+        /// <param name="eventName">The name used to identify the kind of event to wait for</param>
+        /// <param name="eventKey">A specific key value within the context of the event to wait for</param>
+        /// <param name="effectiveDate">Listen for events as of this effective date</param>
+        /// <param name="cancelCondition">A condition that when true will cancel this WaitFor</param>
+        /// <returns></returns>
+        IStepBuilder<TData, WaitFor> WaitFor(
+            string eventName, Expression<Func<TData, string>> eventKey,
+            Expression<Func<TData, DateTime>> effectiveDate = null,
+            Expression<Func<TData, bool>> cancelCondition = null);
 
-    /// <summary>
-    /// Wait here until to specified event is published
-    /// </summary>
-    /// <param name="eventName">The name used to identify the kind of event to wait for</param>
-    /// <param name="eventKey">A specific key value within the context of the event to wait for</param>
-    /// <param name="effectiveDate">Listen for events as of this effective date</param>
-    /// <param name="cancelCondition">A conditon that when true will cancel this WaitFor</param>
-    /// <returns></returns>
-    IStepBuilder<TData, WaitFor> WaitFor(string eventName,
-        Expression<Func<TData, IStepExecutionContext, string>> eventKey,
-        Expression<Func<TData, DateTime>> effectiveDate = null, Expression<Func<TData, bool>> cancelCondition = null);
+        /// <summary>
+        /// Wait here until to specified event is published
+        /// </summary>
+        /// <param name="eventName">The name used to identify the kind of event to wait for</param>
+        /// <param name="eventKey">A specific key value within the context of the event to wait for</param>
+        /// <param name="effectiveDate">Listen for events as of this effective date</param>
+        /// <param name="cancelCondition">A condition that when true will cancel this WaitFor</param>
+        /// <returns></returns>
+        IStepBuilder<TData, WaitFor> WaitFor(string eventName,
+            Expression<Func<TData, IStepExecutionContext, string>> eventKey,
+            Expression<Func<TData, DateTime>> effectiveDate = null,
+            Expression<Func<TData, bool>> cancelCondition = null);
 
-    /// <summary>
-    /// Wait for a specified period
-    /// </summary>
-    /// <param name="period"></param>
-    /// <returns></returns>
-    IStepBuilder<TData, Delay> Delay(Expression<Func<TData, TimeSpan>> period);
+        /// <summary>
+        /// Wait for a specified period
+        /// </summary>
+        /// <param name="period"></param>
+        /// <returns></returns>
+        IStepBuilder<TData, Delay> Delay(Expression<Func<TData, TimeSpan>> period);
 
-    /// <summary>
-    /// Evaluate an expression and take a different path depending on the value
-    /// </summary>
-    /// <param name="expression">Expression to evaluate for decision</param>
-    /// <returns></returns>
-    IStepBuilder<TData, Decide> Decide(Expression<Func<TData, object>> expression);
+        /// <summary>
+        /// Evaluate an expression and take a different path depending on the value
+        /// </summary>
+        /// <param name="expression">Expression to evaluate for decision</param>
+        /// <returns></returns>
+        IStepBuilder<TData, Decide> Decide(Expression<Func<TData, object>> expression);
 
-    /// <summary>
-    /// Execute a block of steps, once for each item in a collection in a parallel foreach
-    /// </summary>
-    /// <param name="collection">Resolves a collection for iterate over</param>
-    /// <returns></returns>
-    IContainerStepBuilder<TData, Foreach, Foreach> ForEach(Expression<Func<TData, IEnumerable>> collection);
+        /// <summary>
+        /// Execute a block of steps, once for each item in a collection in a parallel foreach
+        /// </summary>
+        /// <param name="collection">Resolves a collection for iterate over</param>
+        /// <returns></returns>
+        IContainerStepBuilder<TData, Foreach, Foreach> ForEach(Expression<Func<TData, IEnumerable>> collection);
 
-    /// <summary>
-    /// Execute a block of steps, once for each item in a collection in a RunParallel foreach
-    /// </summary>
-    /// <param name="collection">Resolves a collection for iterate over</param>
-    /// <returns></returns>
-    IContainerStepBuilder<TData, Foreach, Foreach> ForEach(Expression<Func<TData, IEnumerable>> collection, Expression<Func<TData, bool>> runParallel);
+        /// <summary>
+        /// Execute a block of steps, once for each item in a collection in a RunParallel foreach
+        /// </summary>
+        /// <param name="collection">Resolves a collection for iterate over</param>
+        /// <returns></returns>
+        IContainerStepBuilder<TData, Foreach, Foreach> ForEach(
+            Expression<Func<TData, IEnumerable>> collection,
+            Expression<Func<TData, bool>> runParallel);
 
-    /// <summary>
-    /// Execute a block of steps, once for each item in a collection in a RunParallel foreach
-    /// </summary>
-    /// <param name="collection">Resolves a collection for iterate over</param>
-    /// <returns></returns>
-    IContainerStepBuilder<TData, Foreach, Foreach> ForEach(Expression<Func<TData, IStepExecutionContext, IEnumerable>> collection, Expression<Func<TData, bool>> runParallel);
+        /// <summary>
+        /// Execute a block of steps, once for each item in a collection in a RunParallel foreach
+        /// </summary>
+        /// <param name="collection">Resolves a collection for iterate over</param>
+        /// <returns></returns>
+        IContainerStepBuilder<TData, Foreach, Foreach> ForEach(
+            Expression<Func<TData, IStepExecutionContext, IEnumerable>> collection,
+            Expression<Func<TData, bool>> runParallel);
 
-    /// <summary>
-    /// Repeat a block of steps until a condition becomes true
-    /// </summary>
-    /// <param name="condition">Resolves a condition to break out of the while loop</param>
-    /// <returns></returns>
-    IContainerStepBuilder<TData, While, While> While(Expression<Func<TData, bool>> condition);
+        /// <summary>
+        /// Repeat a block of steps until a condition becomes true
+        /// </summary>
+        /// <param name="condition">Resolves a condition to break out of the while loop</param>
+        /// <returns></returns>
+        IContainerStepBuilder<TData, While, While> While(Expression<Func<TData, bool>> condition);
 
-    /// <summary>
-    /// Repeat a block of steps until a condition becomes true
-    /// </summary>
-    /// <param name="condition">Resolves a condition to break out of the while loop</param>
-    /// <returns></returns>
-    IContainerStepBuilder<TData, While, While> While(Expression<Func<TData, IStepExecutionContext, bool>> condition);
+        /// <summary>
+        /// Repeat a block of steps until a condition becomes true
+        /// </summary>
+        /// <param name="condition">Resolves a condition to break out of the while loop</param>
+        /// <returns></returns>
+        IContainerStepBuilder<TData, While, While> While(Expression<Func<TData, IStepExecutionContext, bool>> condition);
 
-    /// <summary>
-    /// Execute a block of steps if a condition is true
-    /// </summary>
-    /// <param name="condition">Resolves a condition to evaluate</param>
-    /// <returns></returns>
-    IContainerStepBuilder<TData, If, If> If(Expression<Func<TData, bool>> condition);
+        /// <summary>
+        /// Execute a block of steps if a condition is true
+        /// </summary>
+        /// <param name="condition">Resolves a condition to evaluate</param>
+        /// <returns></returns>
+        IContainerStepBuilder<TData, If, If> If(Expression<Func<TData, bool>> condition);
 
-    /// <summary>
-    /// Execute a block of steps if a condition is true
-    /// </summary>
-    /// <param name="condition">Resolves a condition to evaluate</param>
-    /// <returns></returns>
-    IContainerStepBuilder<TData, If, If> If(Expression<Func<TData, IStepExecutionContext, bool>> condition);
+        /// <summary>
+        /// Execute a block of steps if a condition is true
+        /// </summary>
+        /// <param name="condition">Resolves a condition to evaluate</param>
+        /// <returns></returns>
+        IContainerStepBuilder<TData, If, If> If(Expression<Func<TData, IStepExecutionContext, bool>> condition);
 
-    /// <summary>
-    /// Configure an outcome for this step, then wire it to a sequence
-    /// </summary>
-    /// <param name="outcomeValue"></param>
-    /// <returns></returns>
-    IContainerStepBuilder<TData, When, OutcomeSwitch> When(Expression<Func<TData, object>> outcomeValue,
-        string label = null);
+        /// <summary>
+        /// Configure an outcome for this step, then wire it to a sequence
+        /// </summary>
+        /// <param name="outcomeValue"></param>
+        /// <returns></returns>
+        IContainerStepBuilder<TData, When, OutcomeSwitch> When(Expression<Func<TData, object>> outcomeValue, string label = null);
 
-    /// <summary>
-    /// Execute multiple blocks of steps in parallel
-    /// </summary>
-    /// <returns></returns>
-    IParallelStepBuilder<TData, Sequence> Parallel();
+        /// <summary>
+        /// Execute multiple blocks of steps in parallel
+        /// </summary>
+        /// <returns></returns>
+        IParallelStepBuilder<TData, Sequence> Parallel();
 
-    /// <summary>
-    /// Execute a sequence of steps in a container
-    /// </summary>
-    /// <returns></returns>
-    IStepBuilder<TData, Sequence> Saga(Action<IWorkflowBuilder<TData>> builder);
+        /// <summary>
+        /// Execute a sequence of steps in a container
+        /// </summary>
+        /// <returns></returns>
+        IStepBuilder<TData, Sequence> Saga(Action<IWorkflowBuilder<TData>> builder);
 
-    /// <summary>
-    /// Schedule a block of steps to execute in parallel sometime in the future
-    /// </summary>
-    /// <param name="time">The time span to wait before executing the block</param>
-    /// <returns></returns>
-    IContainerStepBuilder<TData, Schedule, TStepBody> Schedule(Expression<Func<TData, TimeSpan>> time);
+        /// <summary>
+        /// Schedule a block of steps to execute in parallel sometime in the future
+        /// </summary>
+        /// <param name="time">The time span to wait before executing the block</param>
+        /// <returns></returns>
+        IContainerStepBuilder<TData, Schedule, TStepBody> Schedule(Expression<Func<TData, TimeSpan>> time);
 
-    /// <summary>
-    /// Schedule a block of steps to execute in parallel sometime in the future at a recurring interval
-    /// </summary>
-    /// <param name="interval">The time span to wait between recurring executions</param>
-    /// <param name="until">Resolves a condition to stop the recurring task</param>
-    /// <returns></returns>
-    IContainerStepBuilder<TData, Recur, TStepBody> Recur(Expression<Func<TData, TimeSpan>> interval,
-        Expression<Func<TData, bool>> until);
+        /// <summary>
+        /// Schedule a block of steps to execute in parallel sometime in the future at a recurring interval
+        /// </summary>
+        /// <param name="interval">The time span to wait between recurring executions</param>
+        /// <param name="until">Resolves a condition to stop the recurring task</param>
+        /// <returns></returns>
+        IContainerStepBuilder<TData, Recur, TStepBody> Recur(
+            Expression<Func<TData, TimeSpan>> interval,
+            Expression<Func<TData, bool>> until);
 
-    /// <summary>
-    /// Wait here until an external activity is complete
-    /// </summary>
-    /// <param name="activityName">The name used to identify the activity to wait for</param>
-    /// <param name="parameters">The data to pass the external activity worker</param>
-    /// <param name="effectiveDate">Listen for events as of this effective date</param>
-    /// <param name="cancelCondition">A conditon that when true will cancel this WaitFor</param>
-    /// <returns></returns>
-    IStepBuilder<TData, Activity> Activity(string activityName, Expression<Func<TData, object>> parameters = null,
-        Expression<Func<TData, DateTime>> effectiveDate = null, Expression<Func<TData, bool>> cancelCondition = null);
+        /// <summary>
+        /// Wait here until an external activity is complete
+        /// </summary>
+        /// <param name="activityName">The name used to identify the activity to wait for</param>
+        /// <param name="parameters">The data to pass the external activity worker</param>
+        /// <param name="effectiveDate">Listen for events as of this effective date</param>
+        /// <param name="cancelCondition">A condition that when true will cancel this WaitFor</param>
+        /// <returns></returns>
+        IStepBuilder<TData, Activity> Activity(
+            string activityName,
+            Expression<Func<TData, object>> parameters = null,
+            Expression<Func<TData, DateTime>> effectiveDate = null,
+            Expression<Func<TData, bool>> cancelCondition = null);
 
-    /// <summary>
-    /// Wait here until an external activity is complete
-    /// </summary>
-    /// <param name="activityName">The name used to identify the activity to wait for</param>
-    /// <param name="parameters">The data to pass the external activity worker</param>
-    /// <param name="effectiveDate">Listen for events as of this effective date</param>
-    /// <param name="cancelCondition">A conditon that when true will cancel this WaitFor</param>
-    /// <returns></returns>
-    IStepBuilder<TData, Activity> Activity(Expression<Func<TData, IStepExecutionContext, string>> activityName, Expression<Func<TData, object>> parameters = null,
-        Expression<Func<TData, DateTime>> effectiveDate = null, Expression<Func<TData, bool>> cancelCondition = null);
+        /// <summary>
+        /// Wait here until an external activity is complete
+        /// </summary>
+        /// <param name="activityName">The name used to identify the activity to wait for</param>
+        /// <param name="parameters">The data to pass the external activity worker</param>
+        /// <param name="effectiveDate">Listen for events as of this effective date</param>
+        /// <param name="cancelCondition">A condition that when true will cancel this WaitFor</param>
+        /// <returns></returns>
+        IStepBuilder<TData, Activity> Activity(
+            Expression<Func<TData, IStepExecutionContext, string>> activityName,
+            Expression<Func<TData, object>> parameters = null,
+            Expression<Func<TData, DateTime>> effectiveDate = null,
+            Expression<Func<TData, bool>> cancelCondition = null);
     }
 }

--- a/src/WorkflowCore/Interface/IWorkflowRegistry.cs
+++ b/src/WorkflowCore/Interface/IWorkflowRegistry.cs
@@ -1,4 +1,7 @@
 ﻿using System.Collections.Generic;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using WorkflowCore.Models;
 
 namespace WorkflowCore.Interface

--- a/src/WorkflowCore/Models/WorkflowDefinition.cs
+++ b/src/WorkflowCore/Models/WorkflowDefinition.cs
@@ -1,5 +1,8 @@
 ﻿using System;
-
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+#endif
 
 namespace WorkflowCore.Models
 {
@@ -13,6 +16,9 @@ namespace WorkflowCore.Models
 
         public WorkflowStepCollection Steps { get; set; } = new WorkflowStepCollection();
 
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
         public Type DataType { get; set; }
 
         public WorkflowErrorHandling DefaultErrorBehavior { get; set; }
@@ -21,9 +27,11 @@ namespace WorkflowCore.Models
         public Type OnExecuteMiddlewareError { get; set; }
 
         public TimeSpan? DefaultErrorRetryInterval { get; set; }
-
     }
 
+#if NET8_0_OR_GREATER
+    [JsonConverter(typeof(JsonStringEnumConverter<WorkflowErrorHandling>))]
+#endif
     public enum WorkflowErrorHandling
     {
         Retry = 0,

--- a/src/WorkflowCore/Models/WorkflowStep.cs
+++ b/src/WorkflowCore/Models/WorkflowStep.cs
@@ -1,12 +1,19 @@
 ﻿using System;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Reflection;
 using WorkflowCore.Interface;
 
 namespace WorkflowCore.Models
 {
     public abstract class WorkflowStep
     {
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
         public abstract Type BodyType { get; }
 
         public virtual int Id { get; set; }
@@ -48,7 +55,7 @@ namespace WorkflowCore.Models
         }
 
         public virtual void AfterExecute(WorkflowExecutorResult executorResult, IStepExecutionContext context, ExecutionResult stepResult, ExecutionPointer executionPointer)
-        {            
+        {
         }
 
         public virtual void PrimeForRetry(ExecutionPointer pointer)
@@ -57,40 +64,45 @@ namespace WorkflowCore.Models
 
         /// <summary>
         /// Called after every workflow execution round,
-        /// every exectuon pointer with no end time, even if this step was not executed in this round
+        /// every execution pointer with no end time, even if this step was not executed in this round
         /// </summary>
         /// <param name="executorResult"></param>
-        /// <param name="defintion"></param>
+        /// <param name="definition"></param>
         /// <param name="workflow"></param>
         /// <param name="executionPointer"></param>
-        public virtual void AfterWorkflowIteration(WorkflowExecutorResult executorResult, WorkflowDefinition defintion, WorkflowInstance workflow, ExecutionPointer executionPointer)
+        public virtual void AfterWorkflowIteration(WorkflowExecutorResult executorResult, WorkflowDefinition definition, WorkflowInstance workflow, ExecutionPointer executionPointer)
         {
-            
         }
 
         public virtual IStepBody ConstructBody(IServiceProvider serviceProvider)
         {
-            IStepBody body = (serviceProvider.GetService(BodyType) as IStepBody);
-            if (body == null)
+            if (serviceProvider.GetService(BodyType) is IStepBody body)
             {
-                var stepCtor = BodyType.GetConstructor(new Type[] { });
-                if (stepCtor != null)
-                    body = (stepCtor.Invoke(null) as IStepBody);
+                return body;
             }
-            return body;
+
+            var stepCtor = BodyType.GetConstructor(Array.Empty<Type>());
+            return stepCtor != null ? stepCtor.Invoke(Array.Empty<object>()) as IStepBody : null;
         }
     }
 
-    public class WorkflowStep<TStepBody> : WorkflowStep
-        where TStepBody : IStepBody 
+    public class WorkflowStep<
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+        TStepBody> : WorkflowStep
+        where TStepBody : IStepBody
     {
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
         public override Type BodyType => typeof(TStepBody);
     }
 
-	public enum ExecutionPipelineDirective 
-    { 
-        Next = 0, 
-        Defer = 1, 
-        EndWorkflow = 2 
+    public enum ExecutionPipelineDirective
+    {
+        Next = 0,
+        Defer = 1,
+        EndWorkflow = 2
     }
 }

--- a/src/WorkflowCore/Models/WorkflowStepCollection.cs
+++ b/src/WorkflowCore/Models/WorkflowStepCollection.cs
@@ -8,7 +8,7 @@ namespace WorkflowCore.Models
     public class WorkflowStepCollection : ICollection<WorkflowStep>
     {
         private readonly Dictionary<int, WorkflowStep> _dictionary = new Dictionary<int, WorkflowStep>();
-        
+
         public WorkflowStepCollection()
         {
         }
@@ -38,12 +38,9 @@ namespace WorkflowCore.Models
 
         public WorkflowStep FindById(int id)
         {
-            if (!_dictionary.ContainsKey(id))
-                return null;
-
-            return _dictionary[id];
+            return !_dictionary.TryGetValue(id, out WorkflowStep value) ? null : value;
         }
-        
+
         public void Add(WorkflowStep item)
         {
             _dictionary.Add(item.Id, item);

--- a/src/WorkflowCore/Primitives/Activity.cs
+++ b/src/WorkflowCore/Primitives/Activity.cs
@@ -8,25 +8,18 @@ namespace WorkflowCore.Primitives
     public class Activity : StepBody
     {
         public string ActivityName { get; set; }
-        
+
         public DateTime EffectiveDate { get; set; }
 
         public object Parameters { get; set; }
-        
+
         public object Result { get; set; }
 
         public override ExecutionResult Run(IStepExecutionContext context)
         {
             if (!context.ExecutionPointer.EventPublished)
             {
-                DateTime effectiveDate = DateTime.MinValue;
-
-                if (EffectiveDate != null)
-                {
-                    effectiveDate = EffectiveDate;
-                }
-
-                return ExecutionResult.WaitForActivity(ActivityName, Parameters, effectiveDate);
+                return ExecutionResult.WaitForActivity(ActivityName, Parameters, EffectiveDate);
             }
 
             if (context.ExecutionPointer.EventData is ActivityResult)

--- a/src/WorkflowCore/Primitives/EndStep.cs
+++ b/src/WorkflowCore/Primitives/EndStep.cs
@@ -1,16 +1,22 @@
 ﻿using System;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using WorkflowCore.Models;
 
 namespace WorkflowCore.Primitives
 {
     public class EndStep : WorkflowStep
     {
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
         public override Type BodyType => null;
 
         public override ExecutionPipelineDirective InitForExecution(
-            WorkflowExecutorResult executorResult, 
-            WorkflowDefinition defintion, 
-            WorkflowInstance workflow, 
+            WorkflowExecutorResult executorResult,
+            WorkflowDefinition definition,
+            WorkflowInstance workflow,
             ExecutionPointer executionPointer)
         {
             return ExecutionPipelineDirective.EndWorkflow;

--- a/src/WorkflowCore/Primitives/SagaContainer.cs
+++ b/src/WorkflowCore/Primitives/SagaContainer.cs
@@ -1,9 +1,16 @@
-﻿using WorkflowCore.Interface;
+﻿#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+using WorkflowCore.Interface;
 using WorkflowCore.Models;
 
 namespace WorkflowCore.Primitives
 {
-    public class SagaContainer<TStepBody> : WorkflowStep<TStepBody>
+    public class SagaContainer<
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+        TStepBody> : WorkflowStep<TStepBody>
         where TStepBody : IStepBody
     {
         public override bool ResumeChildrenAfterCompensation => false;

--- a/src/WorkflowCore/Primitives/WaitFor.cs
+++ b/src/WorkflowCore/Primitives/WaitFor.cs
@@ -18,14 +18,7 @@ namespace WorkflowCore.Primitives
         {
             if (!context.ExecutionPointer.EventPublished)
             {
-                DateTime effectiveDate = DateTime.MinValue;
-
-                if (EffectiveDate != null)
-                {
-                    effectiveDate = EffectiveDate;
-                }
-
-                return ExecutionResult.WaitForEvent(EventName, EventKey, effectiveDate);
+                return ExecutionResult.WaitForEvent(EventName, EventKey, EffectiveDate);
             }
 
             EventData = context.ExecutionPointer.EventData;

--- a/src/WorkflowCore/ServiceCollectionExtensions.cs
+++ b/src/WorkflowCore/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using WorkflowCore.Interface;
 using WorkflowCore.Services;
@@ -93,7 +94,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TMiddleware">The type of middleware.
         /// It must implement <see cref="IWorkflowStepMiddleware"/>.</typeparam>
         /// <returns>The services collection for chaining.</returns>
-        public static IServiceCollection AddWorkflowStepMiddleware<TMiddleware>(
+        public static IServiceCollection AddWorkflowStepMiddleware<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            TMiddleware>(
             this IServiceCollection services,
             Func<IServiceProvider, TMiddleware> factory = null)
             where TMiddleware : class, IWorkflowStepMiddleware =>
@@ -111,7 +116,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TMiddleware">The type of middleware.
         /// It must implement <see cref="IWorkflowMiddleware"/>.</typeparam>
         /// <returns>The services collection for chaining.</returns>
-        public static IServiceCollection AddWorkflowMiddleware<TMiddleware>(
+        public static IServiceCollection AddWorkflowMiddleware<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            TMiddleware>(
             this IServiceCollection services,
             Func<IServiceProvider, TMiddleware> factory = null)
             where TMiddleware : class, IWorkflowMiddleware =>
@@ -120,4 +129,3 @@ namespace Microsoft.Extensions.DependencyInjection
                     : services.AddTransient<IWorkflowMiddleware, TMiddleware>(factory);
     }
 }
-

--- a/src/WorkflowCore/Services/DefaultProviders/MemoryPersistenceProvider.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/MemoryPersistenceProvider.cs
@@ -99,14 +99,14 @@ namespace WorkflowCore.Services
         {
             lock (_instances)
             {
-                var result = _instances.AsQueryable();
+                IEnumerable<WorkflowInstance> result = _instances;
 
                 if (status.HasValue)
                 {
                     result = result.Where(x => x.Status == status.Value);
                 }
 
-                if (!String.IsNullOrEmpty(type))
+                if (!string.IsNullOrEmpty(type))
                 {
                     result = result.Where(x => x.WorkflowDefinitionId == type);
                 }

--- a/src/WorkflowCore/Services/DefaultProviders/TransientMemoryPersistenceProvider.cs
+++ b/src/WorkflowCore/Services/DefaultProviders/TransientMemoryPersistenceProvider.cs
@@ -40,6 +40,7 @@ namespace WorkflowCore.Services
 
         public Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(IEnumerable<string> ids, CancellationToken _ = default) => _innerService.GetWorkflowInstances(ids);
 
+        [Obsolete]
         public Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(WorkflowStatus? status, string type, DateTime? createdFrom, DateTime? createdTo, int skip, int take) => _innerService.GetWorkflowInstances(status, type, createdFrom, createdTo, skip, take);
 
         public Task MarkEventProcessed(string id, CancellationToken _ = default) => _innerService.MarkEventProcessed(id);

--- a/src/WorkflowCore/Services/FluentBuilders/ParallelStepBuilder.cs
+++ b/src/WorkflowCore/Services/FluentBuilders/ParallelStepBuilder.cs
@@ -1,11 +1,18 @@
 ﻿using System;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
 using WorkflowCore.Primitives;
 
 namespace WorkflowCore.Services
 {
-    public class ParallelStepBuilder<TData, TStepBody> : IParallelStepBuilder<TData, TStepBody>
+    public class ParallelStepBuilder<TData,
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+        TStepBody> : IParallelStepBuilder<TData, TStepBody>
         where TStepBody : IStepBody
     {
         private readonly IStepBuilder<TData, Sequence> _referenceBuilder;
@@ -14,7 +21,7 @@ namespace WorkflowCore.Services
         public IWorkflowBuilder<TData> WorkflowBuilder { get; private set; }
 
         public WorkflowStep<TStepBody> Step { get; set; }
-        
+
         public ParallelStepBuilder(IWorkflowBuilder<TData> workflowBuilder, IStepBuilder<TData, TStepBody> stepBuilder, IStepBuilder<TData, Sequence> referenceBuilder)
         {
             WorkflowBuilder = workflowBuilder;
@@ -22,15 +29,15 @@ namespace WorkflowCore.Services
             _stepBuilder = stepBuilder;
             _referenceBuilder = referenceBuilder;
         }
-        
+
         public IParallelStepBuilder<TData, TStepBody> Do(Action<IWorkflowBuilder<TData>> builder)
         {
             var lastStep = WorkflowBuilder.LastStep;
             builder.Invoke(WorkflowBuilder);
-            
+
             if (lastStep == WorkflowBuilder.LastStep)
                 throw new NotSupportedException("Empty Do block not supported");
-            
+
             Step.Children.Add(lastStep + 1); //TODO: make more elegant
 
             return this;

--- a/src/WorkflowCore/Services/FluentBuilders/ReturnStepBuilder.cs
+++ b/src/WorkflowCore/Services/FluentBuilders/ReturnStepBuilder.cs
@@ -1,10 +1,21 @@
 ﻿using System;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
 
 namespace WorkflowCore.Services
 {
-    public class ReturnStepBuilder<TData, TStepBody, TParentStep> : IContainerStepBuilder<TData, TStepBody, TParentStep>
+    public class ReturnStepBuilder<TData,
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+        TStepBody,
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+        TParentStep> : IContainerStepBuilder<TData, TStepBody, TParentStep>
         where TStepBody : IStepBody
         where TParentStep : IStepBody
     {
@@ -20,7 +31,7 @@ namespace WorkflowCore.Services
             Step = step;
             _referenceBuilder = referenceBuilder;
         }
-        
+
         public IStepBuilder<TData, TParentStep> Do(Action<IWorkflowBuilder<TData>> builder)
         {
             builder.Invoke(WorkflowBuilder);

--- a/src/WorkflowCore/Services/FluentBuilders/StepBuilder.cs
+++ b/src/WorkflowCore/Services/FluentBuilders/StepBuilder.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Linq.Expressions;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
@@ -7,7 +10,11 @@ using WorkflowCore.Primitives;
 
 namespace WorkflowCore.Services
 {
-    public class StepBuilder<TData, TStepBody> : IStepBuilder<TData, TStepBody>, IContainerStepBuilder<TData, TStepBody, TStepBody>
+    public class StepBuilder<TData,
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+        TStepBody> : IStepBuilder<TData, TStepBody>, IContainerStepBuilder<TData, TStepBody, TStepBody>
         where TStepBody : IStepBody
     {
         public IWorkflowBuilder<TData> WorkflowBuilder { get; private set; }
@@ -32,7 +39,11 @@ namespace WorkflowCore.Services
             return this;
         }
 
-        public IStepBuilder<TData, TStep> Then<TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null)
+        public IStepBuilder<TData, TStep> Then<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null)
             where TStep : IStepBody
         {
             WorkflowStep<TStep> newStep = new WorkflowStep<TStep>();
@@ -50,7 +61,11 @@ namespace WorkflowCore.Services
             return stepBuilder;
         }
 
-        public IStepBuilder<TData, TStep> Then<TStep>(IStepBuilder<TData, TStep> newStep)
+        public IStepBuilder<TData, TStep> Then<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(IStepBuilder<TData, TStep> newStep)
             where TStep : IStepBody
         {
             Step.Outcomes.Add(new ValueOutcome { NextStep = newStep.Step.Id });
@@ -101,7 +116,11 @@ namespace WorkflowCore.Services
             return outcomeBuilder;
         }
 
-        public IStepBuilder<TData, TStepBody> Branch<TStep>(object outcomeValue, IStepBuilder<TData, TStep> branch) where TStep : IStepBody
+        public IStepBuilder<TData, TStepBody> Branch<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(object outcomeValue, IStepBuilder<TData, TStep> branch) where TStep : IStepBody
         {
             if (branch.WorkflowBuilder.Steps.Count == 0)
                 return this;
@@ -118,7 +137,11 @@ namespace WorkflowCore.Services
             return this;
         }
 
-        public IStepBuilder<TData, TStepBody> Branch<TStep>(Expression<Func<TData, object, bool>> outcomeExpression, IStepBuilder<TData, TStep> branch) where TStep : IStepBody
+        public IStepBuilder<TData, TStepBody> Branch<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(Expression<Func<TData, object, bool>> outcomeExpression, IStepBuilder<TData, TStep> branch) where TStep : IStepBody
         {
             if (branch.WorkflowBuilder.Steps.Count == 0)
                 return this;
@@ -207,7 +230,11 @@ namespace WorkflowCore.Services
             return stepBuilder;
         }
 
-        public IStepBuilder<TData, TStep> End<TStep>(string name) where TStep : IStepBody
+        public IStepBuilder<TData, TStep> End<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(string name) where TStep : IStepBody
         {
             var ancestor = IterateParents(Step.Id, name);
 
@@ -495,7 +522,11 @@ namespace WorkflowCore.Services
             return this;
         }
 
-        public IStepBuilder<TData, TStepBody> CompensateWith<TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody
+        public IStepBuilder<TData, TStepBody> CompensateWith<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody
         {
             WorkflowStep<TStep> newStep = new WorkflowStep<TStep>();
             WorkflowBuilder.AddStep(newStep);

--- a/src/WorkflowCore/Services/FluentBuilders/StepOutcomeBuilder.cs
+++ b/src/WorkflowCore/Services/FluentBuilders/StepOutcomeBuilder.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
 using WorkflowCore.Primitives;
@@ -16,7 +19,11 @@ namespace WorkflowCore.Services
             Outcome = outcome;
         }
 
-        public IStepBuilder<TData, TStep> Then<TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null)
+        public IStepBuilder<TData, TStep> Then<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null)
             where TStep : IStepBody
         {
             WorkflowStep<TStep> step = new WorkflowStep<TStep>();
@@ -34,7 +41,11 @@ namespace WorkflowCore.Services
             return stepBuilder;
         }
 
-        public IStepBuilder<TData, TStep> Then<TStep>(IStepBuilder<TData, TStep> step)
+        public IStepBuilder<TData, TStep> Then<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(IStepBuilder<TData, TStep> step)
             where TStep : IStepBody
         {
             Outcome.NextStep = step.Step.Id;

--- a/src/WorkflowCore/Services/FluentBuilders/WorkflowBuilder.cs
+++ b/src/WorkflowCore/Services/FluentBuilders/WorkflowBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,7 +22,11 @@ namespace WorkflowCore.Services
 
         public int LastStep => Steps.Max(x => x.Id);
 
-        public IWorkflowBuilder<T> UseData<T>()
+        public IWorkflowBuilder<T> UseData<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            T>()
         {
             IWorkflowBuilder<T> result = new WorkflowBuilder<T>(Steps);
             return result;
@@ -119,12 +124,14 @@ namespace WorkflowCore.Services
 
             Branches.Add(branch);
         }
-
     }
 
-    public class WorkflowBuilder<TData> : WorkflowBuilder, IWorkflowBuilder<TData>
+    public class WorkflowBuilder<
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+        TData> : WorkflowBuilder, IWorkflowBuilder<TData>
     {
-
         public override WorkflowDefinition Build(string id, int version)
         {
             var result = base.Build(id, version);
@@ -137,7 +144,11 @@ namespace WorkflowCore.Services
             this.Steps.AddRange(steps);
         }
 
-        public IStepBuilder<TData, TStep> StartWith<TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null)
+        public IStepBuilder<TData, TStep> StartWith<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null)
             where TStep : IStepBody
         {
             WorkflowStep<TStep> step = new WorkflowStep<TStep>();
@@ -189,12 +200,20 @@ namespace WorkflowCore.Services
             return result;
         }
 
-        public IStepBuilder<TData, TStep> Then<TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody
+        public IStepBuilder<TData, TStep> Then<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(Action<IStepBuilder<TData, TStep>> stepSetup = null) where TStep : IStepBody
         {
             return Start().Then(stepSetup);
         }
 
-        public IStepBuilder<TData, TStep> Then<TStep>(IStepBuilder<TData, TStep> newStep) where TStep : IStepBody
+        public IStepBuilder<TData, TStep> Then<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            TStep>(IStepBuilder<TData, TStep> newStep) where TStep : IStepBody
         {
             return Start().Then(newStep);
         }
@@ -209,13 +228,17 @@ namespace WorkflowCore.Services
             return Start().Then(body);
         }
 
-        public IStepBuilder<TData, WaitFor> WaitFor(string eventName, Expression<Func<TData, string>> eventKey, Expression<Func<TData, DateTime>> effectiveDate = null,
+        public IStepBuilder<TData, WaitFor> WaitFor(
+            string eventName, Expression<Func<TData, string>> eventKey,
+            Expression<Func<TData, DateTime>> effectiveDate = null,
             Expression<Func<TData, bool>> cancelCondition = null)
         {
             return Start().WaitFor(eventName, eventKey, effectiveDate, cancelCondition);
         }
 
-        public IStepBuilder<TData, WaitFor> WaitFor(string eventName, Expression<Func<TData, IStepExecutionContext, string>> eventKey, Expression<Func<TData, DateTime>> effectiveDate = null,
+        public IStepBuilder<TData, WaitFor> WaitFor(
+            string eventName, Expression<Func<TData, IStepExecutionContext, string>> eventKey,
+            Expression<Func<TData, DateTime>> effectiveDate = null,
             Expression<Func<TData, bool>> cancelCondition = null)
         {
             return Start().WaitFor(eventName, eventKey, effectiveDate, cancelCondition);
@@ -236,12 +259,16 @@ namespace WorkflowCore.Services
             return Start().ForEach(collection);
         }
 
-        public IContainerStepBuilder<TData, Foreach, Foreach> ForEach(Expression<Func<TData, IEnumerable>> collection, Expression<Func<TData, bool>> runParallel)
+        public IContainerStepBuilder<TData, Foreach, Foreach> ForEach(
+            Expression<Func<TData, IEnumerable>> collection,
+            Expression<Func<TData, bool>> runParallel)
         {
             return Start().ForEach(collection, runParallel);
         }
 
-        public IContainerStepBuilder<TData, Foreach, Foreach> ForEach(Expression<Func<TData, IStepExecutionContext, IEnumerable>> collection, Expression<Func<TData, bool>> runParallel)
+        public IContainerStepBuilder<TData, Foreach, Foreach> ForEach(
+            Expression<Func<TData, IStepExecutionContext, IEnumerable>> collection,
+            Expression<Func<TData, bool>> runParallel)
         {
             return Start().ForEach(collection, runParallel);
         }
@@ -286,17 +313,25 @@ namespace WorkflowCore.Services
             return Start().Schedule(time);
         }
 
-        public IContainerStepBuilder<TData, Recur, InlineStepBody> Recur(Expression<Func<TData, TimeSpan>> interval, Expression<Func<TData, bool>> until)
+        public IContainerStepBuilder<TData, Recur, InlineStepBody> Recur(
+            Expression<Func<TData, TimeSpan>> interval,
+            Expression<Func<TData, bool>> until)
         {
             return Start().Recur(interval, until);
         }
 
-        public IStepBuilder<TData, Activity> Activity(string activityName, Expression<Func<TData, object>> parameters = null, Expression<Func<TData, DateTime>> effectiveDate = null,
+        public IStepBuilder<TData, Activity> Activity(
+            string activityName, Expression<Func<TData, object>> parameters = null,
+            Expression<Func<TData, DateTime>> effectiveDate = null,
             Expression<Func<TData, bool>> cancelCondition = null)
         {
             return Start().Activity(activityName, parameters, effectiveDate, cancelCondition);
         }
-        public IStepBuilder<TData, Activity> Activity(Expression<Func<TData, IStepExecutionContext, string>> activityName, Expression<Func<TData, object>> parameters = null, Expression<Func<TData, DateTime>> effectiveDate = null, Expression<Func<TData, bool>> cancelCondition = null)
+        public IStepBuilder<TData, Activity> Activity(
+            Expression<Func<TData, IStepExecutionContext, string>> activityName,
+            Expression<Func<TData, object>> parameters = null,
+            Expression<Func<TData, DateTime>> effectiveDate = null,
+            Expression<Func<TData, bool>> cancelCondition = null)
         {
             return Start().Activity(activityName, parameters, effectiveDate, cancelCondition);
         }

--- a/src/WorkflowCore/Services/SyncWorkflowRunner.cs
+++ b/src/WorkflowCore/Services/SyncWorkflowRunner.cs
@@ -64,7 +64,7 @@ namespace WorkflowCore.Services
                 if (typeof(TData) == def.DataType)
                     wf.Data = new TData();
                 else
-                    wf.Data = def.DataType.GetConstructor(new Type[0]).Invoke(new object[0]);
+                    wf.Data = def.DataType.GetConstructor(Array.Empty<Type>()).Invoke(Array.Empty<object>());
             }
 
             wf.ExecutionPointers.Add(_pointerFactory.BuildGenesisPointer(def));

--- a/src/WorkflowCore/Services/WorkflowController.cs
+++ b/src/WorkflowCore/Services/WorkflowController.cs
@@ -1,5 +1,7 @@
 ﻿using System;
-using System.Linq;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -80,7 +82,7 @@ namespace WorkflowCore.Services
                 if (typeof(TData) == def.DataType)
                     wf.Data = new TData();
                 else
-                    wf.Data = def.DataType.GetConstructor(new Type[0]).Invoke(new object[0]);
+                    wf.Data = def.DataType.GetConstructor(Array.Empty<Type>()).Invoke(Array.Empty<object>());
             }
 
             wf.ExecutionPointers.Add(_pointerFactory.BuildGenesisPointer(def));
@@ -226,14 +228,22 @@ namespace WorkflowCore.Services
             }
         }
 
-        public void RegisterWorkflow<TWorkflow>()
+        public void RegisterWorkflow<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            TWorkflow>()
             where TWorkflow : IWorkflow
         {
             var wf = ActivatorUtilities.CreateInstance<TWorkflow>(_serviceProvider);
             _registry.RegisterWorkflow(wf);
         }
 
-        public void RegisterWorkflow<TWorkflow, TData>()
+        public void RegisterWorkflow<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            TWorkflow, TData>()
             where TWorkflow : IWorkflow<TData>
             where TData : new()
         {

--- a/src/WorkflowCore/Services/WorkflowHost.cs
+++ b/src/WorkflowCore/Services/WorkflowHost.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -135,13 +137,21 @@ namespace WorkflowCore.Services
             await _lifeCycleEventHub.Stop();
         }
 
-        public void RegisterWorkflow<TWorkflow>()
+        public void RegisterWorkflow<
+#if NET8_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            TWorkflow>()
             where TWorkflow : IWorkflow
         {
             _workflowController.RegisterWorkflow<TWorkflow>();
         }
 
-        public void RegisterWorkflow<TWorkflow, TData>()
+        public void RegisterWorkflow<
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            TWorkflow, TData>()
             where TWorkflow : IWorkflow<TData>
             where TData : new()
         {

--- a/src/WorkflowCore/WorkflowCore.csproj
+++ b/src/WorkflowCore/WorkflowCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Workflow Core</AssemblyTitle>
     <Authors>Daniel Gerlag</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>WorkflowCore</AssemblyName>
     <PackageId>WorkflowCore</PackageId>
     <PackageTags>workflow;.NET;Core;state machine</PackageTags>
@@ -13,28 +13,29 @@
     <Description>Workflow Core is a light weight workflow engine targeting .NET Standard.</Description>
   </PropertyGroup>
 
+  <!-- if net8.0, enable trimming -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <IsAotCompatible>true</IsAotCompatible>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="ConcurrentHashSet" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
-    <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.1.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
-	<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-		<_Parameter1>WorkflowCore.IntegrationTests</_Parameter1>
-	</AssemblyAttribute>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="OpenTelemetry.Api" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Services\DefinitionStorage\" />
+    <InternalsVisibleTo Include="WorkflowCore.IntegrationTests"/>
   </ItemGroup>
 
 </Project>

--- a/src/extensions/WorkflowCore.Users/WorkflowCore.Users.csproj
+++ b/src/extensions/WorkflowCore.Users/WorkflowCore.Users.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Workflow Core extensions for human workflow</AssemblyTitle>
     <Authors>Daniel Gerlag</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>WorkflowCore.Users</AssemblyName>
     <PackageId>WorkflowCore.Users</PackageId>
     <PackageTags>workflow;.NET;Core;state machine;WorkflowCore;human;user</PackageTags>
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/extensions/WorkflowCore.WebAPI/Controllers/WorkflowsController.cs
+++ b/src/extensions/WorkflowCore.WebAPI/Controllers/WorkflowsController.cs
@@ -27,8 +27,8 @@ namespace WorkflowCore.WebAPI.Controllers
             _logger = loggerFactory.CreateLogger<WorkflowsController>();
         }
 
-
         [HttpGet]
+        [Obsolete]
         public async Task<IActionResult> Get(WorkflowStatus? status, string type, DateTime? createdFrom, DateTime? createdTo, int skip, int take)
         {
             var result = await _workflowStore.GetWorkflowInstances(status, type, createdFrom, createdTo, skip, take);

--- a/src/extensions/WorkflowCore.WebAPI/WorkflowCore.WebAPI.csproj
+++ b/src/extensions/WorkflowCore.WebAPI/WorkflowCore.WebAPI.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Workflow Core REST API</AssemblyTitle>
     <Authors>Daniel Gerlag</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>WorkflowCore.WebAPI</AssemblyName>
     <PackageId>WorkflowCore.WebAPI</PackageId>
     <PackageTags>workflow;.NET;Core;state machine;WorkflowCore;REST;API</PackageTags>
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/providers/WorkflowCore.LockProviders.SqlServer/SqlLockProvider.cs
+++ b/src/providers/WorkflowCore.LockProviders.SqlServer/SqlLockProvider.cs
@@ -80,7 +80,7 @@ namespace WorkflowCore.LockProviders.SqlServer
                     catch (Exception ex)
                     {
                         connection.Close();
-                        throw ex;
+                        throw;
                     }
                 }
                 finally

--- a/src/providers/WorkflowCore.LockProviders.SqlServer/WorkflowCore.LockProviders.SqlServer.csproj
+++ b/src/providers/WorkflowCore.LockProviders.SqlServer/WorkflowCore.LockProviders.SqlServer.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <Description>Distributed lock provider for Workflow-core using SQL Server</Description>
     <PackageProjectUrl>https://github.com/danielgerlag/workflow-core</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/danielgerlag/workflow-core/blob/master/LICENSE.md</PackageLicenseUrl>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="System.Data.SqlClient" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/providers/WorkflowCore.Persistence.EntityFramework/WorkflowCore.Persistence.EntityFramework.csproj
+++ b/src/providers/WorkflowCore.Persistence.EntityFramework/WorkflowCore.Persistence.EntityFramework.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Workflow Core EntityFramework Core Persistence Provider</AssemblyTitle>
     <Authors>Daniel Gerlag</Authors>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>WorkflowCore.Persistence.EntityFramework</AssemblyName>
     <PackageId>WorkflowCore.Persistence.EntityFramework</PackageId>
     <PackageTags>workflow;.NET;Core;state machine;WorkflowCore;EntityFramework;EntityFrameworkCore</PackageTags>
@@ -21,17 +21,9 @@
     <ProjectReference Include="..\..\WorkflowCore\WorkflowCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.*" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.2" />
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/providers/WorkflowCore.Persistence.MongoDB/WorkflowCore.Persistence.MongoDB.csproj
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/WorkflowCore.Persistence.MongoDB.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Workflow Core MongoDB Persistence Provider</AssemblyTitle>
     <Authors>Daniel Gerlag</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>WorkflowCore.Persistence.MongoDB</AssemblyName>
     <PackageId>WorkflowCore.Persistence.MongoDB</PackageId>
     <PackageTags>workflow;.NET;Core;state machine;WorkflowCore;MongoDB;Mongo</PackageTags>
@@ -22,12 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="MongoDB.Driver" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="System.Reflection" />
   </ItemGroup>
 
 

--- a/src/providers/WorkflowCore.Persistence.MySQL/WorkflowCore.Persistence.MySQL.csproj
+++ b/src/providers/WorkflowCore.Persistence.MySQL/WorkflowCore.Persistence.MySQL.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Workflow Core MySQL Persistence Provider</AssemblyTitle>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Authors>Daniel Gerlag</Authors>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>WorkflowCore.Persistence.MySQL</AssemblyName>
     <PackageId>WorkflowCore.Persistence.MySQL</PackageId>
     <PackageTags>workflow;.NET;Core;state machine;WorkflowCore;MySQL</PackageTags>
@@ -18,28 +18,12 @@
     <Description>Provides support to persist workflows running on Workflow Core to a MySQL database.</Description>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.2">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.7">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.*">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.*" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/providers/WorkflowCore.Persistence.PostgreSQL/WorkflowCore.Persistence.PostgreSQL.csproj
+++ b/src/providers/WorkflowCore.Persistence.PostgreSQL/WorkflowCore.Persistence.PostgreSQL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Workflow Core PostgreSQL Persistence Provider</AssemblyTitle>
     <Authors>Daniel Gerlag</Authors>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>WorkflowCore.Persistence.PostgreSQL</AssemblyName>
     <PackageId>WorkflowCore.Persistence.PostgreSQL</PackageId>
     <PackageTags>workflow;.NET;Core;state machine;WorkflowCore;PostgreSQL</PackageTags>
@@ -22,25 +22,12 @@
     <ProjectReference Include="..\WorkflowCore.Persistence.EntityFramework\WorkflowCore.Persistence.EntityFramework.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-	<PackageReference Include="Npgsql" Version="7.*" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.*">
+  <ItemGroup>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.*">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="Npgsql" Version="5.0.14" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.1">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/providers/WorkflowCore.Persistence.RavenDB/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.RavenDB/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography.X509Certificates;
 using WorkflowCore.Persistence.RavenDB.Services;
 using WorkflowCore.Interface;
 using WorkflowCore.Persistence.RavenDB;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -21,7 +22,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
 			options.UsePersistence(sp =>
 			{
-				return new RavendbPersistenceProvider(store);
+				var loggerFactory = sp.GetService<ILoggerFactory>();
+                return new RavendbPersistenceProvider(store, loggerFactory);
 			});
 
 			options.Services.AddTransient<IWorkflowPurger>(sp =>

--- a/src/providers/WorkflowCore.Persistence.RavenDB/Services/RavendbPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.RavenDB/Services/RavendbPersistenceProvider.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Client.Documents;
+﻿using Microsoft.Extensions.Logging;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Session;
@@ -16,15 +17,18 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 	public class RavendbPersistenceProvider : IPersistenceProvider
 	{
 		internal const string WorkflowCollectionName = "wfc.workflows";
+		private static bool indexesCreated = false;
+
 		private readonly IDocumentStore _database;
-		static bool indexesCreated = false;
+		private readonly ILogger _logger;
 
         public bool SupportsScheduledCommands => false;
 
-        public RavendbPersistenceProvider(IDocumentStore database)
+        public RavendbPersistenceProvider(IDocumentStore database, ILoggerFactory loggerFactory)
 		{
 			_database = database;
-			CreateIndexes(this);
+            _logger = loggerFactory.CreateLogger<RavendbPersistenceProvider>();
+            CreateIndexes(this);
 		}
 
 		static void CreateIndexes(RavendbPersistenceProvider instance)
@@ -216,7 +220,8 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 			}
 			catch (Exception e)
 			{
-				return false;
+				_logger.LogError(e, "Failed to set subscription token");
+                return false;
 			}
 		}
 
@@ -240,7 +245,8 @@ namespace WorkflowCore.Persistence.RavenDB.Services
 			}
 			catch (Exception e)
 			{
-				throw e;
+                _logger.LogError(e, "Failed to clear subscription token");
+                throw;
 			}
 		}
 

--- a/src/providers/WorkflowCore.Persistence.RavenDB/WorkflowCore.Persistence.RavenDB.csproj
+++ b/src/providers/WorkflowCore.Persistence.RavenDB/WorkflowCore.Persistence.RavenDB.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Workflow Core RavenDB Persistence Provider</AssemblyTitle>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>WorkflowCore.Persistence.RavenDB</AssemblyName>
     <PackageId>WorkflowCore.Persistence.RavenDB</PackageId>
     <PackageTags>workflow;.NET;Core;state machine;WorkflowCore;RavenDB</PackageTags>
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RavenDB.Client" Version="5.1.2" />
+    <PackageReference Include="RavenDB.Client" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="System.Reflection" />
   </ItemGroup>
 
 

--- a/src/providers/WorkflowCore.Persistence.SqlServer/WorkflowCore.Persistence.SqlServer.csproj
+++ b/src/providers/WorkflowCore.Persistence.SqlServer/WorkflowCore.Persistence.SqlServer.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Workflow Core SQL Server Persistence Provider</AssemblyTitle>
     <VersionPrefix>1.8.0</VersionPrefix>
     <Authors>Daniel Gerlag</Authors>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>WorkflowCore.Persistence.SqlServer</AssemblyName>
     <PackageId>WorkflowCore.Persistence.SqlServer</PackageId>
     <PackageTags>workflow;.NET;Core;state machine;WorkflowCore</PackageTags>
@@ -23,23 +23,12 @@
     <ProjectReference Include="..\WorkflowCore.Persistence.EntityFramework\WorkflowCore.Persistence.EntityFramework.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.*">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.*">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.1">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/providers/WorkflowCore.Persistence.Sqlite/WorkflowCore.Persistence.Sqlite.csproj
+++ b/src/providers/WorkflowCore.Persistence.Sqlite/WorkflowCore.Persistence.Sqlite.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Workflow Core Sqlite Persistence Provider</AssemblyTitle>
     <VersionPrefix>1.5.0</VersionPrefix>
     <Authors>Daniel Gerlag</Authors>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>WorkflowCore.Persistence.Sqlite</AssemblyName>
     <PackageId>WorkflowCore.Persistence.Sqlite</PackageId>
     <PackageTags>workflow;.NET;Core;state machine;WorkflowCore;Sqlite</PackageTags>
@@ -23,12 +23,8 @@
     <ProjectReference Include="..\WorkflowCore.Persistence.EntityFramework\WorkflowCore.Persistence.EntityFramework.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.*" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.1" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
   </ItemGroup>
 
 </Project>

--- a/src/providers/WorkflowCore.Providers.AWS/WorkflowCore.Providers.AWS.csproj
+++ b/src/providers/WorkflowCore.Providers.AWS/WorkflowCore.Providers.AWS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <Authors>Daniel Gerlag</Authors>
     <Description>AWS providers for Workflow Core
 
@@ -14,11 +14,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.11" />
-    <PackageReference Include="AWSSDK.Kinesis" Version="3.7.1.32" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.33" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" />
+    <PackageReference Include="AWSSDK.Kinesis" />
+    <PackageReference Include="AWSSDK.SQS" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/providers/WorkflowCore.Providers.Azure/WorkflowCore.Providers.Azure.csproj
+++ b/src/providers/WorkflowCore.Providers.Azure/WorkflowCore.Providers.Azure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <Description>Azure providers for Workflow Core
 
 - Provides distributed lock management  on Workflow Core
@@ -16,10 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.19.0" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.11.6" />
-	  <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.0.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB" />
+	  <PackageReference Include="Microsoft.Azure.ServiceBus" />
+    <PackageReference Include="WindowsAzure.Storage" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/providers/WorkflowCore.Providers.Elasticsearch/WorkflowCore.Providers.Elasticsearch.csproj
+++ b/src/providers/WorkflowCore.Providers.Elasticsearch/WorkflowCore.Providers.Elasticsearch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <PackageLicenseUrl>https://github.com/danielgerlag/workflow-core/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/danielgerlag/workflow-core</PackageProjectUrl>
     <RepositoryUrl>https://github.com/danielgerlag/workflow-core.git</RepositoryUrl>
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="NEST" Version="7.14.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="NEST" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/providers/WorkflowCore.Providers.Redis/WorkflowCore.Providers.Redis.csproj
+++ b/src/providers/WorkflowCore.Providers.Redis/WorkflowCore.Providers.Redis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <PackageLicenseUrl>https://github.com/danielgerlag/workflow-core/blob/master/LICENSE.md</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/danielgerlag/workflow-core.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -10,10 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="RedLock.net" Version="2.2.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="RedLock.net" />
+    <PackageReference Include="StackExchange.Redis" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/providers/WorkflowCore.QueueProviders.RabbitMQ/WorkflowCore.QueueProviders.RabbitMQ.csproj
+++ b/src/providers/WorkflowCore.QueueProviders.RabbitMQ/WorkflowCore.QueueProviders.RabbitMQ.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Workflow Core RabbitMQ queue provider</AssemblyTitle>
     <Authors>Daniel Gerlag</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>WorkflowCore.QueueProviders.RabbitMQ</AssemblyName>
     <PackageId>WorkflowCore.QueueProviders.RabbitMQ</PackageId>
     <PackageTags>workflow;.NET;Core;state machine;WorkflowCore;RabbitMQ</PackageTags>
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="4.1.3" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="RabbitMQ.Client" />
   </ItemGroup>
 
 </Project>

--- a/src/providers/WorkflowCore.QueueProviders.SqlServer/WorkflowCore.QueueProviders.SqlServer.csproj
+++ b/src/providers/WorkflowCore.QueueProviders.SqlServer/WorkflowCore.QueueProviders.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <Authors>Roberto Paterlini</Authors>
     <Description>Queue provider for Workflow-core using SQL Server Service Broker</Description>
     <Company />
@@ -9,20 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Services\DequeueWork.sql" />
-    <None Remove="Services\QueueWork.sql" />
-    <None Remove="Services\SqlServerQueueProviderOption.cs~RF7cacba9.TMP" />
-  </ItemGroup>
-
-  <ItemGroup>
     <EmbeddedResource Include="SqlCommands\DequeueWork.sql" />
     <EmbeddedResource Include="SqlCommands\QueueWork.sql" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-    <PackageReference Include="System.Data.Common" Version="4.3.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="System.Data.Common" />
+    <PackageReference Include="System.Data.SqlClient" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/samples/Directory.Build.props
+++ b/src/samples/Directory.Build.props
@@ -1,7 +1,13 @@
 <Project>
-    <PropertyGroup>
-        <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-        <LangVersion>latest</LangVersion>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <!-- disable warnings for netcoreapp3.1 -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
+  </PropertyGroup>
 </Project>

--- a/src/samples/WorkflowCore.Sample01/WorkflowCore.Sample01.csproj
+++ b/src/samples/WorkflowCore.Sample01/WorkflowCore.Sample01.csproj
@@ -15,12 +15,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
 </Project>

--- a/src/samples/WorkflowCore.Sample02/SimpleDecisionWorkflow.cs
+++ b/src/samples/WorkflowCore.Sample02/SimpleDecisionWorkflow.cs
@@ -11,6 +11,7 @@ namespace WorkflowCore.Sample02
 
         public int Version => 1;
 
+        [Obsolete]
         public void Build(IWorkflowBuilder<object> builder)
         {
             builder

--- a/src/samples/WorkflowCore.Sample02/WorkflowCore.Sample02.csproj
+++ b/src/samples/WorkflowCore.Sample02/WorkflowCore.Sample02.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/samples/WorkflowCore.Sample03/Steps/AddNumbers.cs
+++ b/src/samples/WorkflowCore.Sample03/Steps/AddNumbers.cs
@@ -14,11 +14,10 @@ namespace WorkflowCore.Sample03.Steps
 
         public int Output { get; set; }
 
-
-        public override async Task<ExecutionResult> RunAsync(IStepExecutionContext context)
+        public override Task<ExecutionResult> RunAsync(IStepExecutionContext context)
         {
-            Output = (Input1 + Input2);
-            return ExecutionResult.Next();
+            Output = Input1 + Input2;
+            return Task.FromResult(ExecutionResult.Next());
         }
     }
 }

--- a/src/samples/WorkflowCore.Sample03/WorkflowCore.Sample03.csproj
+++ b/src/samples/WorkflowCore.Sample03/WorkflowCore.Sample03.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
 </Project>

--- a/src/samples/WorkflowCore.Sample04/WorkflowCore.Sample04.csproj
+++ b/src/samples/WorkflowCore.Sample04/WorkflowCore.Sample04.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.33" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.2" />
+    <PackageReference Include="AWSSDK.SQS" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
 </Project>

--- a/src/samples/WorkflowCore.Sample05/WorkflowCore.Sample05.csproj
+++ b/src/samples/WorkflowCore.Sample05/WorkflowCore.Sample05.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
 </Project>

--- a/src/samples/WorkflowCore.Sample06/MultipleOutcomeWorkflow.cs
+++ b/src/samples/WorkflowCore.Sample06/MultipleOutcomeWorkflow.cs
@@ -11,6 +11,7 @@ namespace WorkflowCore.Sample06
 
         public int Version => 1;
 
+        [Obsolete]
         public void Build(IWorkflowBuilder<object> builder)
         {
             builder

--- a/src/samples/WorkflowCore.Sample06/WorkflowCore.Sample06.csproj
+++ b/src/samples/WorkflowCore.Sample06/WorkflowCore.Sample06.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
 </Project>

--- a/src/samples/WorkflowCore.Sample07/Startup.cs
+++ b/src/samples/WorkflowCore.Sample07/Startup.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using WorkflowCore.Interface;
 
@@ -10,7 +11,6 @@ namespace WorkflowCore.Sample07
 {
     public class Startup
     {
-        
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddLogging();
@@ -18,15 +18,14 @@ namespace WorkflowCore.Sample07
             services.AddMvc();
         }
 
-        
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
             //loggerFactory.AddConsole();
 
             //start the workflow host
             var host = app.ApplicationServices.GetService<IWorkflowHost>();
             host.RegisterWorkflow<Sample03.PassingDataWorkflow, Sample03.MyDataClass>();
-            host.RegisterWorkflow<Sample04.EventSampleWorkflow, Sample04.MyDataClass>();            
+            host.RegisterWorkflow<Sample04.EventSampleWorkflow, Sample04.MyDataClass>();
             host.Start();
 
             if (env.IsDevelopment())
@@ -34,7 +33,7 @@ namespace WorkflowCore.Sample07
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseMvc(); 
+            app.UseMvc();
         }
     }
 }

--- a/src/samples/WorkflowCore.Sample07/WorkflowCore.Sample07.csproj
+++ b/src/samples/WorkflowCore.Sample07/WorkflowCore.Sample07.csproj
@@ -22,9 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.2.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" />
   </ItemGroup>
 
 </Project>

--- a/src/samples/WorkflowCore.Sample08/WorkflowCore.Sample08.csproj
+++ b/src/samples/WorkflowCore.Sample08/WorkflowCore.Sample08.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
 </Project>

--- a/src/samples/WorkflowCore.Sample09/WorkflowCore.Sample09.csproj
+++ b/src/samples/WorkflowCore.Sample09/WorkflowCore.Sample09.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/samples/WorkflowCore.Sample09s/WorkflowCore.Sample09s.csproj
+++ b/src/samples/WorkflowCore.Sample09s/WorkflowCore.Sample09s.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/samples/WorkflowCore.Sample10/WorkflowCore.Sample10.csproj
+++ b/src/samples/WorkflowCore.Sample10/WorkflowCore.Sample10.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/samples/WorkflowCore.Sample11/WorkflowCore.Sample11.csproj
+++ b/src/samples/WorkflowCore.Sample11/WorkflowCore.Sample11.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/samples/WorkflowCore.Sample12/WorkflowCore.Sample12.csproj
+++ b/src/samples/WorkflowCore.Sample12/WorkflowCore.Sample12.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/samples/WorkflowCore.Sample13/WorkflowCore.Sample13.csproj
+++ b/src/samples/WorkflowCore.Sample13/WorkflowCore.Sample13.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/samples/WorkflowCore.Sample15/WorkflowCore.Sample15.csproj
+++ b/src/samples/WorkflowCore.Sample15/WorkflowCore.Sample15.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/samples/WorkflowCore.Sample16/WorkflowCore.Sample16.csproj
+++ b/src/samples/WorkflowCore.Sample16/WorkflowCore.Sample16.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/samples/WorkflowCore.Sample18/WorkflowCore.Sample18.csproj
+++ b/src/samples/WorkflowCore.Sample18/WorkflowCore.Sample18.csproj
@@ -1,14 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/samples/WorkflowCore.Sample19/WorkflowCore.Sample19.csproj
+++ b/src/samples/WorkflowCore.Sample19/WorkflowCore.Sample19.csproj
@@ -5,11 +5,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
-        <PackageReference Include="Polly" Version="7.2.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
+        <PackageReference Include="Polly" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/WorkflowCore.TestSample01/NUnitTest.cs
+++ b/src/samples/WorkflowCore.TestSample01/NUnitTest.cs
@@ -11,7 +11,7 @@ namespace WorkflowCore.TestSample01
     public class NUnitTest : WorkflowTest<MyWorkflow, MyDataClass>
     {
         [SetUp]
-        protected void Setup()
+        protected override void Setup()
         {
             base.Setup();
         }

--- a/src/samples/WorkflowCore.TestSample01/WorkflowCore.TestSample01.csproj
+++ b/src/samples/WorkflowCore.TestSample01/WorkflowCore.TestSample01.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,24 +1,25 @@
 <Project>
-    <PropertyGroup>
-        <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-        <LangVersion>latest</LangVersion>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0"/>
-        <PackageReference Include="xunit" Version="2.4.1"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
-        <PackageReference Include="FluentAssertions" Version="4.19.4" />
-        <PackageReference Include="Moq" Version="4.7.145" />
-        <PackageReference Include="FakeItEasy" Version="4.9.2" />
-    </ItemGroup>
-    
-    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
-    </ItemGroup>
+  <!-- disable warnings for netcoreapp3.1 -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
+  </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FakeItEasy" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.core" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
 </Project>

--- a/test/Docker.Testify/Docker.Testify.csproj
+++ b/test/Docker.Testify/Docker.Testify.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Docker.DotNet" Version="3.125.2" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="Docker.DotNet" />
+    <PackageReference Include="System.Net.NetworkInformation" />
   </ItemGroup>
 </Project>

--- a/test/WorkflowCore.IntegrationTests/Scenarios/ActivityScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/ActivityScenario.cs
@@ -5,6 +5,7 @@ using Xunit;
 using FluentAssertions;
 using System.Linq;
 using WorkflowCore.Testing;
+using System.Threading.Tasks;
 
 namespace WorkflowCore.IntegrationTests.Scenarios
 {
@@ -47,16 +48,16 @@ namespace WorkflowCore.IntegrationTests.Scenarios
         }
 
         [Fact]
-        public void Scenario()
+        public async Task Scenario()
         {
             var workflowId = StartWorkflow(new MyDataClass { ActivityInput = new ActivityInput { Value1 = "a", Value2 = 1 } });
-            var activity = Host.GetPendingActivity("act-1", "worker1", TimeSpan.FromSeconds(30)).Result;
+            var activity = await Host.GetPendingActivity("act-1", "worker1", TimeSpan.FromSeconds(30));
 
             if (activity != null)
             {
                 var actInput = (ActivityInput)activity.Parameters;
-                Host.SubmitActivitySuccess(activity.Token, new ActivityOutput
-                { 
+                await Host.SubmitActivitySuccess(activity.Token, new ActivityOutput
+                {
                     Value1 = actInput.Value1 + "1",
                     Value2 = actInput.Value2 + 1
                 });

--- a/test/WorkflowCore.IntegrationTests/Scenarios/ForkScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/ForkScenario.cs
@@ -3,9 +3,11 @@ using WorkflowCore.Interface;
 using WorkflowCore.Models;
 using Xunit;
 using FluentAssertions;
+using System.Threading.Tasks;
 
 namespace WorkflowCore.IntegrationTests.Scenarios
 {
+    [Obsolete]
     public class ForkScenario : BaseScenario<ForkScenario.OutcomeFork, Object>
     {
         static int TaskATicker = 0;
@@ -57,16 +59,16 @@ namespace WorkflowCore.IntegrationTests.Scenarios
         }
 
         [Fact]
-        public void Scenario()
+        public async Task Scenario()
         {
-            var workflowId = Host.StartWorkflow("OutcomeFork").Result;
-            var instance = PersistenceProvider.GetWorkflowInstance(workflowId).Result;
+            var workflowId = await Host.StartWorkflow("OutcomeFork");
+            var instance = await PersistenceProvider.GetWorkflowInstance(workflowId);
             int counter = 0;
             while ((instance.Status == WorkflowStatus.Runnable) && (counter < 300))
             {
                 System.Threading.Thread.Sleep(100);
                 counter++;
-                instance = PersistenceProvider.GetWorkflowInstance(workflowId).Result;
+                instance = await PersistenceProvider.GetWorkflowInstance(workflowId);
             }
 
             instance.Status.Should().Be(WorkflowStatus.Complete);

--- a/test/WorkflowCore.IntegrationTests/Scenarios/UserScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/UserScenario.cs
@@ -5,6 +5,7 @@ using Xunit;
 using FluentAssertions;
 using System.Linq;
 using WorkflowCore.Testing;
+using System.Threading.Tasks;
 
 namespace WorkflowCore.IntegrationTests.Scenarios
 {
@@ -37,7 +38,7 @@ namespace WorkflowCore.IntegrationTests.Scenarios
         }
 
         [Fact]
-        public void Scenario()
+        public async Task Scenario()
         {
             var workflowId = StartWorkflow(null);
             var counter = 0;
@@ -50,11 +51,11 @@ namespace WorkflowCore.IntegrationTests.Scenarios
 
             var openItems1 = Host.GetOpenUserActions(workflowId).ToList();
 
-            Host.PublishUserAction(openItems1.First().Key, "user1", "yes").Wait();
+            await Host.PublishUserAction(openItems1.First().Key, "user1", "yes");
 
             WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(30));
 
-            var openItems2 = Host.GetOpenUserActions(workflowId);        
+            var openItems2 = Host.GetOpenUserActions(workflowId);
 
             ApproveStepTicker.Should().Be(1);
             DisapproveStepTicker.Should().Be(0);

--- a/test/WorkflowCore.IntegrationTests/WorkflowCore.IntegrationTests.csproj
+++ b/test/WorkflowCore.IntegrationTests/WorkflowCore.IntegrationTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.1" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WorkflowCore.TestAssets/WorkflowCore.TestAssets.csproj
+++ b/test/WorkflowCore.TestAssets/WorkflowCore.TestAssets.csproj
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NUnit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WorkflowCore.Tests.DynamoDB/WorkflowCore.Tests.DynamoDB.csproj
+++ b/test/WorkflowCore.Tests.DynamoDB/WorkflowCore.Tests.DynamoDB.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.11" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WorkflowCore.Tests.Elasticsearch/WorkflowCore.Tests.Elasticsearch.csproj
+++ b/test/WorkflowCore.Tests.Elasticsearch/WorkflowCore.Tests.Elasticsearch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Squadron.Elasticsearch" Version="0.17.0" />
+    <PackageReference Include="Squadron.Elasticsearch" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WorkflowCore.Tests.MongoDB/Scenarios/MongoForkScenario.cs
+++ b/test/WorkflowCore.Tests.MongoDB/Scenarios/MongoForkScenario.cs
@@ -6,6 +6,7 @@ using Xunit;
 namespace WorkflowCore.Tests.MongoDB.Scenarios
 {
     [Collection("Mongo collection")]
+    [Obsolete]
     public class MongoForkScenario : ForkScenario
     {        
         protected override void Configure(IServiceCollection services)

--- a/test/WorkflowCore.Tests.MongoDB/WorkflowCore.Tests.MongoDB.csproj
+++ b/test/WorkflowCore.Tests.MongoDB/WorkflowCore.Tests.MongoDB.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Squadron.Mongo" Version="0.17.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+    <PackageReference Include="Squadron.Mongo" />
+    <PackageReference Include="MongoDB.Driver" />
   </ItemGroup>
 
 </Project>

--- a/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlForkScenario.cs
+++ b/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlForkScenario.cs
@@ -6,6 +6,7 @@ using Xunit;
 namespace WorkflowCore.Tests.MySQL.Scenarios
 {
     [Collection("Mysql collection")]
+    [Obsolete]
     public class MysqlForkScenario : ForkScenario
     {        
         protected override void Configure(IServiceCollection services)

--- a/test/WorkflowCore.Tests.MySQL/WorkflowCore.Tests.MySQL.csproj
+++ b/test/WorkflowCore.Tests.MySQL/WorkflowCore.Tests.MySQL.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Squadron.MySql" Version="0.18.0-preview.7" />
+    <PackageReference Include="MySqlConnector" />
+    <PackageReference Include="Squadron.MySql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WorkflowCore.Tests.PostgreSQL/Scenarios/PostgresForkScenario.cs
+++ b/test/WorkflowCore.Tests.PostgreSQL/Scenarios/PostgresForkScenario.cs
@@ -6,6 +6,7 @@ using Xunit;
 namespace WorkflowCore.Tests.PostgreSQL.Scenarios
 {
     [Collection("Postgres collection")]
+    [Obsolete]
     public class PostgresForkScenario : ForkScenario
     {        
         protected override void Configure(IServiceCollection services)

--- a/test/WorkflowCore.Tests.PostgreSQL/WorkflowCore.Tests.PostgreSQL.csproj
+++ b/test/WorkflowCore.Tests.PostgreSQL/WorkflowCore.Tests.PostgreSQL.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Squadron.PostgreSql" Version="0.17.0" />
+    <PackageReference Include="Squadron.PostgreSql" />
   </ItemGroup>
 
 </Project>

--- a/test/WorkflowCore.Tests.QueueProviders.RabbitMQ/WorkflowCore.Tests.QueueProviders.RabbitMQ.csproj
+++ b/test/WorkflowCore.Tests.QueueProviders.RabbitMQ/WorkflowCore.Tests.QueueProviders.RabbitMQ.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="1.2.0" />
+        <PackageReference Include="coverlet.collector" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/WorkflowCore.Tests.Redis/WorkflowCore.Tests.Redis.csproj
+++ b/test/WorkflowCore.Tests.Redis/WorkflowCore.Tests.Redis.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
-    <PackageReference Include="Squadron.Redis" Version="0.17.0" />
+    <PackageReference Include="StackExchange.Redis" />
+    <PackageReference Include="Squadron.Redis" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WorkflowCore.Tests.SqlServer/WorkflowCore.Tests.SqlServer.csproj
+++ b/test/WorkflowCore.Tests.SqlServer/WorkflowCore.Tests.SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Squadron.SqlServer" Version="0.17.0" />
+    <PackageReference Include="Squadron.SqlServer" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Describe the change**

Since the release of .NET 7.0, many libraries have started to support the Ahead-of-Time (AOT) compilation feature. I believe it is essential for this library to stay current, so I invested some time in making it compatible.


**Describe your implementation or design**

Follow [official document](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming?pivots=dotnet-8-0)


**Tests**

Not yet, this topic may require further discussion.


**Breaking change**

None


**Additional context**

By the way, I've made some improvements:

1. Add [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management) to make handling a bunch of packages way more convenient.
2. I went ahead and bumped up the versions on some packages. Might need to double-check things.
3. Fixed most of the warnings.
4. Removed unnecessary dependencies from the WorkflowCore project 

| before | after |
| ---- | ---- |
| `ConcurrentHashSet-1.1.0` | |
| `Microsoft.Extensions.DependencyInjection.Abstractions-2.2.0` | |
| `Microsoft.Extensions.Hosting.Abstractions-2.2.0` | `Microsoft.Extensions.Hosting.Abstractions-*` |
| `Microsoft.Extensions.Logging.Abstractions-2.2.0` | `Microsoft.Extensions.Logging.Abstractions-?` |
| `Microsoft.Extensions.ObjectPool-2.2.0` | `Microsoft.Extensions.ObjectPool` |
| `Newtonsoft.Json-13.0.1` | `System.Text.Json-*` |
| `System.Threading.Tasks.Parallel-4.3.0` | |
| `System.Threading.ThreadPool-4.3.0` | |
| `System.Reflection-4.3.0` | |
| `System.Reflection.TypeExtensions-4.7.0` | |
| `System.Threading.Thread-4.3.0` | |
| `System.Linq.Queryable-4.3.0` | |
| `OpenTelemetry.Api-1.1.0` | `OpenTelemetry.Api-*` |
| `System.Diagnostics.DiagnosticSource-6.0.0` | |
| `System.Linq.Queryable-4.3.0` | |
| `System.Linq.Queryable-4.3.0` | |
| `System.Linq.Queryable-4.3.0` | |
| `System.Linq.Queryable-4.3.0` | |
| `System.Linq.Queryable-4.3.0` | |

`-*` indicates version dependency on the framework; `-?` indicates usage of references in certain frameworks.