### PR TITLE
Update correct workflow name for Sample09s

### DIFF
--- a/src/samples/WorkflowCore.Sample09s/Program.cs
+++ b/src/samples/WorkflowCore.Sample09s/Program.cs
@@ -16,7 +16,7 @@ namespace WorkflowCore.Sample09s
             host.Start();
             
             Console.WriteLine("Starting workflow...");
-            string workflowId = host.StartWorkflow("Foreach").Result;
+            string workflowId = host.StartWorkflow("ForeachSync").Result;
 
             
             Console.ReadLine();


### PR DESCRIPTION
The correct workflow name for Sample09s is "ForeachSync" not "Foreach".