### PR TITLE
fix: prevent redis provider from crashing when using deleteComplete

### DIFF
--- a/src/providers/WorkflowCore.Providers.Redis/Services/RedisPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Providers.Redis/Services/RedisPersistenceProvider.cs
@@ -92,6 +92,10 @@ namespace WorkflowCore.Providers.Redis.Services
         public async Task<WorkflowInstance> GetWorkflowInstance(string Id, CancellationToken _ = default)
         {
             var raw = await _redis.HashGetAsync($"{_prefix}.{WORKFLOW_SET}", Id);
+            if (!raw.HasValue)
+            {
+                return null;
+            }
             return JsonConvert.DeserializeObject<WorkflowInstance>(raw, _serializerSettings);
         }
 


### PR DESCRIPTION
**Describe the change**

While testing the redis persistence provider, I set `deleteComplete: true` I started getting lots of warnings and errors:
`Error indexing workfow`

**Describe your implementation or design**
I checked if the redis response has value, and if it didn't return null, don't try to deserialize it.

**Tests**
Did not add any now tests.

**Breaking change**
No breaking changes.

**Additional context**
Any additional information you'd like to provide?