### PR TITLE
Fixed usage of CreateIndexes for mongo

### DIFF
--- a/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/Services/MongoPersistenceProvider.cs
@@ -23,7 +23,6 @@ namespace WorkflowCore.Persistence.MongoDB.Services
         public MongoPersistenceProvider(IMongoDatabase database)
         {
             _database = database;
-            CreateIndexes(this);
         }
 
         static MongoPersistenceProvider()
@@ -263,7 +262,7 @@ namespace WorkflowCore.Persistence.MongoDB.Services
 
         public void EnsureStoreExists()
         {
-
+            CreateIndexes(this);
         }
 
         public async Task<IEnumerable<EventSubscription>> GetSubscriptions(string eventName, string eventKey, DateTime asOf, CancellationToken cancellationToken = default)

--- a/test/WorkflowCore.Tests.MongoDB/MongoPersistenceProviderFixture.cs
+++ b/test/WorkflowCore.Tests.MongoDB/MongoPersistenceProviderFixture.cs
@@ -1,5 +1,4 @@
 ﻿using MongoDB.Driver;
-using System;
 using WorkflowCore.Interface;
 using WorkflowCore.Persistence.MongoDB.Services;
 using WorkflowCore.UnitTests;
@@ -23,7 +22,9 @@ namespace WorkflowCore.Tests.MongoDB
             {
                 var client = new MongoClient(MongoDockerSetup.ConnectionString);
                 var db = client.GetDatabase(nameof(MongoPersistenceProviderFixture));
-                return new MongoPersistenceProvider(db);
+                var provider = new MongoPersistenceProvider(db);
+                provider.EnsureStoreExists();
+                return provider;
             }
         }
     }


### PR DESCRIPTION
**Describe the change**
Fixed usage of CreateIndexes for MongoPersistenceProvider.cs to avoid database connection already opening during ioc.
Doing database operations in constructor of services that are registered in ioc is dangerous.
In case of connection error the application will crash during ioc already.

**Describe your implementation or design**
I checked how EntityFrameworkPersistenceProvider does database changes and its done in EnsureStoreExists there.
https://github.com/danielgerlag/workflow-core/blob/master/src/providers/WorkflowCore.Persistence.EntityFramework/Services/EntityFrameworkPersistenceProvider.cs#L192

**Tests**
I adjusted the MongoPersistenceProviderFixture to call EnsureStoreExists like its done for the other Providers too.

**Breaking change**
Change should be minor, as EnsureStoreExists is already used from workflow-core for other providers.

**Additional context**
Some of the mongo unit tests do not execute, but this was already the case before my change.
This is probably cause of the mongodb driver update from 2.8 to 2.19
https://www.mongodb.com/docs/drivers/csharp/v2.19/faq/#what-object-types-can-be-serialized-
There is already in issue for this https://github.com/danielgerlag/workflow-core/issues/1250