### PR TITLE
Add ResumeWorkflowSync methods to SyncWorkflowRunner

### DIFF
--- a/src/WorkflowCore/Interface/ISyncWorkflowRunner.cs
+++ b/src/WorkflowCore/Interface/ISyncWorkflowRunner.cs
@@ -7,10 +7,14 @@ namespace WorkflowCore.Interface
 {
     public interface ISyncWorkflowRunner
     {
-        Task<WorkflowInstance> RunWorkflowSync<TData>(string workflowId, int version, TData data, string reference, TimeSpan timeOut, bool persistSate = true)
+        Task<WorkflowInstance> RunWorkflowSync<TData>(string workflowId, int version, TData data, string reference, TimeSpan timeOut, bool persistState = true)
             where TData : new();
 
-        Task<WorkflowInstance> RunWorkflowSync<TData>(string workflowId, int version, TData data, string reference, CancellationToken token, bool persistSate = true)
+        Task<WorkflowInstance> RunWorkflowSync<TData>(string workflowId, int version, TData data, string reference, CancellationToken token, bool persistState = true)
             where TData : new();
+
+        Task<WorkflowInstance> ResumeWorkflowSync(string workflowId, TimeSpan timeOut, bool persistState = true);
+
+        Task<WorkflowInstance> ResumeWorkflowSync(string workflowId, CancellationToken token, bool persistState = true);
     }
 }


### PR DESCRIPTION
**Describe the change**
Added the ability to resume workflows synchronously with the SyncWorkflowRunner.

**Describe your implementation or design**
I simply split off some of the logic within the RunWorkflowInstanceSync method into a new private method. I then created the ResumeWorkflowSync methods which simply find the existing WorkflowInstance and then passes that into the new private method.

**Tests**
No.

**Breaking change**
I added the two new methods to the public ISyncWorkflowRunner interface. 

**Additional context**
No.