### PR TITLE
Upgrade to Mongo Version 2.30

### DIFF
--- a/src/providers/WorkflowCore.Persistence.MongoDB/WorkflowCore.Persistence.MongoDB.csproj
+++ b/src/providers/WorkflowCore.Persistence.MongoDB/WorkflowCore.Persistence.MongoDB.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.30.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/test/WorkflowCore.Tests.MongoDB/WorkflowCore.Tests.MongoDB.csproj
+++ b/test/WorkflowCore.Tests.MongoDB/WorkflowCore.Tests.MongoDB.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Squadron.Mongo" Version="0.17.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.30.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgrading mongo to version 2.30. MongoDb started strong naming their packages with plenty of pushback. However it appears they are committed to this change, and therefore needing all projects to upgrade to 2.28+.  A major version 3.0 exists, but would require more testing than just this upgrade and ensure builds are passing.
Discussion on the change:
https://www.mongodb.com/community/forums/t/net-c-driver-strong-naming/291649/16
