### PR TITLE
feat: add JSON serialization configuration and change SerializerSettings visibility to public

### DIFF
--- a/src/providers/WorkflowCore.Persistence.EntityFramework/ExtensionMethods.cs
+++ b/src/providers/WorkflowCore.Persistence.EntityFramework/ExtensionMethods.cs
@@ -9,7 +9,7 @@ namespace WorkflowCore.Persistence.EntityFramework
 {
     internal static class ExtensionMethods
     {
-        private static JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
+        public static JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
         {
             TypeNameHandling = TypeNameHandling.All,
             ObjectCreationHandling = ObjectCreationHandling.Replace

--- a/src/providers/WorkflowCore.Persistence.EntityFramework/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.EntityFramework/ServiceCollectionExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Data.Common;
+using Newtonsoft.Json;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using WorkflowCore.Persistence.EntityFramework;
+using WorkflowCore.Persistence.EntityFramework.Services;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static WorkflowOptions ConfigureJsonSettings(this WorkflowOptions options, Action<JsonSerializerSettings> settings)
+        {
+            settings(ExtensionMethods.SerializerSettings);
+            return options;
+        }
+    }
+}


### PR DESCRIPTION

- Added the `ConfigureJsonSettings` extension to customize JSON serialization settings in `WorkflowOptions`.
- Changed `SerializerSettings` visibility from private to public to allow external access to Newtonsoft.Json configuration.

Reason:
When serializing objects like `Outcome` or `Steps`, some could not be serialized correctly. This change enables adjusting Newtonsoft.Json settings to meet specific requirements.


**Describe the change**
A clear and concise description of what the change is. Any PR submitted without a description of the change will not be reviewed.

**Describe your implementation or design**
How did you go about implementing the change?

**Tests**
Did you cover your changes with tests?

**Breaking change**
Do you changes break compatibility with previous versions?

**Additional context**
Any additional information you'd like to provide?