### PR TITLE
Using Xunit test output helper in some tests

### DIFF
--- a/src/WorkflowCore.Testing/WorkflowCore.Testing.csproj
+++ b/src/WorkflowCore.Testing/WorkflowCore.Testing.csproj
@@ -19,4 +19,10 @@
     <ProjectReference Include="..\..\src\WorkflowCore\WorkflowCore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="xunit.abstractions">
+      <HintPath>..\..\..\..\..\.nuget\packages\xunit.abstractions\2.0.3\lib\netstandard2.0\xunit.abstractions.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
 </Project>

--- a/src/WorkflowCore.Testing/WorkflowCore.Testing.csproj
+++ b/src/WorkflowCore.Testing/WorkflowCore.Testing.csproj
@@ -12,17 +12,11 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="xunit.abstractions" Version="2.0.3" />  
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\WorkflowCore.DSL\WorkflowCore.DSL.csproj" />
     <ProjectReference Include="..\..\src\WorkflowCore\WorkflowCore.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="xunit.abstractions">
-      <HintPath>..\..\..\..\..\.nuget\packages\xunit.abstractions\2.0.3\lib\netstandard2.0\xunit.abstractions.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>

--- a/src/WorkflowCore.Testing/WorkflowTest.cs
+++ b/src/WorkflowCore.Testing/WorkflowTest.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
+using Xunit.Abstractions;
 
 namespace WorkflowCore.Testing
 {
@@ -18,11 +19,16 @@ namespace WorkflowCore.Testing
         protected IPersistenceProvider PersistenceProvider;
         protected List<StepError> UnhandledStepErrors = new List<StepError>();
 
-        protected virtual void Setup()
+        protected virtual void Setup(ITestOutputHelper testOutputHelper = null)
         {
             //setup dependency injection
             IServiceCollection services = new ServiceCollection();
-            services.AddLogging();
+            services.AddLogging(l => l.SetMinimumLevel(LogLevel.Trace));
+            services.AddSingleton<ILoggerProvider>(p => new XUnitLoggerProvider(testOutputHelper));
+            services.Add(ServiceDescriptor.Singleton<ILoggerFactory, LoggerFactory>());
+            services.Add(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(XUnitLogger<>)));
+            services.AddSingleton(sp => testOutputHelper);
+            
             ConfigureServices(services);
 
             var serviceProvider = services.BuildServiceProvider();

--- a/src/WorkflowCore.Testing/WorkflowTest.cs
+++ b/src/WorkflowCore.Testing/WorkflowTest.cs
@@ -23,12 +23,19 @@ namespace WorkflowCore.Testing
         {
             //setup dependency injection
             IServiceCollection services = new ServiceCollection();
-            services.AddLogging(l => l.SetMinimumLevel(LogLevel.Trace));
-            services.AddSingleton<ILoggerProvider>(p => new XUnitLoggerProvider(testOutputHelper));
-            services.Add(ServiceDescriptor.Singleton<ILoggerFactory, LoggerFactory>());
-            services.Add(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(XUnitLogger<>)));
-            services.AddSingleton(sp => testOutputHelper);
-            
+
+            if (testOutputHelper == null)
+            {
+                services.AddLogging();
+            }
+            else
+            {
+                services.AddLogging(loggingBuilder => loggingBuilder
+                    .SetMinimumLevel(LogLevel.Trace)
+                    .ClearProviders()
+                    .AddProvider(new XUnitLoggerProvider(testOutputHelper)));
+            }
+
             ConfigureServices(services);
 
             var serviceProvider = services.BuildServiceProvider();

--- a/src/WorkflowCore.Testing/XUnitLogger.cs
+++ b/src/WorkflowCore.Testing/XUnitLogger.cs
@@ -57,7 +57,7 @@ namespace WorkflowCore.Testing
 
         private static string GetLogLevelString(LogLevel logLevel)
         {
-            return logLevel.ToString().ToUpper();            
+            return logLevel.ToString().ToUpper();
         }
     }
     

--- a/src/WorkflowCore.Testing/XUnitLogger.cs
+++ b/src/WorkflowCore.Testing/XUnitLogger.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace WorkflowCore.Testing
+{
+    internal class XUnitLogger : ILogger
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+        private readonly string _categoryName;
+        private readonly LoggerExternalScopeProvider _scopeProvider;
+
+        public static ILogger CreateLogger(ITestOutputHelper testOutputHelper) =>
+            new XUnitLogger(testOutputHelper, new LoggerExternalScopeProvider(), "");
+
+        public static ILogger<T> CreateLogger<T>(ITestOutputHelper testOutputHelper) =>
+            new XUnitLogger<T>(testOutputHelper, new LoggerExternalScopeProvider());
+
+        public XUnitLogger(ITestOutputHelper testOutputHelper, LoggerExternalScopeProvider scopeProvider,
+            string categoryName)
+        {
+            _testOutputHelper = testOutputHelper;
+            _scopeProvider = scopeProvider;
+            _categoryName = categoryName;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+        public IDisposable BeginScope<TState>(TState state) => _scopeProvider.Push(state);
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+            Func<TState, Exception, string> formatter)
+        {
+            if (_testOutputHelper == null) return;
+            var sb = new StringBuilder();
+            sb.Append(DateTime.Now.ToString("HH:mm:ss.fff"))
+                .Append(" ")
+                .Append(GetLogLevelString(logLevel))
+                .Append(" [").Append(_categoryName).Append("] ")
+                .Append(formatter(state, exception));
+
+            if (exception != null)
+            {
+                sb.Append('\n').Append(exception);
+            }
+
+            // Append scopes
+            _scopeProvider.ForEachScope((scope, s) =>
+            {
+                s.Append("\n => ");
+                s.Append(scope);
+            }, sb);
+
+            _testOutputHelper.WriteLine(sb.ToString());
+        }
+
+        private static string GetLogLevelString(LogLevel logLevel)
+        {
+            return logLevel.ToString().ToUpper();            
+        }
+    }
+    
+    internal sealed class XUnitLogger<T> : XUnitLogger, ILogger<T>
+    {
+        public XUnitLogger(ITestOutputHelper testOutputHelper, LoggerExternalScopeProvider scopeProvider)
+            : base(testOutputHelper, scopeProvider, typeof(T).FullName)
+        {
+        }
+    }
+    
+    internal sealed class XUnitLoggerProvider : ILoggerProvider
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+        private readonly LoggerExternalScopeProvider _scopeProvider = new LoggerExternalScopeProvider();
+
+        public XUnitLoggerProvider(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new XUnitLogger(_testOutputHelper, _scopeProvider, categoryName);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/test/WorkflowCore.IntegrationTests/Scenarios/DelayScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/DelayScenario.cs
@@ -4,6 +4,7 @@ using WorkflowCore.Models;
 using Xunit;
 using FluentAssertions;
 using WorkflowCore.Testing;
+using Xunit.Abstractions;
 
 namespace WorkflowCore.IntegrationTests.Scenarios
 {
@@ -31,9 +32,9 @@ namespace WorkflowCore.IntegrationTests.Scenarios
 
     public class DelayScenario : WorkflowTest<DelayWorkflow, DelayWorkflow.MyDataClass>
     {   
-        public DelayScenario()
+        public DelayScenario(ITestOutputHelper testOutputHelper)
         {
-            Setup();
+            Setup(testOutputHelper);
         }
 
         [Fact]

--- a/test/WorkflowCore.Tests.MongoDB/Scenarios/MongoDelayScenario.cs
+++ b/test/WorkflowCore.Tests.MongoDB/Scenarios/MongoDelayScenario.cs
@@ -3,13 +3,14 @@ using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Bson.Serialization;
 using WorkflowCore.IntegrationTests.Scenarios;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace WorkflowCore.Tests.MongoDB.Scenarios
 {
     [Collection("Mongo collection")]
     public class MongoDelayScenario : DelayScenario
     {
-        public MongoDelayScenario() : base()
+        public MongoDelayScenario(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
         {
             BsonClassMap.RegisterClassMap<DelayWorkflow.MyDataClass>(map => map.AutoMap());
         }

--- a/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlDelayScenario.cs
+++ b/test/WorkflowCore.Tests.MySQL/Scenarios/MysqlDelayScenario.cs
@@ -2,12 +2,17 @@
 using System;
 using WorkflowCore.IntegrationTests.Scenarios;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace WorkflowCore.Tests.MySQL.Scenarios
 {
     [Collection("Mysql collection")]
     public class MysqlDelayScenario : DelayScenario
     {
+        public MysqlDelayScenario(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
         protected override void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow(cfg =>

--- a/test/WorkflowCore.Tests.Oracle/Scenarios/OracleDelayScenario.cs
+++ b/test/WorkflowCore.Tests.Oracle/Scenarios/OracleDelayScenario.cs
@@ -5,12 +5,17 @@ using WorkflowCore.Persistence.Oracle;
 using WorkflowCore.Tests.Oracle;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace WorkflowCore.Tests.Oracle.Scenarios
 {
     [Collection("Oracle collection")]
     public class OracleDelayScenario : DelayScenario
-    {        
+    {
+        public OracleDelayScenario(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
         protected override void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow(cfg =>

--- a/test/WorkflowCore.Tests.SqlServer/Scenarios/SqlServerDelayScenario.cs
+++ b/test/WorkflowCore.Tests.SqlServer/Scenarios/SqlServerDelayScenario.cs
@@ -2,12 +2,17 @@
 using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace WorkflowCore.Tests.SqlServer.Scenarios
 {
     [Collection("SqlServer collection")]
     public class SqlServerDelayScenario : DelayScenario
-    {        
+    {
+        public SqlServerDelayScenario(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
         protected override void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow(cfg =>

--- a/test/WorkflowCore.Tests.Sqlite/Scenarios/SqliteDelayScenario.cs
+++ b/test/WorkflowCore.Tests.Sqlite/Scenarios/SqliteDelayScenario.cs
@@ -1,15 +1,15 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace WorkflowCore.Tests.PostgreSQL.Scenarios
+namespace WorkflowCore.Tests.Sqlite.Scenarios
 {
-    [Collection("Postgres collection")]
-    public class PostgresDelayScenario : DelayScenario
+    [Collection("Sqlite collection")]
+    public class SqliteDelayScenario : DelayScenario
     {
-        public PostgresDelayScenario(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        public SqliteDelayScenario(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
         {
         }
 
@@ -17,9 +17,10 @@ namespace WorkflowCore.Tests.PostgreSQL.Scenarios
         {
             services.AddWorkflow(cfg =>
             {
-                cfg.UsePostgreSQL(PostgresDockerSetup.ScenarioConnectionString, true, true);
+                cfg.UseSqlite($"Data Source=wfc-tests-{DateTime.Now.Ticks}.db;", true);
                 cfg.UsePollInterval(TimeSpan.FromSeconds(2));
             });
         }
     }
 }
+


### PR DESCRIPTION
**Describe the change**
This PR is adding logger to capture the log entries for tests and to improve test feedback.

**Describe your implementation or design**
Added new `XunitLogger` class and added `ITestOutputHelper` parameter to some scenario constructors.

**Tests**
No tests are necessary.

**Breaking change**
No.