### PR TITLE
feat: Add .NET 8.0 support for Oracle persistence provider and improve test infrastructure

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -143,3 +143,19 @@ jobs:
         run: dotnet build --no-restore
       - name: Elasticsearch Tests
         run: dotnet test test/WorkflowCore.Tests.Elasticsearch --no-build --verbosity normal -p:ParallelizeTestCollections=false
+  Oracle-Tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: | 
+            6.0.x
+            8.0.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
+      - name: Oracle Tests
+        run: dotnet test test/WorkflowCore.Tests.Oracle --no-build --verbosity normal -p:ParallelizeTestCollections=false

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -153,6 +153,7 @@ jobs:
           dotnet-version: | 
             6.0.x
             8.0.x
+            9.0.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ There are several persistence providers available as separate Nuget packages.
 * [Sqlite](src/providers/WorkflowCore.Persistence.Sqlite)
 * [MySQL](src/providers/WorkflowCore.Persistence.MySQL)
 * [Redis](src/providers/WorkflowCore.Providers.Redis)
+* [Oracle](src/providers/WorkflowCore.Persistence.Oracle)
 
 ## Search
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -11,3 +11,4 @@ There are several persistence providers available as separate Nuget packages.
 * [Amazon DynamoDB](https://github.com/danielgerlag/workflow-core/tree/master/src/providers/WorkflowCore.Providers.AWS)
 * [Cosmos DB](https://github.com/danielgerlag/workflow-core/tree/master/src/providers/WorkflowCore.Providers.Azure)
 * [Redis](https://github.com/danielgerlag/workflow-core/tree/master/src/providers/WorkflowCore.Providers.Redis)
+* [Oracle](https://github.com/danielgerlag/workflow-core/tree/master/src/providers/WorkflowCore.Persistence.Oracle)

--- a/src/providers/WorkflowCore.Persistence.Oracle/MigrationContextFactory.cs
+++ b/src/providers/WorkflowCore.Persistence.Oracle/MigrationContextFactory.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-
-using Microsoft.EntityFrameworkCore.Design;
+﻿using Microsoft.EntityFrameworkCore.Design;
 
 namespace WorkflowCore.Persistence.Oracle
 {

--- a/src/providers/WorkflowCore.Persistence.Oracle/OracleContext.cs
+++ b/src/providers/WorkflowCore.Persistence.Oracle/OracleContext.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Linq;
 
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 using Oracle.EntityFrameworkCore.Infrastructure;

--- a/src/providers/WorkflowCore.Persistence.Oracle/OracleContextFactory.cs
+++ b/src/providers/WorkflowCore.Persistence.Oracle/OracleContextFactory.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Linq;
-
-using Microsoft.EntityFrameworkCore.Infrastructure;
 
 using Oracle.EntityFrameworkCore.Infrastructure;
 

--- a/src/providers/WorkflowCore.Persistence.Oracle/README.md
+++ b/src/providers/WorkflowCore.Persistence.Oracle/README.md
@@ -18,7 +18,7 @@ Use the .UseOracle extension method when building your service provider.
 services.AddWorkflow(x => x.UseOracle(@"Server=127.0.0.1;Database=workflow;User=root;Password=password;", true, true));
 ```
 
-You can also add specific database version compability if needed.
+You can also add specific database version compatibility if needed.
 
 ```C#
 services.AddWorkflow(x =>

--- a/src/providers/WorkflowCore.Persistence.Oracle/README.md
+++ b/src/providers/WorkflowCore.Persistence.Oracle/README.md
@@ -17,3 +17,15 @@ Use the .UseOracle extension method when building your service provider.
 ```C#
 services.AddWorkflow(x => x.UseOracle(@"Server=127.0.0.1;Database=workflow;User=root;Password=password;", true, true));
 ```
+
+You can also add specific database version compability if needed.
+
+```C#
+services.AddWorkflow(x =>
+    {
+        x.UseOracle(connectionString, false, true, options =>
+            {
+                options.UseOracleSQLCompatibility(OracleSQLCompatibility.DatabaseVersion19);
+            });
+    });
+```

--- a/src/providers/WorkflowCore.Persistence.Oracle/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Persistence.Oracle/ServiceCollectionExtensions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Linq;
-
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
 using Oracle.EntityFrameworkCore.Infrastructure;
@@ -14,10 +11,10 @@ namespace WorkflowCore.Persistence.Oracle
 {
     public static class ServiceCollectionExtensions
     {
-        public static WorkflowOptions UseOracle(this WorkflowOptions options, string connectionString, bool canCreateDB, bool canMigrateDB, Action<OracleDbContextOptionsBuilder> mysqlOptionsAction = null)
+        public static WorkflowOptions UseOracle(this WorkflowOptions options, string connectionString, bool canCreateDB, bool canMigrateDB, Action<OracleDbContextOptionsBuilder> oracleOptionsAction = null)
         {
-            options.UsePersistence(sp => new EntityFrameworkPersistenceProvider(new OracleContextFactory(connectionString, mysqlOptionsAction), canCreateDB, canMigrateDB));
-            options.Services.AddTransient<IWorkflowPurger>(sp => new WorkflowPurger(new OracleContextFactory(connectionString, mysqlOptionsAction)));
+            options.UsePersistence(sp => new EntityFrameworkPersistenceProvider(new OracleContextFactory(connectionString, oracleOptionsAction), canCreateDB, canMigrateDB));
+            options.Services.AddTransient<IWorkflowPurger>(sp => new WorkflowPurger(new OracleContextFactory(connectionString, oracleOptionsAction)));
             return options;
         }
     }

--- a/src/providers/WorkflowCore.Persistence.Oracle/WorkflowCore.Persistence.Oracle.csproj
+++ b/src/providers/WorkflowCore.Persistence.Oracle/WorkflowCore.Persistence.Oracle.csproj
@@ -1,40 +1,50 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <AssemblyTitle>Workflow Core Oracle Persistence Provider</AssemblyTitle>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <Authors>Christian Jundt</Authors>
-    <TargetFrameworks>net6.0</TargetFrameworks>
-    <AssemblyName>WorkflowCore.Persistence.Oracle</AssemblyName>
-    <PackageId>WorkflowCore.Persistence.Oracle</PackageId>
-    <PackageTags>workflow;.NET;Core;state machine;WorkflowCore;Oracle</PackageTags>
-    <PackageProjectUrl>https://github.com/danielgerlag/workflow-core</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/danielgerlag/workflow-core/blob/master/LICENSE.md</PackageLicenseUrl>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/danielgerlag/workflow-core.git</RepositoryUrl>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Description>Provides support to persist workflows running on Workflow Core to a Oracle database.</Description>
-  </PropertyGroup>
+	<PropertyGroup>
+		<AssemblyTitle>Workflow Core Oracle Persistence Provider</AssemblyTitle>
+		<VersionPrefix>1.0.0</VersionPrefix>
+		<Authors>Christian Jundt</Authors>
+		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+		<AssemblyName>WorkflowCore.Persistence.Oracle</AssemblyName>
+		<PackageId>WorkflowCore.Persistence.Oracle</PackageId>
+		<PackageTags>workflow;.NET;Core;state machine;WorkflowCore;Oracle</PackageTags>
+		<PackageProjectUrl>https://github.com/danielgerlag/workflow-core</PackageProjectUrl>
+		<PackageLicenseUrl>https://github.com/danielgerlag/workflow-core/blob/master/LICENSE.md</PackageLicenseUrl>
+		<RepositoryType>git</RepositoryType>
+		<RepositoryUrl>https://github.com/danielgerlag/workflow-core.git</RepositoryUrl>
+		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+		<Description>Provides support to persist workflows running on Workflow Core to a Oracle database.</Description>
+	</PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.*" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.*">
-		  <PrivateAssets>All</PrivateAssets>
-	  </PackageReference>
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.*">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
-    <PackageReference Include="Oracle.EntityFrameworkCore">
-        <Version>7.21.13</Version>
-    </PackageReference>
-  </ItemGroup>  
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.*">
+			<PrivateAssets>All</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.*">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Oracle.EntityFrameworkCore" Version="8.*" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\WorkflowCore\WorkflowCore.csproj" />
-    <ProjectReference Include="..\WorkflowCore.Persistence.EntityFramework\WorkflowCore.Persistence.EntityFramework.csproj" />
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.*">
+			<PrivateAssets>All</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.*">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Oracle.EntityFrameworkCore">
+			<Version>7.21.13</Version>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\WorkflowCore\WorkflowCore.csproj" />
+		<ProjectReference Include="..\WorkflowCore.Persistence.EntityFramework\WorkflowCore.Persistence.EntityFramework.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/test/WorkflowCore.Tests.Oracle/OraclePersistenceProviderFixture.cs
+++ b/test/WorkflowCore.Tests.Oracle/OraclePersistenceProviderFixture.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using WorkflowCore.Interface;
+﻿using WorkflowCore.Interface;
 using WorkflowCore.Persistence.EntityFramework.Services;
 using WorkflowCore.Persistence.Oracle;
-using WorkflowCore.Tests.Oracle;
 using WorkflowCore.UnitTests;
 using Xunit;
 using Xunit.Abstractions;
@@ -12,10 +10,10 @@ namespace WorkflowCore.Tests.Oracle
     [Collection("Oracle collection")]
     public class OraclePersistenceProviderFixture : BasePersistenceFixture
     {
-        private readonly IPersistenceProvider _subject;
+        private readonly EntityFrameworkPersistenceProvider _subject;
         protected override IPersistenceProvider Subject => _subject;
 
-        public OraclePersistenceProviderFixture(OracleDockerSetup dockerSetup, ITestOutputHelper output)
+        public OraclePersistenceProviderFixture(ITestOutputHelper output)
         {
             output.WriteLine($"Connecting on {OracleDockerSetup.ConnectionString}");
             _subject = new EntityFrameworkPersistenceProvider(new OracleContextFactory(OracleDockerSetup.ConnectionString), true, true);

--- a/test/WorkflowCore.Tests.Oracle/OraclePersistenceProviderFixture.cs
+++ b/test/WorkflowCore.Tests.Oracle/OraclePersistenceProviderFixture.cs
@@ -13,7 +13,7 @@ namespace WorkflowCore.Tests.Oracle
         private readonly EntityFrameworkPersistenceProvider _subject;
         protected override IPersistenceProvider Subject => _subject;
 
-        public OraclePersistenceProviderFixture(ITestOutputHelper output)
+        public OraclePersistenceProviderFixture(OracleDockerSetup dockerSetup, ITestOutputHelper output)
         {
             output.WriteLine($"Connecting on {OracleDockerSetup.ConnectionString}");
             _subject = new EntityFrameworkPersistenceProvider(new OracleContextFactory(OracleDockerSetup.ConnectionString), true, true);

--- a/test/WorkflowCore.Tests.Oracle/Scenarios/OracleActivityScenario.cs
+++ b/test/WorkflowCore.Tests.Oracle/Scenarios/OracleActivityScenario.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using WorkflowCore.Persistence.Oracle;
-using WorkflowCore.Tests.Oracle;
 
 using Xunit;
 
@@ -10,7 +8,7 @@ namespace WorkflowCore.Tests.Oracle.Scenarios
 {
     [Collection("Oracle collection")]
     public class OracleActivityScenario : ActivityScenario
-    {        
+    {
         protected override void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow(x => x.UseOracle(OracleDockerSetup.ConnectionString, true, true));

--- a/test/WorkflowCore.Tests.Oracle/Scenarios/OracleBasicScenario.cs
+++ b/test/WorkflowCore.Tests.Oracle/Scenarios/OracleBasicScenario.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using WorkflowCore.Persistence.Oracle;
-using WorkflowCore.Tests.Oracle;
 
 using Xunit;
 
@@ -10,7 +8,7 @@ namespace WorkflowCore.Tests.Oracle.Scenarios
 {
     [Collection("Oracle collection")]
     public class OracleBasicScenario : BasicScenario
-    {        
+    {
         protected override void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow(x => x.UseOracle(OracleDockerSetup.ConnectionString, true, true));

--- a/test/WorkflowCore.Tests.Oracle/Scenarios/OracleDataScenario.cs
+++ b/test/WorkflowCore.Tests.Oracle/Scenarios/OracleDataScenario.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using WorkflowCore.Persistence.Oracle;
-using WorkflowCore.Tests.Oracle;
 
 using Xunit;
 
@@ -10,7 +8,7 @@ namespace WorkflowCore.Tests.Oracle.Scenarios
 {
     [Collection("Oracle collection")]
     public class OracleDataScenario : DataIOScenario
-    {        
+    {
         protected override void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow(x => x.UseOracle(OracleDockerSetup.ConnectionString, true, true));

--- a/test/WorkflowCore.Tests.Oracle/Scenarios/OracleDelayScenario.cs
+++ b/test/WorkflowCore.Tests.Oracle/Scenarios/OracleDelayScenario.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using WorkflowCore.Persistence.Oracle;
-using WorkflowCore.Tests.Oracle;
 
 using Xunit;
 
@@ -10,7 +9,7 @@ namespace WorkflowCore.Tests.Oracle.Scenarios
 {
     [Collection("Oracle collection")]
     public class OracleDelayScenario : DelayScenario
-    {        
+    {
         protected override void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow(cfg =>

--- a/test/WorkflowCore.Tests.Oracle/Scenarios/OracleDynamicDataScenario.cs
+++ b/test/WorkflowCore.Tests.Oracle/Scenarios/OracleDynamicDataScenario.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using WorkflowCore.Persistence.Oracle;
-using WorkflowCore.Tests.Oracle;
 
 using Xunit;
 

--- a/test/WorkflowCore.Tests.Oracle/Scenarios/OracleEventScenario.cs
+++ b/test/WorkflowCore.Tests.Oracle/Scenarios/OracleEventScenario.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using WorkflowCore.Persistence.Oracle;
-using WorkflowCore.Tests.Oracle;
 
 using Xunit;
 
@@ -10,7 +8,7 @@ namespace WorkflowCore.Tests.Oracle.Scenarios
 {
     [Collection("Oracle collection")]
     public class OracleEventScenario : EventScenario
-    {        
+    {
         protected override void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow(x => x.UseOracle(OracleDockerSetup.ConnectionString, true, true));

--- a/test/WorkflowCore.Tests.Oracle/Scenarios/OracleForeachScenario.cs
+++ b/test/WorkflowCore.Tests.Oracle/Scenarios/OracleForeachScenario.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using WorkflowCore.Persistence.Oracle;
-using WorkflowCore.Tests.Oracle;
 
 using Xunit;
 
@@ -10,7 +8,7 @@ namespace WorkflowCore.Tests.Oracle.Scenarios
 {
     [Collection("Oracle collection")]
     public class OracleForeachScenario : ForeachScenario
-    {        
+    {
         protected override void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow(x => x.UseOracle(OracleDockerSetup.ConnectionString, true, true));

--- a/test/WorkflowCore.Tests.Oracle/Scenarios/OracleForkScenario.cs
+++ b/test/WorkflowCore.Tests.Oracle/Scenarios/OracleForkScenario.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using WorkflowCore.Persistence.Oracle;
-using WorkflowCore.Tests.Oracle;
 
 using Xunit;
 
@@ -10,7 +8,7 @@ namespace WorkflowCore.Tests.Oracle.Scenarios
 {
     [Collection("Oracle collection")]
     public class OracleForkScenario : ForkScenario
-    {        
+    {
         protected override void Configure(IServiceCollection services)
         {
             services.AddWorkflow(x => x.UseOracle(OracleDockerSetup.ConnectionString, true, true));

--- a/test/WorkflowCore.Tests.Oracle/Scenarios/OracleIfScenario.cs
+++ b/test/WorkflowCore.Tests.Oracle/Scenarios/OracleIfScenario.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using WorkflowCore.Persistence.Oracle;
-using WorkflowCore.Tests.Oracle;
 
 using Xunit;
 
@@ -10,7 +8,7 @@ namespace WorkflowCore.Tests.Oracle.Scenarios
 {
     [Collection("Oracle collection")]
     public class OracleIfScenario : IfScenario
-    {        
+    {
         protected override void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow(x => x.UseOracle(OracleDockerSetup.ConnectionString, true, true));

--- a/test/WorkflowCore.Tests.Oracle/Scenarios/OracleRetrySagaScenario.cs
+++ b/test/WorkflowCore.Tests.Oracle/Scenarios/OracleRetrySagaScenario.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using WorkflowCore.Persistence.Oracle;
-using WorkflowCore.Tests.Oracle;
 
 using Xunit;
 
@@ -10,7 +8,7 @@ namespace WorkflowCore.Tests.Oracle.Scenarios
 {
     [Collection("Oracle collection")]
     public class OracleRetrySagaScenario : RetrySagaScenario
-    {        
+    {
         protected override void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow(x => x.UseOracle(OracleDockerSetup.ConnectionString, true, true));

--- a/test/WorkflowCore.Tests.Oracle/Scenarios/OracleSagaScenario.cs
+++ b/test/WorkflowCore.Tests.Oracle/Scenarios/OracleSagaScenario.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using WorkflowCore.Persistence.Oracle;
-using WorkflowCore.Tests.Oracle;
 
 using Xunit;
 
@@ -10,7 +8,7 @@ namespace WorkflowCore.Tests.Oracle.Scenarios
 {
     [Collection("Oracle collection")]
     public class OracleSagaScenario : SagaScenario
-    {        
+    {
         protected override void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow(x => x.UseOracle(OracleDockerSetup.ConnectionString, true, true));

--- a/test/WorkflowCore.Tests.Oracle/Scenarios/OracleUserScenario.cs
+++ b/test/WorkflowCore.Tests.Oracle/Scenarios/OracleUserScenario.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using WorkflowCore.Persistence.Oracle;
-using WorkflowCore.Tests.Oracle;
 
 using Xunit;
 
@@ -10,7 +8,7 @@ namespace WorkflowCore.Tests.Oracle.Scenarios
 {
     [Collection("Oracle collection")]
     public class OracleUserScenario : UserScenario
-    {        
+    {
         protected override void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow(x => x.UseOracle(OracleDockerSetup.ConnectionString, true, true));

--- a/test/WorkflowCore.Tests.Oracle/Scenarios/OracleWhenScenario.cs
+++ b/test/WorkflowCore.Tests.Oracle/Scenarios/OracleWhenScenario.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using WorkflowCore.Persistence.Oracle;
-using WorkflowCore.Tests.Oracle;
 
 using Xunit;
 
@@ -10,7 +8,7 @@ namespace WorkflowCore.Tests.Oracle.Scenarios
 {
     [Collection("Oracle collection")]
     public class OracleWhenScenario : WhenScenario
-    {        
+    {
         protected override void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow(x => x.UseOracle(OracleDockerSetup.ConnectionString, true, true));

--- a/test/WorkflowCore.Tests.Oracle/Scenarios/OracleWhileScenario.cs
+++ b/test/WorkflowCore.Tests.Oracle/Scenarios/OracleWhileScenario.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using WorkflowCore.IntegrationTests.Scenarios;
 using WorkflowCore.Persistence.Oracle;
-using WorkflowCore.Tests.Oracle;
 
 using Xunit;
 
@@ -10,7 +8,7 @@ namespace WorkflowCore.Tests.Oracle.Scenarios
 {
     [Collection("Oracle collection")]
     public class OracleWhileScenario : WhileScenario
-    {        
+    {
         protected override void ConfigureServices(IServiceCollection services)
         {
             services.AddWorkflow(x => x.UseOracle(OracleDockerSetup.ConnectionString, true, true));

--- a/test/WorkflowCore.Tests.Oracle/WorkflowCore.Tests.Oracle.csproj
+++ b/test/WorkflowCore.Tests.Oracle/WorkflowCore.Tests.Oracle.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net6.0</TargetFrameworks>
+	<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyName>WorkflowCore.Tests.Oracle</AssemblyName>
     <PackageId>WorkflowCore.Tests.Oracle</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -9,6 +9,10 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Testcontainers.Oracle" Version="3.7.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\WorkflowCore\WorkflowCore.csproj" />


### PR DESCRIPTION
**Describe the change**
This PR adds .NET 8.0 support to the Oracle persistence provider and improves the overall test infrastructure and documentation. The main highlight is the addition of .NET 8.0 compatibility, making the Oracle provider fully supported on the latest .NET version.

**Describe your implementation or design**
- **Added .NET 8.0 support**: Updated the Oracle persistence provider to target .NET 8.0 alongside existing .NET 6.0 support
- **Improved test infrastructure**: 
  - Added Oracle tests to the GitHub CI/CD pipeline
  - Fixed Oracle tests using TestContainers for reliable containerized testing
  - Added .NET 8.0 test support for Oracle scenarios
- **Enhanced documentation**: 
  - Improved Oracle persistence README with better usage examples and configuration details
  - Added Oracle as a persistence option to the main project README
- **Code cleanup and maintenance**:
  - Removed unnecessary SqlServer package dependencies from Oracle project
  - Cleaned up code files and made minor adjustments for better maintainability

**Tests**
- Oracle tests are now included in the GitHub pipeline and run successfully
- Tests use TestContainers for consistent and reliable Oracle database testing
- Added .NET 8.0 test support to ensure compatibility across both target frameworks
- All existing functionality remains intact and tested

**Breaking change**
No breaking changes. This is a backward-compatible enhancement that adds .NET 8.0 support while maintaining full compatibility with .NET 6.0.

**Additional context**
The Oracle persistence provider now fully supports the latest .NET 8.0 framework, making it ready for modern .NET applications. The improved test infrastructure ensures reliable testing across different environments, and the enhanced documentation makes it easier for developers to integrate Oracle persistence into their WorkflowCore applications.