### PR TITLE
#1368: SqlClient dependency update to fix vulnerability

### DIFF
--- a/src/providers/WorkflowCore.LockProviders.SqlServer/SqlLockProvider.cs
+++ b/src/providers/WorkflowCore.LockProviders.SqlServer/SqlLockProvider.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using WorkflowCore.Interface;

--- a/src/providers/WorkflowCore.LockProviders.SqlServer/WorkflowCore.LockProviders.SqlServer.csproj
+++ b/src/providers/WorkflowCore.LockProviders.SqlServer/WorkflowCore.LockProviders.SqlServer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Replacing vulnerable System.Data.SqlClient dependency in the LockProviders.SqlServer project with Microsoft.Data.SqlClient version used by  Persistence.SqlServer project.
Closes #1368 