### PR TITLE
fix: use timestamp with time zone in PostgreSQL

### DIFF
--- a/src/providers/WorkflowCore.Persistence.PostgreSQL/Migrations/20250807084543_ChangeDataTimeTypeForPostgreSQL.Designer.cs
+++ b/src/providers/WorkflowCore.Persistence.PostgreSQL/Migrations/20250807084543_ChangeDataTimeTypeForPostgreSQL.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WorkflowCore.Persistence.PostgreSQL;
@@ -11,9 +12,11 @@ using WorkflowCore.Persistence.PostgreSQL;
 namespace WorkflowCore.Persistence.PostgreSQL.Migrations
 {
     [DbContext(typeof(PostgresContext))]
-    partial class PostgresPersistenceProviderModelSnapshot : ModelSnapshot
+    [Migration("20250807084543_ChangeDataTimeTypeForPostgreSQL")]
+    partial class ChangeDataTimeTypeForPostgreSQL
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/providers/WorkflowCore.Persistence.PostgreSQL/Migrations/20250807084543_ChangeDataTimeTypeForPostgreSQL.cs
+++ b/src/providers/WorkflowCore.Persistence.PostgreSQL/Migrations/20250807084543_ChangeDataTimeTypeForPostgreSQL.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WorkflowCore.Persistence.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangeDataTimeTypeForPostgreSQL : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CreateTime",
+                schema: "wfc",
+                table: "Workflow",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CompleteTime",
+                schema: "wfc",
+                table: "Workflow",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "SubscribeAsOf",
+                schema: "wfc",
+                table: "Subscription",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "ExternalTokenExpiry",
+                schema: "wfc",
+                table: "Subscription",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "StartTime",
+                schema: "wfc",
+                table: "ExecutionPointer",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "SleepUntil",
+                schema: "wfc",
+                table: "ExecutionPointer",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "EndTime",
+                schema: "wfc",
+                table: "ExecutionPointer",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "ErrorTime",
+                schema: "wfc",
+                table: "ExecutionError",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "EventTime",
+                schema: "wfc",
+                table: "Event",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CreateTime",
+                schema: "wfc",
+                table: "Workflow",
+                type: "timestamp without time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CompleteTime",
+                schema: "wfc",
+                table: "Workflow",
+                type: "timestamp without time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "SubscribeAsOf",
+                schema: "wfc",
+                table: "Subscription",
+                type: "timestamp without time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "ExternalTokenExpiry",
+                schema: "wfc",
+                table: "Subscription",
+                type: "timestamp without time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "StartTime",
+                schema: "wfc",
+                table: "ExecutionPointer",
+                type: "timestamp without time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "SleepUntil",
+                schema: "wfc",
+                table: "ExecutionPointer",
+                type: "timestamp without time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "EndTime",
+                schema: "wfc",
+                table: "ExecutionPointer",
+                type: "timestamp without time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "ErrorTime",
+                schema: "wfc",
+                table: "ExecutionError",
+                type: "timestamp without time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "EventTime",
+                schema: "wfc",
+                table: "Event",
+                type: "timestamp without time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+        }
+    }
+}

--- a/src/providers/WorkflowCore.Persistence.PostgreSQL/PostgresContext.cs
+++ b/src/providers/WorkflowCore.Persistence.PostgreSQL/PostgresContext.cs
@@ -66,6 +66,54 @@ namespace WorkflowCore.Persistence.PostgreSQL
             builder.ToTable("ScheduledCommand", _schemaName);
             builder.Property(x => x.PersistenceId).ValueGeneratedOnAdd();
         }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<PersistedWorkflow>(x =>
+            {
+                x.Property(p => p.CompleteTime)
+                 .HasColumnType("timestamp with time zone");
+
+                x.Property(p => p.CreateTime)
+                 .HasColumnType("timestamp with time zone");
+            });
+
+            modelBuilder.Entity<PersistedExecutionPointer>(x =>
+            {
+                x.Property(p => p.SleepUntil)
+                 .HasColumnType("timestamp with time zone");
+
+                x.Property(p => p.StartTime)
+                 .HasColumnType("timestamp with time zone");
+
+                x.Property(p => p.EndTime)
+                 .HasColumnType("timestamp with time zone");
+
+            });
+
+            modelBuilder.Entity<PersistedExecutionError>(x =>
+            {
+                x.Property(p => p.ErrorTime)
+                 .HasColumnType("timestamp with time zone");
+
+            });
+
+            modelBuilder.Entity<PersistedSubscription>(x =>
+            {
+                x.Property(p => p.SubscribeAsOf)
+                 .HasColumnType("timestamp with time zone");
+
+                x.Property(p => p.ExternalTokenExpiry)
+                 .HasColumnType("timestamp with time zone");
+            });
+
+            modelBuilder.Entity<PersistedEvent>(
+                x => x.Property(x => x.EventTime)
+                .HasColumnType("timestamp with time zone")
+            );
+        }
     }
 }
 


### PR DESCRIPTION
**Describe the change**

Use timestamp with time zone in postgresql.

**Describe your implementation or design**

Only add column type.


**Additional context**

Relative issue: #1373 