### PR TITLE
Removed System.Data.SqlClient reference from SqlServer QueueProvider

### DIFF
--- a/src/providers/WorkflowCore.QueueProviders.SqlServer/Interfaces/ISqlCommandExecutor.cs
+++ b/src/providers/WorkflowCore.QueueProviders.SqlServer/Interfaces/ISqlCommandExecutor.cs
@@ -2,9 +2,9 @@
 
 using System;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 
 #endregion
 

--- a/src/providers/WorkflowCore.QueueProviders.SqlServer/Services/SqlCommandExecutor.cs
+++ b/src/providers/WorkflowCore.QueueProviders.SqlServer/Services/SqlCommandExecutor.cs
@@ -2,9 +2,9 @@
 
 using System;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using WorkflowCore.QueueProviders.SqlServer.Interfaces;
 
 #endregion
@@ -18,11 +18,11 @@ namespace WorkflowCore.QueueProviders.SqlServer.Services
             using (var cmd = cn.CreateCommand())
             {
                 cmd.Transaction = tx;
-                cmd.CommandText = cmdtext;                
+                cmd.CommandText = cmdtext;
 
                 foreach (var param in parameters)
                     cmd.Parameters.Add(param);
-                
+
                 return (TResult)await cmd.ExecuteScalarAsync();
             }
         }

--- a/src/providers/WorkflowCore.QueueProviders.SqlServer/Services/SqlServerQueueProvider.cs
+++ b/src/providers/WorkflowCore.QueueProviders.SqlServer/Services/SqlServerQueueProvider.cs
@@ -1,12 +1,12 @@
 ﻿#region using
 
 using System;
-using System.Data.SqlClient;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 
 using WorkflowCore.Interface;
 using WorkflowCore.QueueProviders.SqlServer.Interfaces;
@@ -123,11 +123,11 @@ namespace WorkflowCore.QueueProviders.SqlServer.Services
             {
                 await cn.OpenAsync(cancellationToken);
 
-                var par = _config.GetByQueue(queue);                
+                var par = _config.GetByQueue(queue);
                 var sql = _dequeueWorkCommand.Replace("{queueName}", par.QueueName);
                 var msg = await _sqlCommandExecutor.ExecuteScalarAsync<object>(cn, null, sql);
                 return msg is DBNull ? null : (string)msg;
-                
+
             }
             finally
             {

--- a/src/providers/WorkflowCore.QueueProviders.SqlServer/Services/SqlServerQueueProviderMigrator.cs
+++ b/src/providers/WorkflowCore.QueueProviders.SqlServer/Services/SqlServerQueueProviderMigrator.cs
@@ -1,16 +1,16 @@
 ﻿#region using
 
 using System;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using WorkflowCore.Interface;
 using WorkflowCore.QueueProviders.SqlServer.Interfaces;
 
 #endregion
 
 namespace WorkflowCore.QueueProviders.SqlServer.Services
-{    
+{
 
     public class SqlServerQueueProviderMigrator : ISqlServerQueueProviderMigrator
     {
@@ -54,7 +54,7 @@ namespace WorkflowCore.QueueProviders.SqlServer.Services
                     await CreateService(cn, tx, item.InitiatorService, item.QueueName, item.ContractName);
                     await CreateService(cn, tx, item.TargetService, item.QueueName, item.ContractName);
                 }
-                
+
                 tx.Commit();
             }
             catch
@@ -75,7 +75,7 @@ namespace WorkflowCore.QueueProviders.SqlServer.Services
 
             if (!string.IsNullOrEmpty(existing))
                 return;
-            
+
             await _sqlCommandExecutor.ExecuteCommandAsync(cn, tx, $"CREATE SERVICE [{name}] ON QUEUE [{queueName}]([{contractName}]);");
         }
 
@@ -86,7 +86,7 @@ namespace WorkflowCore.QueueProviders.SqlServer.Services
 
             if (!string.IsNullOrEmpty(existing))
                 return;
-                        
+
             await _sqlCommandExecutor.ExecuteCommandAsync(cn, tx, $"CREATE QUEUE [{queueName}];");
         }
 
@@ -97,7 +97,7 @@ namespace WorkflowCore.QueueProviders.SqlServer.Services
 
             if (!string.IsNullOrEmpty(existing))
                 return;
-                        
+
             await _sqlCommandExecutor.ExecuteCommandAsync(cn, tx, $"CREATE CONTRACT [{contractName}] ( [{messageName}] SENT BY INITIATOR);");
         }
 
@@ -108,7 +108,7 @@ namespace WorkflowCore.QueueProviders.SqlServer.Services
 
             if (!string.IsNullOrEmpty(existing))
                 return;
-            
+
             await _sqlCommandExecutor.ExecuteCommandAsync(cn, tx, $"CREATE MESSAGE TYPE [{message}] VALIDATION = NONE;");
         }
 
@@ -134,7 +134,7 @@ namespace WorkflowCore.QueueProviders.SqlServer.Services
                 dbPresente = (found != null);
 
                 if (!dbPresente)
-                {   
+                {
                     var createCmd = cn.CreateCommand();
                     createCmd.CommandText = "create database [" + builder.InitialCatalog + "]";
                     await createCmd.ExecuteNonQueryAsync();
@@ -143,7 +143,7 @@ namespace WorkflowCore.QueueProviders.SqlServer.Services
             finally
             {
                 cn.Close();
-            }            
+            }
 
             await EnableBroker(masterCnStr, builder.InitialCatalog);
         }
@@ -172,7 +172,7 @@ namespace WorkflowCore.QueueProviders.SqlServer.Services
             finally
             {
                 cn.Close();
-            }            
+            }
         }
     }
 }

--- a/src/providers/WorkflowCore.QueueProviders.SqlServer/WorkflowCore.QueueProviders.SqlServer.csproj
+++ b/src/providers/WorkflowCore.QueueProviders.SqlServer/WorkflowCore.QueueProviders.SqlServer.csproj
@@ -21,8 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-    <PackageReference Include="System.Data.Common" Version="4.3.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Describe the change**
The queue provider project was the last to reference the old, not supported `System.Data.SqlClient` and related packages.
Removed the references and added `Microsoft.Data.SqlClient` to be consistent in the entire codebase.

**Tests**
The classes were not covered by tests.

**Breaking change**
Not more breaking than upgrading was in the LockProvider project :)

Fixes #1414 