### PR TITLE
Add UseCosmosDbPersistence overload for DI-registered CosmosClient

### DIFF
--- a/src/providers/WorkflowCore.Providers.Azure/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Providers.Azure/ServiceCollectionExtensions.cs
@@ -106,5 +106,23 @@ namespace Microsoft.Extensions.DependencyInjection
             options.UsePersistence(sp => new CosmosDbPersistenceProvider(sp.GetService<ICosmosClientFactory>(), databaseId, sp.GetService<ICosmosDbProvisioner>(), cosmosDbStorageOptions));
             return options;
         }
+
+        public static WorkflowOptions UseCosmosDbPersistence(
+            this WorkflowOptions options,
+            string databaseId,
+            CosmosDbStorageOptions cosmosDbStorageOptions = null,
+            CosmosClientOptions clientOptions = null)
+        {
+            if (cosmosDbStorageOptions == null)
+            {
+                cosmosDbStorageOptions = new CosmosDbStorageOptions();
+            }
+
+            options.Services.AddSingleton<ICosmosClientFactory>(sp => new CosmosClientFactory(sp.GetService<CosmosClient>()));
+            options.Services.AddTransient<ICosmosDbProvisioner>(sp => new CosmosDbProvisioner(sp.GetService<ICosmosClientFactory>(), cosmosDbStorageOptions));
+            options.Services.AddSingleton<IWorkflowPurger>(sp => new WorkflowPurger(sp.GetService<ICosmosClientFactory>(), databaseId, cosmosDbStorageOptions));
+            options.UsePersistence(sp => new CosmosDbPersistenceProvider(sp.GetService<ICosmosClientFactory>(), databaseId, sp.GetService<ICosmosDbProvisioner>(), cosmosDbStorageOptions));
+            return options;
+        }        
     }
 }

--- a/src/providers/WorkflowCore.Providers.Azure/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Providers.Azure/ServiceCollectionExtensions.cs
@@ -110,8 +110,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static WorkflowOptions UseCosmosDbPersistence(
             this WorkflowOptions options,
             string databaseId,
-            CosmosDbStorageOptions cosmosDbStorageOptions = null,
-            CosmosClientOptions clientOptions = null)
+            CosmosDbStorageOptions cosmosDbStorageOptions = null)
         {
             if (cosmosDbStorageOptions == null)
             {

--- a/src/providers/WorkflowCore.Providers.Azure/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Providers.Azure/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using Azure.Core;
+using Azure.Data.Tables;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
 using WorkflowCore.Interface;
@@ -122,6 +123,37 @@ namespace Microsoft.Extensions.DependencyInjection
             options.Services.AddSingleton<IWorkflowPurger>(sp => new WorkflowPurger(sp.GetService<ICosmosClientFactory>(), databaseId, cosmosDbStorageOptions));
             options.UsePersistence(sp => new CosmosDbPersistenceProvider(sp.GetService<ICosmosClientFactory>(), databaseId, sp.GetService<ICosmosDbProvisioner>(), cosmosDbStorageOptions));
             return options;
-        }        
+        }
+
+        public static WorkflowOptions UseAzureTableStoragePersistence(
+            this WorkflowOptions options,
+            string connectionString,
+            string tableNamePrefix = "WorkflowCore")
+        {
+            options.Services.AddSingleton<TableServiceClient>(sp => new TableServiceClient(connectionString));
+            options.UsePersistence(sp => new AzureTableStoragePersistenceProvider(sp.GetService<TableServiceClient>(), tableNamePrefix, sp.GetService<ILoggerFactory>()));
+            return options;
+        }
+
+        public static WorkflowOptions UseAzureTableStoragePersistence(
+            this WorkflowOptions options,
+            TableServiceClient tableServiceClient,
+            string tableNamePrefix = "WorkflowCore")
+        {
+            options.Services.AddSingleton(tableServiceClient);
+            options.UsePersistence(sp => new AzureTableStoragePersistenceProvider(sp.GetService<TableServiceClient>(), tableNamePrefix, sp.GetService<ILoggerFactory>()));
+            return options;
+        }
+
+        public static WorkflowOptions UseAzureTableStoragePersistence(
+            this WorkflowOptions options,
+            Uri serviceUri,
+            TokenCredential tokenCredential,
+            string tableNamePrefix = "WorkflowCore")
+        {
+            options.Services.AddSingleton<TableServiceClient>(sp => new TableServiceClient(serviceUri, tokenCredential));
+            options.UsePersistence(sp => new AzureTableStoragePersistenceProvider(sp.GetService<TableServiceClient>(), tableNamePrefix, sp.GetService<ILoggerFactory>()));
+            return options;
+        }
     }
 }

--- a/src/providers/WorkflowCore.Providers.Azure/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Providers.Azure/ServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using Azure.Core;
-using Azure.Data.Tables;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
 using WorkflowCore.Interface;
@@ -91,25 +90,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static WorkflowOptions UseCosmosDbPersistence(
             this WorkflowOptions options,
-            string accountEndpoint,
-            TokenCredential tokenCredential,
-            string databaseId,
-            CosmosDbStorageOptions cosmosDbStorageOptions = null)
-        {
-            if (cosmosDbStorageOptions == null)
-            {
-                cosmosDbStorageOptions = new CosmosDbStorageOptions();
-            }
-
-            options.Services.AddSingleton<ICosmosClientFactory>(sp => new CosmosClientFactory(accountEndpoint, tokenCredential));
-            options.Services.AddTransient<ICosmosDbProvisioner>(sp => new CosmosDbProvisioner(sp.GetService<ICosmosClientFactory>(), cosmosDbStorageOptions));
-            options.Services.AddSingleton<IWorkflowPurger>(sp => new WorkflowPurger(sp.GetService<ICosmosClientFactory>(), databaseId, cosmosDbStorageOptions));
-            options.UsePersistence(sp => new CosmosDbPersistenceProvider(sp.GetService<ICosmosClientFactory>(), databaseId, sp.GetService<ICosmosDbProvisioner>(), cosmosDbStorageOptions));
-            return options;
-        }
-
-        public static WorkflowOptions UseCosmosDbPersistence(
-            this WorkflowOptions options,
             string databaseId,
             CosmosDbStorageOptions cosmosDbStorageOptions = null)
         {
@@ -125,34 +105,22 @@ namespace Microsoft.Extensions.DependencyInjection
             return options;
         }
 
-        public static WorkflowOptions UseAzureTableStoragePersistence(
+        public static WorkflowOptions UseCosmosDbPersistence(
             this WorkflowOptions options,
-            string connectionString,
-            string tableNamePrefix = "WorkflowCore")
-        {
-            options.Services.AddSingleton<TableServiceClient>(sp => new TableServiceClient(connectionString));
-            options.UsePersistence(sp => new AzureTableStoragePersistenceProvider(sp.GetService<TableServiceClient>(), tableNamePrefix, sp.GetService<ILoggerFactory>()));
-            return options;
-        }
-
-        public static WorkflowOptions UseAzureTableStoragePersistence(
-            this WorkflowOptions options,
-            TableServiceClient tableServiceClient,
-            string tableNamePrefix = "WorkflowCore")
-        {
-            options.Services.AddSingleton(tableServiceClient);
-            options.UsePersistence(sp => new AzureTableStoragePersistenceProvider(sp.GetService<TableServiceClient>(), tableNamePrefix, sp.GetService<ILoggerFactory>()));
-            return options;
-        }
-
-        public static WorkflowOptions UseAzureTableStoragePersistence(
-            this WorkflowOptions options,
-            Uri serviceUri,
+            string accountEndpoint,
             TokenCredential tokenCredential,
-            string tableNamePrefix = "WorkflowCore")
+            string databaseId,
+            CosmosDbStorageOptions cosmosDbStorageOptions = null)
         {
-            options.Services.AddSingleton<TableServiceClient>(sp => new TableServiceClient(serviceUri, tokenCredential));
-            options.UsePersistence(sp => new AzureTableStoragePersistenceProvider(sp.GetService<TableServiceClient>(), tableNamePrefix, sp.GetService<ILoggerFactory>()));
+            if (cosmosDbStorageOptions == null)
+            {
+                cosmosDbStorageOptions = new CosmosDbStorageOptions();
+            }
+
+            options.Services.AddSingleton<ICosmosClientFactory>(sp => new CosmosClientFactory(accountEndpoint, tokenCredential));
+            options.Services.AddTransient<ICosmosDbProvisioner>(sp => new CosmosDbProvisioner(sp.GetService<ICosmosClientFactory>(), cosmosDbStorageOptions));
+            options.Services.AddSingleton<IWorkflowPurger>(sp => new WorkflowPurger(sp.GetService<ICosmosClientFactory>(), databaseId, cosmosDbStorageOptions));
+            options.UsePersistence(sp => new CosmosDbPersistenceProvider(sp.GetService<ICosmosClientFactory>(), databaseId, sp.GetService<ICosmosDbProvisioner>(), cosmosDbStorageOptions));
             return options;
         }
     }


### PR DESCRIPTION
## Summary

- Adds a new `UseCosmosDbPersistence` overload that resolves `CosmosClient` from the DI container
- Allows applications that already register `CosmosClient` in their service collection to configure CosmosDB persistence without duplicating client setup
- Consistent with existing overload patterns in `ServiceCollectionExtensions`

Resolves: #1424

## Test plan

- [x] Build solution verified with no compilation errors
- [x] New overload tested and working correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)