### PR TITLE
Bump version to 3.19.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,10 +4,10 @@
     <PackageLicenseUrl>https://github.com/danielgerlag/workflow-core/blob/master/LICENSE.md</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/danielgerlag/workflow-core.git</RepositoryUrl>
-    <Version>3.18.0</Version>
-    <AssemblyVersion>3.18.0.0</AssemblyVersion>
-    <FileVersion>3.18.0.0</FileVersion>
+    <Version>3.19.0</Version>
+    <AssemblyVersion>3.19.0.0</AssemblyVersion>
+    <FileVersion>3.19.0.0</FileVersion>
     <PackageIconUrl>https://github.com/danielgerlag/workflow-core/raw/master/src/logo.png</PackageIconUrl>
-    <PackageVersion>3.18.0</PackageVersion>
+    <PackageVersion>3.19.0</PackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Bump product version 3.18.0 → 3.19.0 so we can ship the #1429 .NET 10 expression compilation fix (3.18.0 is already on NuGet).

## Test plan
- [ ] Confirm Directory.Build.props versions are 3.19.0 / 3.19.0.0
- [ ] After merge: tag v3.19.0, GitHub release, dispatch nuget-publish
