### PR TITLE
3.20.0 security release

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,10 +4,10 @@
     <PackageLicenseUrl>https://github.com/danielgerlag/workflow-core/blob/master/LICENSE.md</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/danielgerlag/workflow-core.git</RepositoryUrl>
-    <Version>3.19.0</Version>
-    <AssemblyVersion>3.19.0.0</AssemblyVersion>
-    <FileVersion>3.19.0.0</FileVersion>
+    <Version>3.20.0</Version>
+    <AssemblyVersion>3.20.0.0</AssemblyVersion>
+    <FileVersion>3.20.0.0</FileVersion>
     <PackageIconUrl>https://github.com/danielgerlag/workflow-core/raw/master/src/logo.png</PackageIconUrl>
-    <PackageVersion>3.19.0</PackageVersion>
+    <PackageVersion>3.20.0</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/WorkflowCore/WorkflowCore.csproj
+++ b/src/WorkflowCore/WorkflowCore.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.17.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />
 	<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
 		<_Parameter1>WorkflowCore.IntegrationTests</_Parameter1>

--- a/src/WorkflowCore/WorkflowCore.csproj
+++ b/src/WorkflowCore/WorkflowCore.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.17.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
 	<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
 		<_Parameter1>WorkflowCore.IntegrationTests</_Parameter1>
 	</AssemblyAttribute>

--- a/src/providers/WorkflowCore.Providers.Redis/Services/RedisLockProvider.cs
+++ b/src/providers/WorkflowCore.Providers.Redis/Services/RedisLockProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,13 +13,14 @@ namespace WorkflowCore.Providers.Redis.Services
 {
     public class RedisLockProvider : IDistributedLockProvider
     {
-        private readonly ILogger _logger;        
+        private readonly ILogger _logger;
         private readonly string _connectionString;
         private readonly string _prefix;
         private IConnectionMultiplexer _multiplexer;
         private RedLockFactory _redlockFactory;
         private readonly TimeSpan _lockTimeout = TimeSpan.FromMinutes(1);
         private readonly List<IRedLock> ManagedLocks = new List<IRedLock>();
+        private readonly SemaphoreSlim _reconnectLock = new SemaphoreSlim(1, 1);
 
         public RedisLockProvider(string connectionString, string prefix, ILoggerFactory logFactory)
         {
@@ -30,8 +31,7 @@ namespace WorkflowCore.Providers.Redis.Services
 
         public async Task<bool> AcquireLock(string Id, CancellationToken cancellationToken)
         {
-            if (_redlockFactory == null)
-                throw new InvalidOperationException();
+            await EnsureConnected(cancellationToken);
 
             var redLock = await _redlockFactory.CreateLockAsync(GetResource(Id), _lockTimeout);
 
@@ -72,16 +72,54 @@ namespace WorkflowCore.Providers.Redis.Services
 
         public async Task Start()
         {
-            _multiplexer = await ConnectionMultiplexer.ConnectAsync(_connectionString);           
-            _redlockFactory = RedLockFactory.Create(new List<RedLockMultiplexer> { new RedLockMultiplexer(_multiplexer) });
+            await Connect(CancellationToken.None);
         }
 
         public async Task Stop()
         {
             _redlockFactory?.Dispose();
-            await _multiplexer.CloseAsync();
-            _multiplexer = null;
+            _redlockFactory = null;
+            if (_multiplexer != null)
+            {
+                await _multiplexer.CloseAsync();
+                _multiplexer = null;
+            }
+        }
 
+        private async Task EnsureConnected(CancellationToken cancellationToken)
+        {
+            if (_redlockFactory != null && _multiplexer != null && _multiplexer.IsConnected)
+                return;
+
+            await _reconnectLock.WaitAsync(cancellationToken);
+            try
+            {
+                if (_redlockFactory != null && _multiplexer != null && _multiplexer.IsConnected)
+                    return;
+
+                _logger.LogWarning("Redis multiplexer is disconnected or missing; reconnecting before lock acquire");
+                await Connect(cancellationToken);
+            }
+            finally
+            {
+                _reconnectLock.Release();
+            }
+        }
+
+        private async Task Connect(CancellationToken cancellationToken)
+        {
+            _redlockFactory?.Dispose();
+            _redlockFactory = null;
+
+            if (_multiplexer != null)
+            {
+                try { await _multiplexer.CloseAsync(); } catch { }
+                _multiplexer = null;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            _multiplexer = await ConnectionMultiplexer.ConnectAsync(_connectionString);
+            _redlockFactory = RedLockFactory.Create(new List<RedLockMultiplexer> { new RedLockMultiplexer(_multiplexer) });
         }
 
         private string GetResource(string key)


### PR DESCRIPTION
## Summary
- Upgrade OpenTelemetry.Api 1.12.0 → 1.17.0 to remediate CVE-2026-40894 (3.19.0 still shipped 1.12.0).
- Reconnect RedisLockProvider when the multiplexer is disconnected after endpoint redistribution (#1435).
- Bump product version to 3.20.0.

Supersedes the intent of #1431 / #1426 for the OTel bump. Leaves #1425 and #1421 as separate PRs.

## Test plan
- [ ] `dotnet restore` / build with NuGet audit — OpenTelemetry.Api 1.12.0 CVE gone
- [ ] Redis lock acquire still works after a reconnect
- [ ] Existing Redis provider tests