### PR TITLE
Added null-handling when recording host startup exception to current …

### DIFF
--- a/src/WorkflowCore/Services/WorkflowHost.cs
+++ b/src/WorkflowCore/Services/WorkflowHost.cs
@@ -49,7 +49,7 @@ namespace WorkflowCore.Services
             _activityController = activityController;
             _lifeCycleEventHub = lifeCycleEventHub;
         }
-        
+
         public Task<string> StartWorkflow(string workflowId, object data = null, string reference=null)
         {
             return _workflowController.StartWorkflow(workflowId, data, reference);
@@ -65,7 +65,7 @@ namespace WorkflowCore.Services
         {
             return _workflowController.StartWorkflow<TData>(workflowId, null, data, reference);
         }
-        
+
         public Task<string> StartWorkflow<TData>(string workflowId, int? version, TData data = null, string reference=null)
             where TData : class, new()
         {
@@ -81,7 +81,7 @@ namespace WorkflowCore.Services
         {
             StartAsync(CancellationToken.None).GetAwaiter().GetResult();
         }
-        
+
         public async Task StartAsync(CancellationToken cancellationToken)
         {
             var activity = WorkflowActivity.StartHost();
@@ -105,7 +105,7 @@ namespace WorkflowCore.Services
             }
             catch (Exception ex)
             {
-                activity.AddException(ex);
+                activity?.AddException(ex);
                 throw;
             }
             finally
@@ -118,7 +118,7 @@ namespace WorkflowCore.Services
         {
             StopAsync(CancellationToken.None).GetAwaiter().GetResult();
         }
-        
+
         public async Task StopAsync(CancellationToken cancellationToken)
         {
             _shutdown = true;


### PR DESCRIPTION
**Describe the change**
In WorkflowHost StartAsync if any exception occures, and there is no ActivityListener for WorkflowCore, then the catch block throws NullReferenceException due to accessing the null activity. This hides the original startup exception and makes impossible to see what had actually happen (eg. RabbitMQ queue provider connection issue, etc.)

**Describe your implementation or design**
Added a null-conditional operator to AddException

**Tests**
No

**Breaking change**
No
