### PR TITLE
Add UseCosmosDbPersistence overload for DI-registered CosmosClient

### DIFF
--- a/src/providers/WorkflowCore.Providers.Azure/ServiceCollectionExtensions.cs
+++ b/src/providers/WorkflowCore.Providers.Azure/ServiceCollectionExtensions.cs
@@ -108,6 +108,23 @@ namespace Microsoft.Extensions.DependencyInjection
             return options;
         }
 
+        public static WorkflowOptions UseCosmosDbPersistence(
+            this WorkflowOptions options,
+            string databaseId,
+            CosmosDbStorageOptions cosmosDbStorageOptions = null)
+        {
+            if (cosmosDbStorageOptions == null)
+            {
+                cosmosDbStorageOptions = new CosmosDbStorageOptions();
+            }
+
+            options.Services.AddSingleton<ICosmosClientFactory>(sp => new CosmosClientFactory(sp.GetService<CosmosClient>()));
+            options.Services.AddTransient<ICosmosDbProvisioner>(sp => new CosmosDbProvisioner(sp.GetService<ICosmosClientFactory>(), cosmosDbStorageOptions));
+            options.Services.AddSingleton<IWorkflowPurger>(sp => new WorkflowPurger(sp.GetService<ICosmosClientFactory>(), databaseId, cosmosDbStorageOptions));
+            options.UsePersistence(sp => new CosmosDbPersistenceProvider(sp.GetService<ICosmosClientFactory>(), databaseId, sp.GetService<ICosmosDbProvisioner>(), cosmosDbStorageOptions));
+            return options;
+        }
+
         public static WorkflowOptions UseAzureTableStoragePersistence(
             this WorkflowOptions options,
             string connectionString,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds `UseCosmosDbPersistence(databaseId, cosmosDbStorageOptions)` that resolves `CosmosClient` from DI via `sp.GetService<CosmosClient>()`, matching the existing Cosmos overload style.
- Rebased onto current `master` so Azure Table persistence methods from later commits are kept.
- Maintainer replacement for #1421 (CONFLICTING vs master). Same approach as mbadev62; closes #1424.

**Describe the change**
Applications that already register `CosmosClient` as a singleton can now configure Cosmos persistence without a connection string, an early-constructed client, or `BuildServiceProvider()`.

**Describe your implementation or design**
New overload copies the existing Cosmos registration (factory, provisioner, purger, persistence provider) and constructs `CosmosClientFactory` from the DI-registered `CosmosClient`. Uses `GetService` to match the rest of this file.

**Tests**
No new tests. Registration matches the existing overloads.

**Breaking change**
No.

**Additional context**
#1421 from mbadev62 had the same change but conflicts with Azure Table persistence methods added to this file after the branch was cut. Cannot push to the contributor fork, so this maintainer branch applies the same overload on current master.

Credits: @mbadev62
Closes #1424
Supersedes #1421
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8ae9534-65c2-40f4-a741-ecd1e16604a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8ae9534-65c2-40f4-a741-ecd1e16604a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

