### PR TITLE
Fix YAML/JSON primitive input binding for step properties (#1375)

### DIFF
--- a/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
+++ b/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
@@ -275,7 +275,7 @@ namespace WorkflowCore.Services.DefinitionStorage
                         if (stepProperty.PropertyType.IsAssignableFrom(primitiveValue.GetType()))
                             stepProperty.SetValue(pStep, primitiveValue);
                         else
-                            stepProperty.SetValue(pStep, Convert.ChangeType(primitiveValue, stepProperty.PropertyType));
+                            stepProperty.SetValue(pStep, System.Convert.ChangeType(primitiveValue, stepProperty.PropertyType));
                     }
                     step.Inputs.Add(new ActionParameter<IStepBody, object>(primitiveAction));
                     continue;

--- a/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
+++ b/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
@@ -267,6 +267,20 @@ namespace WorkflowCore.Services.DefinitionStorage
                     continue;
                 }
 
+                if (input.Value != null && (input.Value.GetType().IsPrimitive || input.Value is decimal))
+                {
+                    var primitiveValue = input.Value;
+                    void primitiveAction(IStepBody pStep, object pData)
+                    {
+                        if (stepProperty.PropertyType.IsAssignableFrom(primitiveValue.GetType()))
+                            stepProperty.SetValue(pStep, primitiveValue);
+                        else
+                            stepProperty.SetValue(pStep, Convert.ChangeType(primitiveValue, stepProperty.PropertyType));
+                    }
+                    step.Inputs.Add(new ActionParameter<IStepBody, object>(primitiveAction));
+                    continue;
+                }
+
                 throw new ArgumentException($"Unknown type for input {input.Key} on {source.Id}");
             }
         }

--- a/test/WorkflowCore.TestAssets/DataTypes/IterateListData.cs
+++ b/test/WorkflowCore.TestAssets/DataTypes/IterateListData.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace WorkflowCore.TestAssets.DataTypes
+{
+    public class IterateListData
+    {
+        public List<string> DataList { get; set; }
+    }
+}

--- a/test/WorkflowCore.TestAssets/Steps/IterateListStep.cs
+++ b/test/WorkflowCore.TestAssets/Steps/IterateListStep.cs
@@ -1,0 +1,8 @@
+using WorkflowCore.Primitives;
+
+namespace WorkflowCore.TestAssets.Steps
+{
+    public class IterateListStep : Foreach
+    {
+    }
+}

--- a/test/WorkflowCore.UnitTests/Services/DefinitionStorage/DefinitionLoaderTests.cs
+++ b/test/WorkflowCore.UnitTests/Services/DefinitionStorage/DefinitionLoaderTests.cs
@@ -2,6 +2,7 @@
 using FluentAssertions;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
@@ -112,6 +113,87 @@ namespace WorkflowCore.UnitTests.Services.DefinitionStorage
 
             body.MessageId.Should().Be("msg-42");
             body.Status.Should().Be("waits-for-batching");
+        }
+
+        // Regression test for issue #1375: YAML (and JSON) deserializers emit
+        // unquoted scalars as CLR primitives. Those must bind to step properties,
+        // including properties inherited from built-in steps such as Foreach.
+        [Fact(DisplayName = "Should assign unquoted YAML primitives on inherited Foreach properties")]
+        public void ShouldAssignUnquotedYamlPrimitivesOnInheritedForeachProperties()
+        {
+            var yaml =
+                "Id: Issue1375\n" +
+                "Version: 1\n" +
+                "DataType: WorkflowCore.TestAssets.DataTypes.IterateListData, WorkflowCore.TestAssets\n" +
+                "Steps:\n" +
+                "  - Id: IterateList\n" +
+                "    StepType: WorkflowCore.TestAssets.Steps.IterateListStep, WorkflowCore.TestAssets\n" +
+                "    Inputs:\n" +
+                "      Collection: data.DataList\n" +
+                "      RunParallel: false\n";
+
+            var def = _subject.LoadDefinition(yaml, Deserializers.Yaml);
+
+            var step = def.Steps.Single(s => s.ExternalId == "IterateList");
+            step.Inputs.Count.Should().Be(2);
+
+            var body = new IterateListStep();
+            var data = new IterateListData { DataList = new List<string> { "item1", "item2" } };
+
+            foreach (var input in step.Inputs)
+                input.AssignInput(data, body, null);
+
+            body.RunParallel.Should().BeFalse();
+            body.Collection.Should().BeEquivalentTo(data.DataList);
+        }
+
+        [Fact(DisplayName = "Should assign unquoted JSON primitives on inherited Foreach properties")]
+        public void ShouldAssignUnquotedJsonPrimitivesOnInheritedForeachProperties()
+        {
+            var json =
+                "{" +
+                "\"Id\": \"Issue1375Json\", \"Version\": 1," +
+                "\"DataType\": \"WorkflowCore.TestAssets.DataTypes.IterateListData, WorkflowCore.TestAssets\"," +
+                "\"Steps\": [{" +
+                    "\"Id\": \"IterateList\"," +
+                    "\"StepType\": \"WorkflowCore.TestAssets.Steps.IterateListStep, WorkflowCore.TestAssets\"," +
+                    "\"Inputs\": {" +
+                        "\"Collection\": \"data.DataList\"," +
+                        "\"RunParallel\": false" +
+                    "}" +
+                "}]}";
+
+            var def = _subject.LoadDefinition(json, Deserializers.Json);
+
+            var step = def.Steps.Single(s => s.ExternalId == "IterateList");
+            var body = new IterateListStep();
+            var data = new IterateListData { DataList = new List<string> { "item1" } };
+
+            foreach (var input in step.Inputs)
+                input.AssignInput(data, body, null);
+
+            body.RunParallel.Should().BeFalse();
+            body.Collection.Should().BeEquivalentTo(data.DataList);
+        }
+
+        [Fact(DisplayName = "Should still throw for unknown YAML input properties")]
+        public void ShouldStillThrowForUnknownYamlInputProperties()
+        {
+            var yaml =
+                "Id: Issue1375Unknown\n" +
+                "Version: 1\n" +
+                "DataType: WorkflowCore.TestAssets.DataTypes.IterateListData, WorkflowCore.TestAssets\n" +
+                "Steps:\n" +
+                "  - Id: IterateList\n" +
+                "    StepType: WorkflowCore.TestAssets.Steps.IterateListStep, WorkflowCore.TestAssets\n" +
+                "    Inputs:\n" +
+                "      Collection: data.DataList\n" +
+                "      NonExistentProperty: false\n";
+
+            var exception = Assert.Throws<ArgumentException>(() =>
+                _subject.LoadDefinition(yaml, Deserializers.Yaml));
+
+            exception.Message.Should().Contain("Unknown property for input NonExistentProperty");
         }
 
         private bool MatchTestDefinition(WorkflowDefinition def)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Describe the change**

`DefinitionLoader.AttachInputs` rejected unquoted YAML/JSON scalars (`RunParallel: false`) with `Unknown type for input ...`. That is the failure reported in #1375 for custom `Foreach` subclasses, and it also happens for `Foreach` itself.

This is a replacement for #1395. That PR is still useful as context, but it is not merge-ready:

- The reported exception is `Unknown type`, not `Unknown property`. `Type.GetProperty(string)` already finds inherited public instance properties (`RunParallel` on `Foreach`).
- The `BindingFlags` change is therefore a no-op (same as the default lookup).
- Tests only asserted that load did not throw, so they never proved `RunParallel` was assigned `false` (the `Foreach` default is `true`).
- The branch is stale and merge-blocked by an Oracle CI job that reports failure even when the Oracle test-results check is green.

**Describe your implementation or design**

In `AttachInputs`, after the existing string-expression and dictionary-object cases, assign CLR primitives (`IsPrimitive` or `decimal`) as constants using the same `SetValue` / `Convert.ChangeType` pattern as scalar expression inputs. No change to `GetProperty`, System.Text.Json, the designer, or other DSL paths.

**Tests**

- YAML `IterateListStep : Foreach` with `Collection: data.DataList` and `RunParallel: false` loads, assigns, and asserts `RunParallel == false` plus the collection value.
- The same case through the JSON deserializer (`"RunParallel": false`).
- Unknown input properties still throw `Unknown property`.

**Breaking change**

No. Workflows that previously threw on unquoted primitives now load. Quoted strings remain Dynamic LINQ expressions.

**Additional context**

Fixes #1375. Prefer this over #1395.

Supersedes https://github.com/danielgerlag/workflow-core/pull/1395
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed1bd664-eb48-4cbf-869e-66eaadad702f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed1bd664-eb48-4cbf-869e-66eaadad702f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

