### PR TITLE
Fix stale second-pass IDs and missing-workflow NREs

### DIFF
--- a/src/WorkflowCore/Services/BackgroundTasks/IndexConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/IndexConsumer.cs
@@ -33,7 +33,13 @@ namespace WorkflowCore.Services.BackgroundTasks
             try
             {
                 var workflow = await FetchWorkflow(itemId);
-                
+                if (workflow == null)
+                {
+                    Logger.LogWarning("Workflow {ItemId} was not found and will not be indexed", itemId);
+                    _errorCounts.TryRemove(itemId, out _);
+                    return;
+                }
+
                 WorkflowActivity.Enrich(workflow, "index");
                 await _searchIndex.IndexWorkflow(workflow);
                 _errorCounts.TryRemove(itemId, out _);

--- a/src/WorkflowCore/Services/BackgroundTasks/QueueConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/QueueConsumer.cs
@@ -194,6 +194,7 @@ namespace WorkflowCore.Services.BackgroundTasks
             finally
             {
                 waitHandle.Set();
+                _secondPasses.TryRemove(itemId);
                 lock (_activeTasks)
                 {
                     _activeTasks.Remove(itemId);

--- a/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
@@ -49,6 +49,11 @@ namespace WorkflowCore.Services.BackgroundTasks
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 workflow = await _persistenceStore.GetWorkflowInstance(itemId, cancellationToken);
+                if (workflow == null)
+                {
+                    Logger.LogWarning("Workflow {ItemId} was not found and will not be processed", itemId);
+                    return;
+                }
 
                 WorkflowActivity.Enrich(workflow, "process");
                 if (workflow.Status == WorkflowStatus.Runnable)

--- a/src/WorkflowCore/WorkflowCore.csproj
+++ b/src/WorkflowCore/WorkflowCore.csproj
@@ -31,6 +31,9 @@
 	<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
 		<_Parameter1>WorkflowCore.IntegrationTests</_Parameter1>
 	</AssemblyAttribute>
+	<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+		<_Parameter1>WorkflowCore.UnitTests</_Parameter1>
+	</AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WorkflowCore.UnitTests/Services/BackgroundTasks/QueueConsumerTests.cs
+++ b/test/WorkflowCore.UnitTests/Services/BackgroundTasks/QueueConsumerTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using WorkflowCore.Services.BackgroundTasks;
+using Xunit;
+
+namespace WorkflowCore.UnitTests.Services.BackgroundTasks
+{
+    public class QueueConsumerTests
+    {
+        [Fact(DisplayName = "ExecuteItem should clear secondPasses after processing completes")]
+        public async Task ExecuteItem_ShouldClearSecondPasses_AfterProcessing()
+        {
+            var queue = new ScriptedQueueProvider();
+            var options = new WorkflowOptions(A.Fake<IServiceCollection>());
+            options.UseIdleTime(TimeSpan.FromMilliseconds(20));
+
+            var entered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var consumer = new TestQueueConsumer(queue, new LoggerFactory(), options)
+            {
+                OnProcess = async (id, ct) =>
+                {
+                    entered.TrySetResult(true);
+                    await release.Task.ConfigureAwait(false);
+                }
+            };
+
+            try
+            {
+                consumer.Start();
+                queue.Enqueue("wf-1");
+
+                await WaitUntil(() => entered.Task.IsCompleted, TimeSpan.FromSeconds(5));
+
+                queue.Enqueue("wf-1");
+                await WaitUntil(() => consumer.HasSecondPass("wf-1"), TimeSpan.FromSeconds(5));
+                consumer.HasSecondPass("wf-1").Should().BeTrue();
+
+                release.TrySetResult(true);
+
+                await WaitUntil(() => !consumer.HasActiveTask("wf-1") && !consumer.HasSecondPass("wf-1"), TimeSpan.FromSeconds(5));
+                consumer.HasSecondPass("wf-1").Should().BeFalse();
+            }
+            finally
+            {
+                release.TrySetResult(true);
+                consumer.Stop();
+            }
+        }
+
+        private static async Task WaitUntil(Func<bool> condition, TimeSpan timeout)
+        {
+            var start = DateTime.UtcNow;
+            while (!condition())
+            {
+                if (DateTime.UtcNow - start > timeout)
+                {
+                    throw new TimeoutException("Condition was not met within the allotted time.");
+                }
+
+                await Task.Delay(20);
+            }
+        }
+
+        private class TestQueueConsumer : QueueConsumer
+        {
+            public TestQueueConsumer(IQueueProvider queueProvider, ILoggerFactory loggerFactory, WorkflowOptions options)
+                : base(queueProvider, loggerFactory, options)
+            {
+            }
+
+            public Func<string, CancellationToken, Task> OnProcess { get; set; }
+
+            protected override QueueType Queue => QueueType.Workflow;
+
+            protected override int MaxConcurrentItems => 4;
+
+            protected override Task ProcessItem(string itemId, CancellationToken cancellationToken)
+            {
+                return OnProcess != null ? OnProcess(itemId, cancellationToken) : Task.CompletedTask;
+            }
+
+            public bool HasSecondPass(string itemId)
+            {
+                var field = typeof(QueueConsumer).GetField("_secondPasses", BindingFlags.NonPublic | BindingFlags.Instance);
+                var set = field.GetValue(this);
+                return (bool)set.GetType().GetMethod("Contains", new[] { typeof(string) }).Invoke(set, new object[] { itemId });
+            }
+
+            public bool HasActiveTask(string itemId)
+            {
+                var field = typeof(QueueConsumer).GetField("_activeTasks", BindingFlags.NonPublic | BindingFlags.Instance);
+                var dict = field.GetValue(this);
+                lock (dict)
+                {
+                    return (bool)dict.GetType().GetMethod("ContainsKey").Invoke(dict, new object[] { itemId });
+                }
+            }
+        }
+
+        private class ScriptedQueueProvider : IQueueProvider
+        {
+            private readonly ConcurrentQueue<string> _items = new ConcurrentQueue<string>();
+
+            public bool IsDequeueBlocking => false;
+
+            public void Enqueue(string id) => _items.Enqueue(id);
+
+            public Task QueueWork(string id, QueueType queue)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task<string> DequeueWork(QueueType queue, CancellationToken cancellationToken)
+            {
+                if (_items.TryDequeue(out var id))
+                {
+                    return Task.FromResult(id);
+                }
+
+                return Task.FromResult<string>(null);
+            }
+
+            public Task Start() => Task.CompletedTask;
+
+            public Task Stop() => Task.CompletedTask;
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/test/WorkflowCore.UnitTests/Services/BackgroundTasks/WorkflowConsumerTests.cs
+++ b/test/WorkflowCore.UnitTests/Services/BackgroundTasks/WorkflowConsumerTests.cs
@@ -1,0 +1,70 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FakeItEasy;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using WorkflowCore.Services.BackgroundTasks;
+using Xunit;
+
+namespace WorkflowCore.UnitTests.Services.BackgroundTasks
+{
+    public class WorkflowConsumerTests
+    {
+        [Fact(DisplayName = "ProcessItem should not throw when the workflow instance is missing")]
+        public async Task ProcessItem_WhenWorkflowInstanceIsNull_DoesNotThrow()
+        {
+            var persistence = A.Fake<IPersistenceProvider>();
+            var queue = A.Fake<IQueueProvider>();
+            var lockProvider = A.Fake<IDistributedLockProvider>();
+            var executor = A.Fake<IWorkflowExecutor>();
+            var datetime = A.Fake<IDateTimeProvider>();
+            var greylist = A.Fake<IGreyList>();
+            var options = new WorkflowOptions(A.Fake<IServiceCollection>());
+
+            A.CallTo(() => lockProvider.AcquireLock("missing-id", A<CancellationToken>._))
+                .Returns(true);
+            A.CallTo(() => persistence.GetWorkflowInstance("missing-id", A<CancellationToken>._))
+                .Returns(Task.FromResult<WorkflowInstance>(null));
+
+            var consumer = new TestableWorkflowConsumer(
+                persistence,
+                queue,
+                new LoggerFactory(),
+                A.Fake<IServiceProvider>(),
+                A.Fake<IWorkflowRegistry>(),
+                lockProvider,
+                executor,
+                datetime,
+                greylist,
+                options);
+
+            await consumer.Process("missing-id", CancellationToken.None);
+
+            A.CallTo(() => executor.Execute(A<WorkflowInstance>._, A<CancellationToken>._)).MustNotHaveHappened();
+            A.CallTo(() => greylist.Remove("wf:missing-id")).MustHaveHappenedOnceExactly();
+            A.CallTo(() => lockProvider.ReleaseLock("missing-id")).MustHaveHappenedOnceExactly();
+        }
+
+        private class TestableWorkflowConsumer : WorkflowConsumer
+        {
+            public TestableWorkflowConsumer(
+                IPersistenceProvider persistenceProvider,
+                IQueueProvider queueProvider,
+                ILoggerFactory loggerFactory,
+                IServiceProvider serviceProvider,
+                IWorkflowRegistry registry,
+                IDistributedLockProvider lockProvider,
+                IWorkflowExecutor executor,
+                IDateTimeProvider datetimeProvider,
+                IGreyList greylist,
+                WorkflowOptions options)
+                : base(persistenceProvider, queueProvider, loggerFactory, serviceProvider, registry, lockProvider, executor, datetimeProvider, greylist, options)
+            {
+            }
+
+            public Task Process(string itemId, CancellationToken cancellationToken) => ProcessItem(itemId, cancellationToken);
+        }
+    }
+}

--- a/test/WorkflowCore.UnitTests/Services/BackgroundTasks/WorkflowConsumerTests.cs
+++ b/test/WorkflowCore.UnitTests/Services/BackgroundTasks/WorkflowConsumerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using FakeItEasy;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1417
Fixes #1376

**Describe the change**
Queue items for completed, terminated, or persistence-deleted workflows could still be processed. That produced two related failures:

- `#1417`: `QueueConsumer._secondPasses` kept a workflow id after `ExecuteItem` finished. A later second pass then tried to process a purged/terminated instance (`Sequence contains no elements` / missing instance).
- `#1376`: With Redis `deleteCompleted` / `removeComplete: true`, `WorkflowConsumer` could dequeue a deleted id. `GetWorkflowInstance` returned null and `Enrich` / `Status` threw `NullReferenceException`.

**Describe your implementation or design**
Smallest consumer-side change; no persistence, Redis, or `deleteCompleted` behavior changes.

1. In `QueueConsumer.ExecuteItem` `finally`, clear `_secondPasses` alongside `_activeTasks.Remove`.
2. After `GetWorkflowInstance`, if the instance is null, log a warning with the item id and return. Applied in `WorkflowConsumer` and `IndexConsumer` (same fetch-then-enrich pattern; index consumer also uses `EnableSecondPasses`).
3. Lock/greylist cleanup still runs via the existing `finally` in `WorkflowConsumer`.

**Tests**
- `QueueConsumerTests.ExecuteItem_ShouldClearSecondPasses_AfterProcessing`: duplicate in-flight item is tracked in `_secondPasses`, then removed after execute.
- `WorkflowConsumerTests.ProcessItem_WhenWorkflowInstanceIsNull_DoesNotThrow`: missing instance does not NRE; executor is not called; greylist and lock are still released.

**Breaking change**
No. Missing instances are now skipped instead of throwing.

**Additional context**
This does not change how completed workflows are deleted. It only makes consumers tolerant of a queue item whose instance is already gone, and stops leftover second-pass ids from sticking around after execute.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb93aa4f-3396-4ea4-9c13-07f9d7c8a70f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb93aa4f-3396-4ea4-9c13-07f9d7c8a70f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

