### PR TITLE
Harden Elasticsearch tests against container startup flakes

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -247,6 +247,8 @@ jobs:
         run: dotnet restore
       - name: Build
         run: dotnet build --no-restore
+      - name: Allow Elasticsearch mmap
+        run: sudo sysctl -w vm.max_map_count=262144
       - name: Elasticsearch Tests
         run: dotnet test test/WorkflowCore.Tests.Elasticsearch --no-build --verbosity detailed --logger "trx;LogFileName=ElasticsearchTests.trx" --logger "console;verbosity=detailed" --results-directory ./test-results -p:ParallelizeTestCollections=false
       - name: Publish Test Results

--- a/test/WorkflowCore.IntegrationTests/SearchIndexTests.cs
+++ b/test/WorkflowCore.IntegrationTests/SearchIndexTests.cs
@@ -20,6 +20,11 @@ namespace WorkflowCore.IntegrationTests
 
             foreach (var item in BuildTestData())
                 Subject.IndexWorkflow(item).Wait();
+            WaitUntilSearchable();
+        }
+
+        protected virtual void WaitUntilSearchable()
+        {
             System.Threading.Thread.Sleep(1000);
         }
 

--- a/test/WorkflowCore.Tests.Elasticsearch/ElasticsearchDockerSetup.cs
+++ b/test/WorkflowCore.Tests.Elasticsearch/ElasticsearchDockerSetup.cs
@@ -1,29 +1,57 @@
 ﻿using System;
+using System.Net;
 using System.Threading.Tasks;
-using Squadron;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
 using Xunit;
 
 namespace WorkflowCore.Tests.Elasticsearch
 {
     public class ElasticsearchDockerSetup : IAsyncLifetime
     {
-        private readonly ElasticsearchResource _elasticsearchResource;
-        public static string ConnectionString { get; set; }
+        // ES 7.17 matches NEST 7.x used by the production indexer. Pin the tag so
+        // `latest` cannot drift onto ES 8/9 (security/TLS on by default).
+        // docker.elastic.co is the official 7.17 distribution; Docker Hub's
+        // elasticsearch official image only publishes 8.x/9.x now.
+        private const string Image = "docker.elastic.co/elasticsearch/elasticsearch:7.17.29";
+        private const ushort HttpPort = 9200;
+
+        private readonly IContainer _container;
+
+        public static string ConnectionString { get; private set; }
 
         public ElasticsearchDockerSetup()
         {
-            _elasticsearchResource = new ElasticsearchResource();
+            _container = new ContainerBuilder()
+                .WithImage(Image)
+                .WithPortBinding(HttpPort, true)
+                .WithEnvironment("discovery.type", "single-node")
+                .WithEnvironment("cluster.name", "workflowcore-tests")
+                .WithEnvironment("xpack.security.enabled", "false")
+                .WithEnvironment("xpack.ml.enabled", "false")
+                .WithEnvironment("ingest.geoip.downloader.enabled", "false")
+                .WithEnvironment("node.store.allow_mmap", "false")
+                .WithEnvironment("cluster.routing.allocation.disk.threshold_enabled", "false")
+                .WithEnvironment("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
+                .WithWaitStrategy(Wait.ForUnixContainer()
+                    .UntilHttpRequestIsSucceeded(
+                        request => request
+                            .ForPort(HttpPort)
+                            .ForPath("/_cluster/health")
+                            .ForStatusCode(HttpStatusCode.OK),
+                        strategy => strategy.WithTimeout(TimeSpan.FromMinutes(3))))
+                .Build();
         }
 
         public async Task InitializeAsync()
         {
-            await _elasticsearchResource.InitializeAsync();
-            ConnectionString = $"http://localhost:{_elasticsearchResource.Instance.HostPort}";
+            await _container.StartAsync();
+            ConnectionString = $"http://localhost:{_container.GetMappedPublicPort(HttpPort)}";
         }
 
-        public Task DisposeAsync()
+        public async Task DisposeAsync()
         {
-            return _elasticsearchResource.DisposeAsync();
+            await _container.DisposeAsync();
         }
     }
 

--- a/test/WorkflowCore.Tests.Elasticsearch/ElasticsearchIndexerTests.cs
+++ b/test/WorkflowCore.Tests.Elasticsearch/ElasticsearchIndexerTests.cs
@@ -11,17 +11,28 @@ namespace WorkflowCore.Tests.Elasticsearch
     [Collection("Elasticsearch collection")]
     public class ElasticsearchIndexerTests : SearchIndexTests
     {
-        ElasticsearchDockerSetup _dockerSetup;
+        private readonly string _indexName = $"workflowcore-tests-{Guid.NewGuid():N}";
 
         public ElasticsearchIndexerTests(ElasticsearchDockerSetup dockerSetup)
         {
-            _dockerSetup = dockerSetup;
+            _ = dockerSetup;
         }
 
         protected override ISearchIndex CreateService()
         {
             var settings = new ConnectionSettings(new Uri(ElasticsearchDockerSetup.ConnectionString));
-            return new ElasticsearchIndexer(settings, "workflowcore.tests", new LoggerFactory());
+            return new ElasticsearchIndexer(settings, _indexName, new LoggerFactory());
+        }
+
+        protected override void WaitUntilSearchable()
+        {
+            var client = new ElasticClient(new ConnectionSettings(new Uri(ElasticsearchDockerSetup.ConnectionString)));
+            var refresh = client.Indices.Refresh(_indexName);
+            if (!refresh.IsValid)
+            {
+                throw new InvalidOperationException(
+                    $"Elasticsearch refresh failed for '{_indexName}': {refresh.DebugInformation}");
+            }
         }
     }
 }

--- a/test/WorkflowCore.Tests.Elasticsearch/WorkflowCore.Tests.Elasticsearch.csproj
+++ b/test/WorkflowCore.Tests.Elasticsearch/WorkflowCore.Tests.Elasticsearch.csproj
@@ -5,12 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Squadron.Elasticsearch" Version="1.0.1" />
+    <PackageReference Include="Testcontainers" Version="4.8.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\providers\WorkflowCore.Providers.Elasticsearch\WorkflowCore.Providers.Elasticsearch.csproj" />
-    <ProjectReference Include="..\Docker.Testify\Docker.Testify.csproj" />
     <ProjectReference Include="..\WorkflowCore.IntegrationTests\WorkflowCore.IntegrationTests.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Describe the change**

`Elasticsearch-Tests` has been failing on master and open PRs (including #1443 / #1444) while every other provider job stays green. The failure is not an assertion flake in the indexer: all 7 tests die in `ElasticsearchDockerSetup.InitializeAsync` with:

```
Initialize sequence timed-out
GET /_cluster/health?wait_for_status=green
Connection refused (127.0.0.1:<mapped-port>)
```

Squadron starts `docker.elastic.co/elasticsearch/elasticsearch:7.17.29` and then polls cluster health **green** through NEST. The mapped port never accepts connections within the 5-minute timeout (single-node bootstrap / mmap / geoip download / NEST product-check during startup). Last time this job was green on this repo was around October 2025; recent master runs fail the same way every time.

**Describe your implementation or design**

Test-only hardening. No production Elasticsearch indexer behavior change.

1. Replace Squadron with Testcontainers `ContainerBuilder` (same approach as Azure/Oracle tests).
2. Pin ES **7.17.29** (matches NEST 7.x used by the provider).
3. Single-node env that actually starts on GHA ubuntu-24.04: security/ML/geoip off, `node.store.allow_mmap=false`, 512MB heap.
4. Wait for HTTP `200` on `/_cluster/health` (yellow is fine) instead of NEST `wait_for_status=green`.
5. Unique index name per test instance; refresh the index instead of `Thread.Sleep(1000)`.
6. Raise `vm.max_map_count` in the Elasticsearch CI job.

**Tests**

Existing `SearchIndexTests` (7 facts) still cover search/filter. They now prove documents are searchable after an explicit refresh on an isolated index.

This environment has no Docker daemon, so the tests were compiled (`net8.0`) but not executed here. CI `Elasticsearch-Tests` is the real verification.

**Breaking change**

No.

**Additional context**

Failing test names (all same fixture timeout):

- `should_search_on_reference`
- `should_search_on_custom_data`
- `should_filter_on_custom_data`
- `should_filter_on_alt_custom_data_with_conflicting_names`
- `should_filter_on_reference`
- `should_filter_on_status`
- `should_filter_on_date_range`

The refresh-race / shared-index hypothesis was not the current CI failure. Unique indexes + refresh are still included so those races cannot return once the container starts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1da950c-f2af-49b3-9312-899abd8478c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1da950c-f2af-49b3-9312-899abd8478c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

